### PR TITLE
fix: number of left columns and top rows would sometimes by wrong

### DIFF
--- a/src/hooks/use-data-model.ts
+++ b/src/hooks/use-data-model.ts
@@ -67,7 +67,7 @@ export default function useDataModel(layout: Layout, model: Model): DataModel {
       setDimInfo(layout.qHyperCube.qDimensionInfo);
       setSize(layout.qHyperCube.qSize);
       setNoOfLeftDims(layout.qHyperCube.qNoOfLeftDims);
-      setPivotData(createData(pivotPage, layout.qHyperCube.qDimensionInfo));
+      setPivotData(createData(pivotPage, layout.qHyperCube.qDimensionInfo, layout.qHyperCube.qNoOfLeftDims));
     }
   }, [layout]);
 
@@ -90,7 +90,7 @@ export default function useDataModel(layout: Layout, model: Model): DataModel {
       setLoading(false);
       setHasMoreRows(pivotPage.qArea.qHeight < qSize.qcy);
       setHasMoreColumns(pivotPage.qArea.qWidth < qSize.qcx);
-      setPivotData(createData(pivotPage, qDimInfo));
+      setPivotData(createData(pivotPage, qDimInfo, qNoOfLeftDims));
     } catch (error) {
       console.log('ERROR', error);
       setLoading(false);

--- a/src/pivot-table/data/__tests__/extract-left.test.ts
+++ b/src/pivot-table/data/__tests__/extract-left.test.ts
@@ -1,4 +1,4 @@
-import { NxDimCellType, NxPageArea, NxPivotDimensionCell } from '../../../types/QIX';
+import { NxDimCellType, NxPivotDimensionCell } from '../../../types/QIX';
 import extractLeft from '../extract-left';
 
 function createNode(qElemNo: number): NxPivotDimensionCell {
@@ -15,15 +15,11 @@ function createNode(qElemNo: number): NxPivotDimensionCell {
   };
 }
 
-function createArea(qHeight: number): NxPageArea {
-  return { qHeight } as NxPageArea;
-}
-
 describe('extractLeft', () => {
   test('should handle empty qLeft array', () => {
     const qLeft: NxPivotDimensionCell[] = [];
 
-    const left = extractLeft(qLeft, { qHeight: 0 } as NxPageArea);
+    const left = extractLeft(qLeft, 1, 1);
 
     expect(left).toHaveLength(0);
   });
@@ -31,9 +27,7 @@ describe('extractLeft', () => {
   test('should extract left data with no nodes expanded', () => {
     const rowCount = 3;
     const qLeft = Array.from({ length: rowCount}, (_, idx: number) => createNode(idx));
-    const qArea = createArea(rowCount);
-
-    const left = extractLeft(qLeft, qArea);
+    const left = extractLeft(qLeft, rowCount, 1);
 
     expect(left).toHaveLength(1);
     expect(left[0]).toHaveLength(rowCount);
@@ -43,19 +37,18 @@ describe('extractLeft', () => {
   });
 
   test('should extract left data with first node expanded', () => {
+    const columnCount = 2;
     const rowCount = 3;
     const subNodesCount = 2;
     const qLeft = Array.from({ length: rowCount}, (_, idx: number) => createNode(idx));
-    const qArea = createArea(rowCount);
     const subNodes = Array.from({ length: subNodesCount}, (_, idx: number) => createNode(idx));
     qLeft[0].qSubNodes = subNodes;
     qLeft[0].qCanCollapse = true;
-    qArea.qHeight = rowCount + subNodesCount - 1;
+    const totalRowCount = rowCount + subNodesCount - 1;
+    const left = extractLeft(qLeft, totalRowCount, columnCount);
 
-    const left = extractLeft(qLeft, qArea);
-
-    expect(left).toHaveLength(2);
-    expect(left[0]).toHaveLength(qArea.qHeight);
+    expect(left).toHaveLength(columnCount);
+    expect(left[0]).toHaveLength(totalRowCount);
     expect(left[0][0]).toMatchObject({ qElemNo: 0 });
     expect(left[0][1]).toBe(null);
     expect(left[0][2]).toMatchObject({ qElemNo: 1 });
@@ -68,22 +61,21 @@ describe('extractLeft', () => {
   });
 
   test('should extract left data when data tree has a depth of 2', () => {
+    const columnCount = 3;
     const rowCount = 3;
     const subNodesCount = 2;
     const qLeft = Array.from({ length: rowCount}, (_, idx: number) => createNode(idx));
-    const qArea = createArea(rowCount);
     const subNodes = Array.from({ length: subNodesCount}, (_, idx: number) => createNode(idx));
     const subSubNodes = Array.from({ length: subNodesCount}, (_, idx: number) => createNode(idx));
     subNodes[1].qSubNodes = subSubNodes;
     subNodes[1].qCanCollapse = true;
     qLeft[2].qSubNodes = subNodes;
     qLeft[2].qCanCollapse = true;
-    qArea.qHeight = rowCount + (subNodesCount - 1) + (subNodesCount - 1);
+    const totalRowCount = rowCount + (subNodesCount - 1) + (subNodesCount - 1);
+    const left = extractLeft(qLeft, totalRowCount, columnCount);
 
-    const left = extractLeft(qLeft, qArea);
-
-    expect(left).toHaveLength(3);
-    expect(left[0]).toHaveLength(qArea.qHeight);
+    expect(left).toHaveLength(columnCount);
+    expect(left[0]).toHaveLength(totalRowCount);
     expect(left[0][0]).toMatchObject({ qElemNo: 0 });
     expect(left[0][1]).toMatchObject({ qElemNo: 1 });
     expect(left[0][2]).toMatchObject({ qElemNo: 2 });

--- a/src/pivot-table/data/__tests__/extract-top.test.ts
+++ b/src/pivot-table/data/__tests__/extract-top.test.ts
@@ -1,4 +1,4 @@
-import { NxDimCellType, NxPageArea, NxPivotDimensionCell } from '../../../types/QIX';
+import { NxDimCellType, NxPivotDimensionCell } from '../../../types/QIX';
 import extractTop from '../extract-top';
 
 function createNode(qElemNo: number): NxPivotDimensionCell {
@@ -15,30 +15,26 @@ function createNode(qElemNo: number): NxPivotDimensionCell {
   };
 }
 
-function createArea(qWidth: number): NxPageArea {
-  return { qWidth } as NxPageArea;
-}
-
-describe('extractLeft', () => {
+describe('extractTop', () => {
   test('should handle empty qTop array', () => {
     const qTop: NxPivotDimensionCell[] = [];
 
-    const top = extractTop(qTop, { qWidth: 0 } as NxPageArea);
+    const top = extractTop(qTop, 1, 1);
 
     expect(top).toHaveLength(0);
   });
 
   test('should extract top data with no nodes expanded', () => {
     const colCount = 3;
+    const rowCount = 1;
     const qTop = Array.from({ length: colCount}, (_, idx: number) => createNode(idx));
-    const qArea = createArea(colCount);
 
-    const top = extractTop(qTop, qArea);
+    const top = extractTop(qTop, colCount, rowCount);
 
     expect(top).toHaveLength(colCount);
-    expect(top[0]).toHaveLength(1);
-    expect(top[1]).toHaveLength(1);
-    expect(top[2]).toHaveLength(1);
+    expect(top[0]).toHaveLength(rowCount);
+    expect(top[1]).toHaveLength(rowCount);
+    expect(top[2]).toHaveLength(rowCount);
     expect(top[0][0]).toMatchObject({ qElemNo: 0 });
     expect(top[1][0]).toMatchObject({ qElemNo: 1 });
     expect(top[2][0]).toMatchObject({ qElemNo: 2 });
@@ -46,18 +42,18 @@ describe('extractLeft', () => {
 
   test('should extract top data with first node expanded', () => {
     const colCount = 3;
+    const rowCount = 2;
     const subNodesCount = 2;
     const qTop = Array.from({ length: colCount}, (_, idx: number) => createNode(idx));
-    const qArea = createArea(colCount);
     const subNodes = Array.from({ length: subNodesCount}, (_, idx: number) => createNode(idx));
     qTop[0].qSubNodes = subNodes;
     qTop[0].qCanCollapse = true;
-    qArea.qWidth = colCount + subNodesCount - 1;
+    const totalColCount = colCount + subNodesCount - 1;
 
-    const top = extractTop(qTop, qArea);
+    const top = extractTop(qTop, totalColCount, rowCount);
 
-    expect(top).toHaveLength(qArea.qWidth);
-    expect(top[0]).toHaveLength(2);
+    expect(top).toHaveLength(totalColCount);
+    expect(top[0]).toHaveLength(rowCount);
     expect(top[0][0]).toMatchObject({ qElemNo: 0 });
     expect(top[1][0]).toBe(null);
     expect(top[2][0]).toMatchObject({ qElemNo: 1 });
@@ -71,21 +67,21 @@ describe('extractLeft', () => {
 
   test('should extract top data when data tree has a depth of 2', () => {
     const colCount = 3;
+    const rowCount = 3;
     const subNodesCount = 2;
     const qTop = Array.from({ length: colCount}, (_, idx: number) => createNode(idx));
-    const qArea = createArea(colCount);
     const subNodes = Array.from({ length: subNodesCount}, (_, idx: number) => createNode(idx));
     const subSubNodes = Array.from({ length: subNodesCount}, (_, idx: number) => createNode(idx));
     subNodes[1].qSubNodes = subSubNodes;
     subNodes[1].qCanCollapse = true;
     qTop[2].qSubNodes = subNodes;
     qTop[2].qCanCollapse = true;
-    qArea.qWidth = colCount + (subNodesCount - 1) + (subNodesCount - 1);
+    const totalColCount = colCount + (subNodesCount - 1) + (subNodesCount - 1);
 
-    const top = extractTop(qTop, qArea);
+    const top = extractTop(qTop, totalColCount, rowCount);
 
-    expect(top).toHaveLength(qArea.qWidth);
-    expect(top[0]).toHaveLength(3);
+    expect(top).toHaveLength(totalColCount);
+    expect(top[0]).toHaveLength(rowCount);
     expect(top[0][0]).toMatchObject({ qElemNo: 0 });
     expect(top[1][0]).toMatchObject({ qElemNo: 1 });
     expect(top[2][0]).toMatchObject({ qElemNo: 2 });

--- a/src/pivot-table/data/__tests__/index.test.ts
+++ b/src/pivot-table/data/__tests__/index.test.ts
@@ -23,9 +23,6 @@ function createPivotPage(): NxPivotPage {
 
 const dimInfo: NxDimensionInfo[] = [];
 
-// const mockDimensionCell = DimensionCell as jest.MockedFunction<typeof DimensionCell>;
-// mockDimensionCell.mockReturnValue(<div />);
-
 describe('createData', () => {
   beforeEach(() => {
     jest.resetAllMocks();
@@ -40,7 +37,7 @@ describe('createData', () => {
     mockedExtractLeft.mockReturnValue(left);
     const pivotPage = createPivotPage();
 
-    const data = createData(pivotPage, dimInfo);
+    const data = createData(pivotPage, dimInfo, 0);
 
     expect(data.left).toEqual(left);
     expect(data.size.left.x).toBe(1);
@@ -52,7 +49,7 @@ describe('createData', () => {
     mockedExtractTop.mockReturnValue(top);
     const pivotPage = createPivotPage();
 
-    const data = createData(pivotPage, dimInfo);
+    const data = createData(pivotPage, dimInfo, 0);
 
     expect(data.top).toEqual(top);
     expect(data.size.top.x).toBe(1);
@@ -64,7 +61,7 @@ describe('createData', () => {
     mockedExtractHeaders.mockReturnValue(headers);
     const pivotPage = createPivotPage();
 
-    const data = createData(pivotPage, dimInfo);
+    const data = createData(pivotPage, dimInfo, 0);
 
     expect(data.headers).toEqual(headers);
     expect(data.size.headers.x).toBe(1);
@@ -77,7 +74,7 @@ describe('createData', () => {
     pivotPage.qArea.qHeight = 2;
     pivotPage.qData = [[]];
 
-    const data = createData(pivotPage, dimInfo);
+    const data = createData(pivotPage, dimInfo, 0);
 
     expect(data.data).toEqual(pivotPage.qData);
     expect(data.size.data.x).toBe(pivotPage.qArea.qWidth);
@@ -93,7 +90,7 @@ describe('createData', () => {
     const left = [['a', 'b']];
     mockedExtractLeft.mockReturnValue(left);
 
-    const data = createData(pivotPage, dimInfo);
+    const data = createData(pivotPage, dimInfo, 0);
 
     expect(data.size.totalColumns).toBe(2);
     expect(data.size.totalRows).toBe(4);

--- a/src/pivot-table/data/extract-left.ts
+++ b/src/pivot-table/data/extract-left.ts
@@ -1,18 +1,17 @@
-import { NxDimCellType, NxPageArea, NxPivotDimensionCell } from '../../types/QIX';
+import { NxDimCellType, NxPivotDimensionCell } from '../../types/QIX';
 import { CellValue } from '../../types/types';
 
-const extractLeft = (qLeft: NxPivotDimensionCell[], qArea: NxPageArea): CellValue[][] => {
+const extractLeft = (qLeft: NxPivotDimensionCell[], rowCount: number, columnCount: number): CellValue[][] => {
   if (!qLeft.length) {
     return [];
   }
 
   let rowIdx = 0;
+  const nullMatrix = Array(columnCount)
+    .fill(null)
+    .map(() => Array(rowCount).fill(null));
 
   function extract(nodes: NxPivotDimensionCell[], matrix: CellValue[][] = [], colIdx = 0): CellValue[][] {
-    if (!Array.isArray(matrix[colIdx])) {
-      matrix[colIdx] = Array.from({ length: qArea.qHeight }, () => null);  // eslint-disable-line no-param-reassign
-    }
-
     return nodes.reduce((innerMatrix: CellValue[][], node) => {
       if (node.qType !== NxDimCellType.NX_DIM_CELL_TOTAL) {
         innerMatrix[colIdx][rowIdx] = node; // eslint-disable-line no-param-reassign
@@ -27,7 +26,7 @@ const extractLeft = (qLeft: NxPivotDimensionCell[], qArea: NxPageArea): CellValu
     }, matrix);
   }
 
-  return extract(qLeft);
+  return extract(qLeft, nullMatrix);
 };
 
 export default extractLeft;

--- a/src/pivot-table/data/extract-top.ts
+++ b/src/pivot-table/data/extract-top.ts
@@ -1,26 +1,17 @@
-import { NxPageArea, NxPivotDimensionCell } from '../../types/QIX';
+import { NxPivotDimensionCell } from '../../types/QIX';
 import { CellValue } from '../../types/types';
 
-const extractTop = (qTop: NxPivotDimensionCell[], qArea: NxPageArea): CellValue[][] => {
+const extractTop = (qTop: NxPivotDimensionCell[], columnCount: number, rowCount: number): CellValue[][] => {
   let colIdx = 0;
   if (!qTop.length) {
     return [];
   }
 
+  const nullMatrix = Array(columnCount)
+    .fill(null)
+    .map(() => Array(rowCount).fill(null));
+
   function extract(nodes: NxPivotDimensionCell[], matrix: CellValue[][] = [], topRowIdx = 0): CellValue[][] {
-    if (!matrix.length) {
-      matrix.push(...Array(qArea.qWidth)
-        .fill(null)
-        .map(() => [null])
-      );
-    }
-
-    if (Array.isArray(matrix[colIdx+1]) && matrix[colIdx+1].length - 1 < topRowIdx) {
-      matrix.forEach((col) => {
-        col.push(null);
-      });
-    }
-
     return nodes.reduce((mtrx: CellValue[][], node: NxPivotDimensionCell, currIdx: number) => {
       colIdx += currIdx === 0 ? 0 : 1;
       mtrx[colIdx][topRowIdx] = node; // eslint-disable-line no-param-reassign
@@ -33,7 +24,7 @@ const extractTop = (qTop: NxPivotDimensionCell[], qArea: NxPageArea): CellValue[
     }, matrix);
   };
 
-  return extract(qTop);
+  return extract(qTop, nullMatrix);
 };
 
 export default extractTop;

--- a/src/pivot-table/data/index.ts
+++ b/src/pivot-table/data/index.ts
@@ -8,17 +8,17 @@ const getColumnCount = (matrix: CellValue[][]): number => matrix.length;
 
 const getRowCount = (matrix: CellValue[][]): number => matrix[0]?.length || 0;
 
-export default function createData(dataPage: NxPivotPage, qDimensionInfo: NxDimensionInfo[]): PivotData {
+export default function createData(dataPage: NxPivotPage, qDimensionInfo: NxDimensionInfo[], leftDimCount: number): PivotData {
   const { qLeft, qArea, qTop, qData } = dataPage;
-
-  const left = extractLeft(qLeft, qArea);
-  const top = extractTop(qTop, qArea);
-  const data = qData;
+  const leftColumnCount = qDimensionInfo.slice(0, leftDimCount).filter(dim => dim.qCardinalities.qHypercubeCardinal > 0).length;
+  const topRowCount = qDimensionInfo.slice(leftDimCount).filter(dim => dim.qCardinalities.qHypercubeCardinal > 0).length;
+  const left = extractLeft(qLeft, qArea.qHeight, leftColumnCount);
+  const top = extractTop(qTop, qArea.qWidth, topRowCount);
   const headers = extractHeaders(qDimensionInfo, getRowCount(top), getColumnCount(left));
   const pivotData: PivotData = {
     left,
     top,
-    data,
+    data: qData,
     headers,
     size: {
       headers: {

--- a/src/types/QIX.ts
+++ b/src/types/QIX.ts
@@ -72,6 +72,7 @@ export interface NxPivotPage {
 export interface NxDimensionInfo {
   qFallbackTitle: string;
   qApprMaxGlyphCount: number;
+  qCardinalities: NxCardinalities;
 }
 
 export interface NxMeasureInfo {
@@ -109,4 +110,10 @@ export interface NxDimension {
 
 export interface NxMeasure {
   qLibraryId?: string;
+}
+
+export interface NxCardinalities {
+  qCardinal: number;
+  qHypercubeCardinal: number;
+  qAllValuesCardinal: number;
 }


### PR DESCRIPTION
Fixes an issue where the number of columns/rows would be wrong given that the user expanded a dimension on a page, then expanded a dimension on an another page, after which they scrolled back to the first page and collapsed the dimension.

A new "page" is loaded when the user scroll so that new data must be fetched.