### PR TITLE
feat: selections

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@testing-library/dom": "8.11.3",
     "@testing-library/jest-dom": "5.16.1",
     "@testing-library/react": "12.1.2",
+    "@testing-library/react-hooks": "7.0.2",
     "@testing-library/user-event": "13.5.0",
     "@types/jest": "27.4.0",
     "@types/react": "17.0.24",

--- a/src/contexts/SelectionsProvider.tsx
+++ b/src/contexts/SelectionsProvider.tsx
@@ -1,0 +1,24 @@
+import { stardust } from '@nebula.js/stardust';
+import React, { createContext, useContext } from 'react';
+import useSelectionsModel, { SelectionModel } from '../hooks/use-selections-model';
+
+interface SelectionsProviderProps {
+  children: JSX.Element | JSX.Element[],
+  selections: stardust.ObjectSelections
+}
+
+const NOOP_CONTEXT = { select: () => () => {}, isSelected: () => false, isActive: false };
+
+const SelectionsContext = createContext<SelectionModel>(NOOP_CONTEXT);
+
+export const useSelectionsContext = (): SelectionModel => useContext(SelectionsContext);
+
+export default function SelectionsProvider({ children, selections }: SelectionsProviderProps): JSX.Element {
+  const selectionsModel = useSelectionsModel(selections);
+
+  return (
+    <SelectionsContext.Provider value={selectionsModel}>
+      {children}
+    </SelectionsContext.Provider>
+  );
+}

--- a/src/contexts/SelectionsProvider.tsx
+++ b/src/contexts/SelectionsProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from 'react';
-import useDebug from '../hooks/use-debug';
+// import useDebug from '../hooks/use-debug';
 import useSelectionsModel, { SelectionModel } from '../hooks/use-selections-model';
 import { ExtendedSelections } from '../types/types';
 
@@ -21,7 +21,7 @@ export const useSelectionsContext = (): SelectionModel => useContext(SelectionsC
 
 export default function SelectionsProvider({ children, selections }: SelectionsProviderProps): JSX.Element {
   const selectionsModel = useSelectionsModel(selections);
-  useDebug('SelectionsProvider', { ...selectionsModel });
+  // useDebug('SelectionsProvider', { ...selectionsModel });
 
   return (
     <SelectionsContext.Provider value={selectionsModel}>

--- a/src/contexts/SelectionsProvider.tsx
+++ b/src/contexts/SelectionsProvider.tsx
@@ -1,13 +1,19 @@
-import { stardust } from '@nebula.js/stardust';
 import React, { createContext, useContext } from 'react';
+import useDebug from '../hooks/use-debug';
 import useSelectionsModel, { SelectionModel } from '../hooks/use-selections-model';
+import { ExtendedSelections } from '../types/types';
 
 interface SelectionsProviderProps {
   children: JSX.Element | JSX.Element[],
-  selections: stardust.ObjectSelections
+  selections: ExtendedSelections;
 }
 
-const NOOP_CONTEXT = { select: () => () => {}, isSelected: () => false, isActive: false };
+const NOOP_CONTEXT = {
+  select: () => () => {},
+  isSelected: () => false,
+  isActive: false,
+  isLocked: () => false
+};
 
 const SelectionsContext = createContext<SelectionModel>(NOOP_CONTEXT);
 
@@ -15,6 +21,7 @@ export const useSelectionsContext = (): SelectionModel => useContext(SelectionsC
 
 export default function SelectionsProvider({ children, selections }: SelectionsProviderProps): JSX.Element {
   const selectionsModel = useSelectionsModel(selections);
+  useDebug('SelectionsProvider', { ...selectionsModel });
 
   return (
     <SelectionsContext.Provider value={selectionsModel}>

--- a/src/contexts/SelectionsProvider.tsx
+++ b/src/contexts/SelectionsProvider.tsx
@@ -8,14 +8,14 @@ interface SelectionsProviderProps {
   selections: ExtendedSelections;
 }
 
-const NOOP_CONTEXT = {
+const NOOP_SELECTIONS_MODEL = {
   select: () => () => {},
   isSelected: () => false,
   isActive: false,
   isLocked: () => false
 };
 
-const SelectionsContext = createContext<SelectionModel>(NOOP_CONTEXT);
+const SelectionsContext = createContext<SelectionModel>(NOOP_SELECTIONS_MODEL);
 
 export const useSelectionsContext = (): SelectionModel => useContext(SelectionsContext);
 

--- a/src/hooks/__tests__/use-selections-model.test.ts
+++ b/src/hooks/__tests__/use-selections-model.test.ts
@@ -1,0 +1,130 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { NxSelectionCellType } from '../../types/QIX';
+import { ExtendedSelections } from '../../types/types';
+import useSelectionsModel from '../use-selections-model';
+
+describe('useSelectionsModel', () => {
+  let selections: ExtendedSelections;
+
+  beforeEach(() => {
+    selections = {
+      on: () => {},
+      removeListener: () => {},
+      select: () => {},
+      isActive: () => false,
+      begin: () => {},
+    } as unknown as ExtendedSelections;
+
+    jest.spyOn(selections, 'on');
+    jest.spyOn(selections, 'removeListener');
+    jest.spyOn(selections, 'select');
+    jest.spyOn(selections, 'isActive');
+    jest.spyOn(selections, 'begin');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('should add and remove event listeners', () => {
+    const { unmount } = renderHook(() => useSelectionsModel(selections));
+
+    expect(selections.on).toHaveBeenCalledWith('deactivated', expect.any(Function));
+    expect(selections.on).toHaveBeenCalledWith('canceled', expect.any(Function));
+    expect(selections.on).toHaveBeenCalledWith('confirmed', expect.any(Function));
+    expect(selections.on).toHaveBeenCalledWith('cleared', expect.any(Function));
+    expect(selections.removeListener).toHaveBeenCalledTimes(0);
+
+    unmount();
+
+    expect(selections.removeListener).toHaveBeenCalledWith('deactivated', expect.any(Function));
+    expect(selections.removeListener).toHaveBeenCalledWith('canceled', expect.any(Function));
+    expect(selections.removeListener).toHaveBeenCalledWith('confirmed', expect.any(Function));
+    expect(selections.removeListener).toHaveBeenCalledWith('cleared', expect.any(Function));
+  });
+
+  test('should select cell and call begin selection', () => {
+    const { result } = renderHook(() => useSelectionsModel(selections));
+
+    act(() => {
+      result.current.select(NxSelectionCellType.NX_CELL_TOP, 0, 1)();
+      result.current.select(NxSelectionCellType.NX_CELL_TOP, 1, 2)();
+    });
+
+    expect(selections.begin).toHaveBeenCalled();
+    expect(result.current.isSelected(NxSelectionCellType.NX_CELL_TOP, 0 ,1 )).toBeTruthy();
+    expect(result.current.isSelected(NxSelectionCellType.NX_CELL_TOP, 1 ,2 )).toBeTruthy();
+  });
+
+  test('should select cell and not call begin selection when already active', () => {
+    selections.isActive = () => true;
+    const { result } = renderHook(() => useSelectionsModel(selections));
+
+    act(() => {
+      result.current.select(NxSelectionCellType.NX_CELL_TOP, 0, 1)();
+    });
+
+    expect(selections.begin).toHaveBeenCalledTimes(0);
+    expect(result.current.isSelected(NxSelectionCellType.NX_CELL_TOP, 0 ,1 )).toBeTruthy();
+  });
+
+  test('should de-select cell', () => {
+    const { result } = renderHook(() => useSelectionsModel(selections));
+
+    act(() => {
+      result.current.select(NxSelectionCellType.NX_CELL_TOP, 0, 1)();
+    });
+
+    expect(result.current.isSelected(NxSelectionCellType.NX_CELL_TOP, 0 ,1 )).toBeTruthy();
+
+    act(() => {
+      result.current.select(NxSelectionCellType.NX_CELL_TOP, 0, 1)();
+    });
+
+    expect(result.current.isSelected(NxSelectionCellType.NX_CELL_TOP, 0 ,1 )).toBeFalsy();
+  });
+
+  test('should not select lock cell type', () => {
+    const { result } = renderHook(() => useSelectionsModel(selections));
+
+    act(() => {
+      result.current.select(NxSelectionCellType.NX_CELL_TOP, 0, 1)();
+    });
+
+    expect(result.current.isSelected(NxSelectionCellType.NX_CELL_TOP, 0 ,1 )).toBeTruthy();
+
+    act(() => {
+      result.current.select(NxSelectionCellType.NX_CELL_LEFT, 0, 1)();
+    });
+
+    expect(result.current.isSelected(NxSelectionCellType.NX_CELL_LEFT, 0 ,1 )).toBeFalsy();
+  });
+
+  test('should lock cells with qType=T', () => {
+    const { result } = renderHook(() => useSelectionsModel(selections));
+
+    act(() => {
+      result.current.select(NxSelectionCellType.NX_CELL_LEFT, 0, 1)();
+    });
+
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_TOP)).toBeTruthy();
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_LEFT)).toBeFalsy();
+  });
+
+  test('should lock cells with qType=L', () => {
+    const { result } = renderHook(() => useSelectionsModel(selections));
+
+    act(() => {
+      result.current.select(NxSelectionCellType.NX_CELL_TOP, 0, 1)();
+    });
+
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_LEFT)).toBeTruthy();
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_TOP)).toBeFalsy();
+  });
+
+  test('should not lock unknown cell type', () => {
+    const { result } = renderHook(() => useSelectionsModel(selections));
+
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_DATA)).toBeFalsy();
+  });
+});

--- a/src/hooks/__tests__/use-selections-model.test.ts
+++ b/src/hooks/__tests__/use-selections-model.test.ts
@@ -100,31 +100,53 @@ describe('useSelectionsModel', () => {
     expect(result.current.isSelected(NxSelectionCellType.NX_CELL_LEFT, 0 ,1 )).toBeFalsy();
   });
 
-  test('should lock cells with qType=T', () => {
+  test('should lock cells with qType=T when qType=L is already selected', () => {
     const { result } = renderHook(() => useSelectionsModel(selections));
 
     act(() => {
       result.current.select(NxSelectionCellType.NX_CELL_LEFT, 0, 1)();
     });
 
-    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_TOP)).toBeTruthy();
-    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_LEFT)).toBeFalsy();
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_TOP, 0, 1)).toBeTruthy();
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_LEFT, 0, 1)).toBeFalsy();
   });
 
-  test('should lock cells with qType=L', () => {
+  test('should lock cells with qType=T and not on the same row', () => {
     const { result } = renderHook(() => useSelectionsModel(selections));
 
     act(() => {
       result.current.select(NxSelectionCellType.NX_CELL_TOP, 0, 1)();
     });
 
-    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_LEFT)).toBeTruthy();
-    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_TOP)).toBeFalsy();
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_TOP, 0, 1)).toBeFalsy();
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_TOP, 1, 1)).toBeTruthy();
+  });
+
+  test('should lock cells with qType=L when qType=T is already selected', () => {
+    const { result } = renderHook(() => useSelectionsModel(selections));
+
+    act(() => {
+      result.current.select(NxSelectionCellType.NX_CELL_TOP, 0, 1)();
+    });
+
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_LEFT, 0, 1)).toBeTruthy();
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_TOP, 0, 1)).toBeFalsy();
+  });
+
+  test('should lock cells with qType=L and not on the same column', () => {
+    const { result } = renderHook(() => useSelectionsModel(selections));
+
+    act(() => {
+      result.current.select(NxSelectionCellType.NX_CELL_LEFT, 0, 0)();
+    });
+
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_LEFT, 0, 0)).toBeFalsy();
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_LEFT, 0, 1)).toBeTruthy();
   });
 
   test('should not lock unknown cell type', () => {
     const { result } = renderHook(() => useSelectionsModel(selections));
 
-    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_DATA)).toBeFalsy();
+    expect(result.current.isLocked(NxSelectionCellType.NX_CELL_DATA, 0, 0)).toBeFalsy();
   });
 });

--- a/src/hooks/use-data-model.ts
+++ b/src/hooks/use-data-model.ts
@@ -3,6 +3,7 @@ import createData from '../pivot-table/data';
 import { DataModel, FetchNextPage, PivotData } from '../types/types';
 import useExpandOrCollapser from './use-expand-or-collapser';
 import { DEFAULT_PAGE_SIZE, Q_PATH } from '../constants';
+import useNebulaCallback from './use-nebula-callback';
 
 const NOOP_PIVOT_DATA = {} as PivotData;
 
@@ -29,7 +30,7 @@ export default function useDataModel(layout: EngineAPI.IGenericHyperCubeLayout, 
     expandTop,
   } = useExpandOrCollapser(model);
 
-  const newLayoutHandler = useMemo(() => async () => {
+  const newLayoutHandler = useNebulaCallback(async () => {
     if (layout && model) {
       const { qLastExpandedPos, qPivotDataPages } = layout.qHyperCube;
       let pivotPage = qPivotDataPages[0];
@@ -55,8 +56,7 @@ export default function useDataModel(layout: EngineAPI.IGenericHyperCubeLayout, 
 
   usePromise(() => newLayoutHandler(), [newLayoutHandler]);
 
-  // To avoid unnecessary rerenders. Only recreate fetchNextPage function if dependencies changes. A crude version of useCallback.
-  const fetchNextPage = useMemo<FetchNextPage>(() => async (isRow: boolean) => {
+  const fetchNextPage = useNebulaCallback<FetchNextPage>(async (isRow: boolean) => {
     if (loading || !model) return;
 
     setLoading(true);

--- a/src/hooks/use-data-model.ts
+++ b/src/hooks/use-data-model.ts
@@ -79,7 +79,7 @@ export default function useDataModel(layout: EngineAPI.IGenericHyperCubeLayout, 
     }
   }, [maxAreaWidth, maxAreaHeight, model, qDimInfo, qSize]);
 
-  const isLocked = useNebulaCallback((qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => {
+  const isDimensionLocked = useNebulaCallback((qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => {
     if (qType === NxSelectionCellType.NX_CELL_LEFT) {
       return qDimInfo.slice(0, layout.qHyperCube.qNoOfLeftDims)?.[qCol]?.qLocked;
     }
@@ -101,7 +101,7 @@ export default function useDataModel(layout: EngineAPI.IGenericHyperCubeLayout, 
     expandTop,
     pivotData,
     hasData: pivotData !== NOOP_PIVOT_DATA,
-    isLocked
+    isDimensionLocked
   }),[fetchNextPage,
     hasMoreColumns,
     hasMoreRows,
@@ -110,7 +110,7 @@ export default function useDataModel(layout: EngineAPI.IGenericHyperCubeLayout, 
     expandLeft,
     expandTop,
     pivotData,
-    isLocked
+    isDimensionLocked
   ]);
 
   return dataModel;

--- a/src/hooks/use-data-model.ts
+++ b/src/hooks/use-data-model.ts
@@ -4,6 +4,7 @@ import { DataModel, FetchNextPage, PivotData } from '../types/types';
 import useExpandOrCollapser from './use-expand-or-collapser';
 import { DEFAULT_PAGE_SIZE, Q_PATH } from '../constants';
 import useNebulaCallback from './use-nebula-callback';
+import { NxSelectionCellType } from '../types/QIX';
 
 const NOOP_PIVOT_DATA = {} as PivotData;
 
@@ -78,6 +79,18 @@ export default function useDataModel(layout: EngineAPI.IGenericHyperCubeLayout, 
     }
   }, [maxAreaWidth, maxAreaHeight, model, qDimInfo, qSize]);
 
+  const isLocked = useNebulaCallback((qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => {
+    if (qType === NxSelectionCellType.NX_CELL_LEFT) {
+      return qDimInfo.slice(0, layout.qHyperCube.qNoOfLeftDims)?.[qCol]?.qLocked;
+    }
+
+    if (qType === NxSelectionCellType.NX_CELL_TOP) {
+      return qDimInfo.slice(layout.qHyperCube.qNoOfLeftDims)?.[qRow]?.qLocked;
+    }
+
+    return false;
+  }, [qDimInfo, layout.qHyperCube.qNoOfLeftDims]);
+
   const dataModel = useMemo<DataModel>(() => ({
     fetchNextPage,
     hasMoreColumns,
@@ -88,6 +101,7 @@ export default function useDataModel(layout: EngineAPI.IGenericHyperCubeLayout, 
     expandTop,
     pivotData,
     hasData: pivotData !== NOOP_PIVOT_DATA,
+    isLocked
   }),[fetchNextPage,
     hasMoreColumns,
     hasMoreRows,
@@ -96,6 +110,7 @@ export default function useDataModel(layout: EngineAPI.IGenericHyperCubeLayout, 
     expandLeft,
     expandTop,
     pivotData,
+    isLocked
   ]);
 
   return dataModel;

--- a/src/hooks/use-expand-or-collapser.ts
+++ b/src/hooks/use-expand-or-collapser.ts
@@ -1,6 +1,6 @@
-import { useMemo } from '@nebula.js/stardust';
 import { Q_PATH } from '../constants';
 import { ExpandOrCollapser } from '../types/types';
+import useNebulaCallback from './use-nebula-callback';
 
 interface ExpandOrCollapserResult {
   collapseLeft: ExpandOrCollapser
@@ -10,25 +10,25 @@ interface ExpandOrCollapserResult {
 }
 
 export default function useExpandOrCollapser(model: EngineAPI.IGenericObject | undefined): ExpandOrCollapserResult {
-  const collapseLeft = useMemo<ExpandOrCollapser>(() => async (rowIndex: number, colIndex: number) => {
+  const collapseLeft = useNebulaCallback<ExpandOrCollapser>(async (rowIndex: number, colIndex: number) => {
     if (!model) return;
 
     await model.collapseLeft(Q_PATH, rowIndex, colIndex, false);
   }, [model]);
 
-  const collapseTop = useMemo<ExpandOrCollapser>(() => async (rowIndex: number, colIndex: number) => {
+  const collapseTop = useNebulaCallback<ExpandOrCollapser>(async (rowIndex: number, colIndex: number) => {
     if (!model) return;
 
     await model.collapseTop(Q_PATH, rowIndex, colIndex, false);
   }, [model]);
 
-  const expandLeft = useMemo<ExpandOrCollapser>(() => async (rowIndex: number, colIndex: number) => {
+  const expandLeft = useNebulaCallback<ExpandOrCollapser>(async (rowIndex: number, colIndex: number) => {
     if (!model) return;
 
     await model.expandLeft(Q_PATH, rowIndex, colIndex, false);
   }, [model]);
 
-  const expandTop = useMemo<ExpandOrCollapser>(() => async (rowIndex: number, colIndex: number) => {
+  const expandTop = useNebulaCallback<ExpandOrCollapser>(async (rowIndex: number, colIndex: number) => {
     if (!model) return;
 
     await model.expandTop(Q_PATH, rowIndex, colIndex, false);

--- a/src/hooks/use-nebula-callback.ts
+++ b/src/hooks/use-nebula-callback.ts
@@ -1,0 +1,5 @@
+import { useMemo } from '@nebula.js/stardust';
+
+export default function useNebulaCallback<T>(callback: T, deps: unknown[]): T {
+  return useMemo(() => callback, deps);
+}

--- a/src/hooks/use-selections-model.ts
+++ b/src/hooks/use-selections-model.ts
@@ -7,7 +7,7 @@ export interface SelectionModel {
   select: (qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => () => void;
   isSelected: (qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => boolean;
   isActive: boolean;
-  isLocked: (qType: EngineAPI.NxSelectionCellType) => boolean;
+  isLocked: (qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => boolean;
 }
 
 export interface SelectedPivotCell {
@@ -35,12 +35,20 @@ export default function useSelectionsModel(selections: ExtendedSelections): Sele
   }, [selections]);
 
   const isLocked = useCallback(
-    (qType) => {
+    (qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => {
       switch (qType) {
         case NxSelectionCellType.NX_CELL_LEFT:
-          return !!selected.find(cell => cell.qType === NxSelectionCellType.NX_CELL_TOP);
+          return !!selected.find(cell => {
+            if (cell.qType === NxSelectionCellType.NX_CELL_TOP) return true;
+            if (cell.qType === NxSelectionCellType.NX_CELL_LEFT && cell.qCol !== qCol) return true;
+            return false;
+          });
         case NxSelectionCellType.NX_CELL_TOP:
-          return !!selected.find(cell => cell.qType === NxSelectionCellType.NX_CELL_LEFT);
+          return !!selected.find(cell => {
+            if (cell.qType === NxSelectionCellType.NX_CELL_LEFT) return true;
+            if (cell.qType === NxSelectionCellType.NX_CELL_TOP && cell.qRow !== qRow) return true;
+            return false;
+          });
         default:
           return false;
       }
@@ -53,7 +61,7 @@ export default function useSelectionsModel(selections: ExtendedSelections): Sele
       selections.begin([Q_PATH]);
     }
 
-    if (isLocked(qType)) {
+    if (isLocked(qType, qRow, qCol)) {
       return;
     }
 

--- a/src/hooks/use-selections-model.ts
+++ b/src/hooks/use-selections-model.ts
@@ -19,8 +19,6 @@ export interface SelectedPivotCell {
 export default function useSelectionsModel(selections: ExtendedSelections): SelectionModel {
   const [selected, setSelected] = useState<SelectedPivotCell[]>([]);
 
-  useEffect(() => console.debug('selected', selected), [selected]);
-
   useEffect(() => {
     const clearSelections = () => setSelected([]);
     selections.on('deactivated', clearSelections);

--- a/src/hooks/use-selections-model.ts
+++ b/src/hooks/use-selections-model.ts
@@ -1,0 +1,75 @@
+import { stardust } from '@nebula.js/stardust';
+import { useCallback, useEffect, useState, useMemo } from 'react';
+import { Q_PATH } from '../constants';
+
+export interface SelectionModel {
+  select: (qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => () => void;
+  isSelected: (qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => boolean;
+  isActive: boolean;
+}
+
+export interface SelectedPivotCell {
+  qType: string;
+  qRow: number;
+  qCol: number;
+}
+
+export default function useSelectionsModel(selections: stardust.ObjectSelections): SelectionModel {
+  const [selected, setSelected] = useState<SelectedPivotCell[]>([]);
+
+  useEffect(() => {
+    const clearSelections = () => setSelected([]);
+    selections.on('deactivated', clearSelections);
+    selections.on('canceled', clearSelections);
+    selections.on('confirmed', clearSelections);
+    selections.on('cleared', clearSelections);
+console.debug('add selection listeners');
+    return () => {
+      console.debug('remove selection listeners');
+      selections.removeListener('deactivated', clearSelections);
+      selections.removeListener('canceled', clearSelections);
+      selections.removeListener('confirmed', clearSelections);
+      selections.removeListener('cleared', clearSelections);
+    };
+  }, [selections]);
+
+  const select = useCallback((qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => () => {
+    if (!selections.isActive()) {
+      selections.begin([Q_PATH]);
+    }
+
+    setSelected(prev => {
+      const values = [...prev];
+      const idx = values.findIndex(cell => cell.qCol === qCol && cell.qRow === qRow);
+      if (idx > -1) {
+        values.splice(idx, 1);
+      } else {
+        values.push({qType, qCol, qRow});
+      }
+
+      selections.select({
+        method: 'selectPivotCells',
+        params: [Q_PATH, values],
+      });
+
+      return values;
+    });
+  }, [selections]);
+
+  const isSelected = useCallback(
+    (qType, qRow, qCol) => !!selected.find(cell => cell.qType === qType && cell.qRow === qRow && cell.qCol === qCol),
+    [selected]
+  );
+
+  const model = useMemo(() => ({
+    select,
+    isSelected,
+    isActive: selections.isActive()
+  }), [
+    select,
+    isSelected,
+    selections.isActive()
+  ]);
+
+  return model;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import properties from './object-properties';
 import data from './data';
 import { render, teardown } from './pivot-table/Root';
 import useDataModel from './hooks/use-data-model';
+import { ExtendedSelections } from './types/types';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default function supernova() {
@@ -20,7 +21,7 @@ export default function supernova() {
       const rect = useRect();
       const constraints = useConstraints();
       const dataModel = useDataModel(layout, model);
-      const selections = useSelections();
+      const selections = useSelections() as ExtendedSelections;
 
       useEffect(() => {
         if (dataModel.hasData && rect && constraints && selections) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { useElement, useStaleLayout, useEffect, useModel, useRect, useConstraints } from '@nebula.js/stardust';
+import { useElement, useStaleLayout, useEffect, useModel, useRect, useConstraints, useSelections } from '@nebula.js/stardust';
 import properties from './object-properties';
 import data from './data';
 import { render, teardown } from './pivot-table/Root';
@@ -20,18 +20,19 @@ export default function supernova() {
       const rect = useRect();
       const constraints = useConstraints();
       const dataModel = useDataModel(layout, model);
+      const selections = useSelections();
 
-      console.debug('component', layout);
       useEffect(() => {
-        console.debug('render', layout);
-        if (dataModel.hasData && rect && constraints) {
+        if (dataModel.hasData && rect && constraints && selections) {
+          console.debug('render', { layout, selections });
           render(element, {
             rect,
             constraints,
-            dataModel
+            dataModel,
+            selections
           });
         }
-      }, [dataModel, rect, constraints]);
+      }, [dataModel, rect, constraints, selections]);
 
       useEffect(() => () => {
           teardown(element);

--- a/src/pivot-table/Root.tsx
+++ b/src/pivot-table/Root.tsx
@@ -3,8 +3,13 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import { PivotTableProps, StickyPivotTable } from './components/PivotTable';
 import SelectionsProvider from '../contexts/SelectionsProvider';
+import { ExtendedSelections } from '../types/types';
 
-export function render(rootElement: Element, props: PivotTableProps): void {
+interface RootProps extends PivotTableProps {
+  selections: ExtendedSelections;
+}
+
+export function render(rootElement: Element, props: RootProps): void {
   ReactDOM.render(
     <React.StrictMode>
       <SelectionsProvider selections={props.selections}>

--- a/src/pivot-table/Root.tsx
+++ b/src/pivot-table/Root.tsx
@@ -1,10 +1,17 @@
+/* eslint-disable react/jsx-props-no-spreading  */
 import ReactDOM from 'react-dom';
 import React from 'react';
 import { PivotTableProps, StickyPivotTable } from './components/PivotTable';
+import SelectionsProvider from '../contexts/SelectionsProvider';
 
 export function render(rootElement: Element, props: PivotTableProps): void {
-  // eslint-disable-next-line
-  ReactDOM.render(<StickyPivotTable {...props} />, rootElement);
+  ReactDOM.render(
+    <React.StrictMode>
+      <SelectionsProvider selections={props.selections}>
+        <StickyPivotTable {...props} />
+      </SelectionsProvider>
+    </React.StrictMode>
+  , rootElement);
 }
 
 export function teardown(rootElement: Element): void {

--- a/src/pivot-table/components/CellFactory.tsx
+++ b/src/pivot-table/components/CellFactory.tsx
@@ -4,6 +4,8 @@ import DimensionCell from './DimensionCell';
 import DimensionTitleCell from './DimensionTitleCell';
 import EmptyHeaderCell from './EmptyHeaderCell';
 import EmptyCell from './EmptyCell';
+import NxDimCellType from '../../types/QIX';
+import PseudoDimensionCell from './PseudoDimensionCell';
 // import useDebug from '../../hooks/use-debug';
 
 interface GridCallbackProps {
@@ -23,6 +25,14 @@ const CellFactory = ({ columnIndex, rowIndex, style, data }: GridCallbackProps):
   }
 
   if (cell !== null) {
+    if (cell.qType === NxDimCellType.NX_DIM_CELL_PSEUDO) {
+      return <PseudoDimensionCell
+        cell={cell}
+        style={style}
+        isLeftColumn={isLeftColumn}
+      />;
+    }
+
     return <DimensionCell
       cell={cell}
       data={data}

--- a/src/pivot-table/components/DataGrid.tsx
+++ b/src/pivot-table/components/DataGrid.tsx
@@ -71,7 +71,6 @@ const DataGrid = ({
       rowHeight={rowHightCallback}
       width={width}
       itemData={{
-        dataModel,
         matrix: dataModel.pivotData.data,
       }}
       onItemsRendered={onItemsRendered}

--- a/src/pivot-table/components/DimensionCell.tsx
+++ b/src/pivot-table/components/DimensionCell.tsx
@@ -103,7 +103,7 @@ const DimensionCell = ({
   } = data;
   const { select, isSelected, isActive, isLocked } = useSelectionsContext();
   const selectionCellType = isLeftColumn ? NxSelectionCellType.NX_CELL_LEFT : NxSelectionCellType.NX_CELL_TOP;
-  const isCellLocked = isLocked(selectionCellType) || dataModel?.isDimensionLocked(selectionCellType, rowIndex, colIndex);
+  const isCellLocked = isLocked(selectionCellType, rowIndex, colIndex) || dataModel?.isDimensionLocked(selectionCellType, rowIndex, colIndex);
   const appliedSelectedStyle = isSelected(selectionCellType, rowIndex, colIndex) ? selectedStyle : {};
   const appliedLockedSelectionStyle = isCellLocked ? lockedFromSelectionStyle : {};
   const onClickHandler = isCellLocked || qType === NxDimCellType.NX_DIM_CELL_EMPTY ? undefined : select(selectionCellType, rowIndex, colIndex);

--- a/src/pivot-table/components/DimensionCell.tsx
+++ b/src/pivot-table/components/DimensionCell.tsx
@@ -47,7 +47,7 @@ const selectedStyle: React.CSSProperties = {
   color: 'white'
 };
 
-const disabledSelection: React.CSSProperties = {
+const lockedFromSelectionStyle: React.CSSProperties = {
   backgroundImage: 'repeating-linear-gradient(-45deg, #f8f8f8, #f8f8f8 2px, transparent 2px, transparent 4px)',
   color: '#bebebe'
 };
@@ -103,9 +103,9 @@ const DimensionCell = ({
   } = data;
   const { select, isSelected, isActive, isLocked } = useSelectionsContext();
   const selectionCellType = isLeftColumn ? NxSelectionCellType.NX_CELL_LEFT : NxSelectionCellType.NX_CELL_TOP;
-  const isCellLocked = isLocked(selectionCellType) || dataModel?.isLocked(selectionCellType, rowIndex, colIndex);
-  const appliedSelectionStyle = isSelected(selectionCellType, rowIndex, colIndex) ? selectedStyle : {};
-  const appliedLockedSelectionStyle = isCellLocked ? disabledSelection : {};
+  const isCellLocked = isLocked(selectionCellType) || dataModel?.isDimensionLocked(selectionCellType, rowIndex, colIndex);
+  const appliedSelectedStyle = isSelected(selectionCellType, rowIndex, colIndex) ? selectedStyle : {};
+  const appliedLockedSelectionStyle = isCellLocked ? lockedFromSelectionStyle : {};
   const onClickHandler = isCellLocked || qType === NxDimCellType.NX_DIM_CELL_EMPTY ? undefined : select(selectionCellType, rowIndex, colIndex);
   let cellIcon = null;
 
@@ -126,7 +126,7 @@ const DimensionCell = ({
   }
 
   return (
-    <div style={{ ...style, ...containerStyle, ...appliedSelectionStyle, ...appliedLockedSelectionStyle}} data-testid={testId}>
+    <div style={{ ...style, ...containerStyle, ...appliedSelectedStyle, ...appliedLockedSelectionStyle}} data-testid={testId}>
       <div
         style={{ ...cellStyle, ...borderStyle }}
         aria-hidden="true"

--- a/src/pivot-table/components/DimensionCell.tsx
+++ b/src/pivot-table/components/DimensionCell.tsx
@@ -42,12 +42,12 @@ const dimTextStyle: React.CSSProperties = {
   marginLeft: 4,
 };
 
-const selectedStyle: React.CSSProperties = {
+export const selectedStyle: React.CSSProperties = {
   backgroundColor: 'rgb(0, 152, 69)',
   color: 'white'
 };
 
-const lockedFromSelectionStyle: React.CSSProperties = {
+export const lockedFromSelectionStyle: React.CSSProperties = {
   backgroundImage: 'repeating-linear-gradient(-45deg, #f8f8f8, #f8f8f8 2px, transparent 2px, transparent 4px)',
   color: '#bebebe'
 };

--- a/src/pivot-table/components/DimensionCell.tsx
+++ b/src/pivot-table/components/DimensionCell.tsx
@@ -48,13 +48,7 @@ const selectedStyle: React.CSSProperties = {
 };
 
 const disabledSelection: React.CSSProperties = {
-  background: `repeating-linear-gradient(
-    -45deg,
-    #f8f8f8,
-    #f8f8f8 2px,
-    transparent 2px,
-    transparent 4px
-  )`,
+  backgroundImage: 'repeating-linear-gradient(-45deg, #f8f8f8, #f8f8f8 2px, transparent 2px, transparent 4px)',
   color: '#bebebe'
 };
 
@@ -109,10 +103,10 @@ const DimensionCell = ({
   } = data;
   const { select, isSelected, isActive, isLocked } = useSelectionsContext();
   const selectionCellType = isLeftColumn ? NxSelectionCellType.NX_CELL_LEFT : NxSelectionCellType.NX_CELL_TOP;
-  const isCellLocked = isLocked(selectionCellType);
+  const isCellLocked = isLocked(selectionCellType) || dataModel?.isLocked(selectionCellType, rowIndex, colIndex);
   const appliedSelectionStyle = isSelected(selectionCellType, rowIndex, colIndex) ? selectedStyle : {};
   const appliedLockedSelectionStyle = isCellLocked ? disabledSelection : {};
-  const onClickHandler = qType === NxDimCellType.NX_DIM_CELL_EMPTY ? undefined : select(selectionCellType, rowIndex, colIndex);
+  const onClickHandler = isCellLocked || qType === NxDimCellType.NX_DIM_CELL_EMPTY ? undefined : select(selectionCellType, rowIndex, colIndex);
   let cellIcon = null;
 
   if (qCanExpand) {
@@ -120,14 +114,14 @@ const DimensionCell = ({
       fontSize="small"
       data-testid={testIdExpandIcon}
       onClick={createOnExpand({ dataModel, isLeftColumn, rowIndex, colIndex, constraints, isActive })}
-      color={isActive ? 'disabled' : undefined}
+      color={isActive ? 'disabled' : 'action'}
     />;
   } else if (qCanCollapse) {
     cellIcon = <RemoveCircleOutlineSharpIcon
       fontSize="small"
       data-testid={testIdCollapseIcon}
       onClick={createOnCollapse({ dataModel, isLeftColumn, rowIndex, colIndex, constraints, isActive })}
-      color={isActive ? 'disabled' : undefined}
+      color={isActive ? 'disabled' : 'action'}
     />;
   }
 

--- a/src/pivot-table/components/DimensionCell.tsx
+++ b/src/pivot-table/components/DimensionCell.tsx
@@ -43,7 +43,7 @@ const dimTextStyle: React.CSSProperties = {
 };
 
 export const selectedStyle: React.CSSProperties = {
-  backgroundColor: 'rgb(0, 152, 69)',
+  backgroundColor: '#0aaf54',
   color: 'white'
 };
 

--- a/src/pivot-table/components/HeaderGrid.tsx
+++ b/src/pivot-table/components/HeaderGrid.tsx
@@ -64,7 +64,6 @@ const HeaderGrid = ({
       rowHeight={rowHightCallback}
       width={width}
       itemData={{
-        dataModel,
         matrix: dataModel.pivotData.headers,
         isHeader: true
       }}

--- a/src/pivot-table/components/PivotTable.tsx
+++ b/src/pivot-table/components/PivotTable.tsx
@@ -71,10 +71,7 @@ export const StickyPivotTable = ({
 
   return (
     <ScrollableContainer rect={rect} onScroll={onScroll} constraints={constraints} >
-      <FullSizeContainer
-        width={columnWidth * size.totalColumns}
-        height={DEFAULT_ROW_HEIGHT * size.totalRows}
-      >
+      <FullSizeContainer width={columnWidth * size.totalColumns} height={DEFAULT_ROW_HEIGHT * size.totalRows}>
         <StickyContainer
           rect={rect}
           leftColumnsWidth={columnWidth * size.left.x}

--- a/src/pivot-table/components/PseudoDimensionCell.tsx
+++ b/src/pivot-table/components/PseudoDimensionCell.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { CellValue } from '../../types/types';
+import { borderStyle, textStyle } from './shared-styles';
+
+interface LabelCellProps {
+  cell: CellValue;
+  style: React.CSSProperties;
+  isLeftColumn: boolean;
+}
+
+const labelTextStyle: React.CSSProperties = {
+  ...textStyle,
+};
+
+const topContainerStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+};
+
+const leftContainerStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+};
+
+export const testId = 'pseudo-dimension-cell';
+
+const PseudoDimensionCell = ({ cell, style, isLeftColumn }: LabelCellProps): JSX.Element => (
+  <div style={{ ...style, ...borderStyle, ...(isLeftColumn ? leftContainerStyle : topContainerStyle) }} data-testid={testId}>
+    <div style={labelTextStyle}>{(cell as EngineAPI.INxPivotDimensionCell).qText}</div>
+  </div>
+);
+
+export default PseudoDimensionCell;

--- a/src/pivot-table/components/__tests__/CellFactory.test.tsx
+++ b/src/pivot-table/components/__tests__/CellFactory.test.tsx
@@ -57,7 +57,7 @@ describe('CellFactory', () => {
       expandLeft: () => {},
       expandTop: () => {},
       hasData: true,
-      isLocked: () => false,
+      isDimensionLocked: () => false,
     };
 
     data = {

--- a/src/pivot-table/components/__tests__/CellFactory.test.tsx
+++ b/src/pivot-table/components/__tests__/CellFactory.test.tsx
@@ -57,6 +57,7 @@ describe('CellFactory', () => {
       expandLeft: () => {},
       expandTop: () => {},
       hasData: true,
+      isLocked: () => false,
     };
 
     data = {

--- a/src/pivot-table/components/__tests__/CellFactory.test.tsx
+++ b/src/pivot-table/components/__tests__/CellFactory.test.tsx
@@ -7,11 +7,14 @@ import DimensionCell from '../DimensionCell';
 import DimensionTitleCell from '../DimensionTitleCell';
 import EmptyHeaderCell from '../EmptyHeaderCell';
 import EmptyCell from '../EmptyCell';
+import PseudoDimensionCell from '../PseudoDimensionCell';
+import NxDimCellType from '../../../types/QIX';
 
 jest.mock('../DimensionCell');
 jest.mock('../DimensionTitleCell');
 jest.mock('../EmptyHeaderCell');
 jest.mock('../EmptyCell');
+jest.mock('../PseudoDimensionCell');
 
 describe('CellFactory', () => {
   const style: React.CSSProperties = {
@@ -102,6 +105,18 @@ describe('CellFactory', () => {
     render(<CellFactory columnIndex={0} rowIndex={0} style={style} data={data} />);
 
     expect(mockDimensionTitleCell).toHaveBeenCalledWith({ style, cell }, {});
+  });
+
+  test('should render pseudo dimension cell', () => {
+    const mockPseudoDimensionCell = PseudoDimensionCell as jest.MockedFunction<typeof PseudoDimensionCell>;
+    mockPseudoDimensionCell.mockReturnValue(<div />);
+    cell = { qText, qType: NxDimCellType.NX_DIM_CELL_PSEUDO } as EngineAPI.INxPivotDimensionCell;
+    data.matrix[0][0] = cell;
+    data.isLeftColumn = false;
+
+    render(<CellFactory columnIndex={0} rowIndex={0} style={style} data={data} />);
+
+    expect(mockPseudoDimensionCell).toHaveBeenCalledWith({ style, cell, isLeftColumn: false }, {});
   });
 
   test('should render empty header cell', () => {

--- a/src/pivot-table/components/__tests__/DimensionCell.test.tsx
+++ b/src/pivot-table/components/__tests__/DimensionCell.test.tsx
@@ -5,6 +5,8 @@ import { stardust } from '@nebula.js/stardust';
 import DimensionCell, { testId, testIdCollapseIcon, testIdExpandIcon } from '../DimensionCell';
 import { CellValue, DataModel, ItemData } from '../../../types/types';
 import { useSelectionsContext } from '../../../contexts/SelectionsProvider';
+import NxDimCellType, { NxSelectionCellType } from '../../../types/QIX';
+import { SelectionModel } from '../../../hooks/use-selections-model';
 
 jest.mock('../../../contexts/SelectionsProvider');
 
@@ -26,9 +28,14 @@ describe('DimensionCell', () => {
   let expandTopSpy: jest.SpyInstance;
   let collapseLeftSpy: jest.SpyInstance;
   let collapseTopSpy: jest.SpyInstance;
+  let mockedSelectionContext: jest.MockedFunction<() => SelectionModel>;
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
   beforeEach(() => {
-    const mockedSelectionContext = useSelectionsContext as jest.MockedFunction<typeof useSelectionsContext>;
+    mockedSelectionContext = useSelectionsContext as jest.MockedFunction<typeof useSelectionsContext>;
     mockedSelectionContext.mockReturnValue({ select: () => () => {}, isSelected: () => false, isActive: false, isLocked: () => false });
 
     constraints = {
@@ -63,7 +70,7 @@ describe('DimensionCell', () => {
       expandLeft: () => {},
       expandTop: () => {},
       hasData: true,
-      isLocked: () => false,
+      isDimensionLocked: () => false,
     };
 
     expandLeftSpy = jest.spyOn(dataModel, 'expandLeft');
@@ -83,10 +90,11 @@ describe('DimensionCell', () => {
       qText,
       qCanExpand: false,
       qCanCollapse: false,
-    } as EngineAPI.INxPivotDimensionCell;
+      qType: NxDimCellType.NX_DIM_CELL_NORMAL
+    } as unknown as EngineAPI.INxPivotDimensionCell;
   });
 
-  test.only('should render', () => {
+  test('should render', () => {
     render(<DimensionCell
       cell={cell}
       data={data}
@@ -118,98 +126,264 @@ describe('DimensionCell', () => {
   });
 
   describe('left column interactions', () => {
-    test('should be possible to expand left column', () => {
-      (cell as EngineAPI.INxPivotDimensionCell).qCanExpand = true;
+    describe('expand/collapse', () => {
+      test('should be possible to expand left column', () => {
+        (cell as EngineAPI.INxPivotDimensionCell).qCanExpand = true;
 
-      render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn />);
+        render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn />);
 
-      expect(screen.queryByTestId(testIdExpandIcon)).toBeInTheDocument();
-      userEvent.click(screen.getByText(qText));
+        expect(screen.queryByTestId(testIdExpandIcon)).toBeInTheDocument();
+        userEvent.click(screen.getByTestId(testIdExpandIcon));
 
-      expect(expandLeftSpy).toHaveBeenCalledWith(0, 1);
+        expect(expandLeftSpy).toHaveBeenCalledWith(0, 1);
+      });
+
+      test('should not be possible to expand left column when active constraint is true', () => {
+        (cell as EngineAPI.INxPivotDimensionCell).qCanExpand = true;
+        (data.constraints as stardust.Constraints).active = true;
+
+        render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn />);
+
+        expect(screen.queryByTestId(testIdExpandIcon)).toBeInTheDocument();
+        userEvent.click(screen.getByTestId(testIdExpandIcon));
+
+        expect(expandLeftSpy).toHaveBeenCalledTimes(0);
+      });
+
+      test('should not be possible to expand left column when selections is active', () => {
+        (cell as EngineAPI.INxPivotDimensionCell).qCanExpand = true;
+        mockedSelectionContext.mockReturnValue({ select: () => () => {}, isSelected: () => false, isActive: true, isLocked: () => false });
+
+        render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn />);
+
+        expect(screen.queryByTestId(testIdExpandIcon)).toBeInTheDocument();
+        userEvent.click(screen.getByTestId(testIdExpandIcon));
+
+        expect(expandLeftSpy).toHaveBeenCalledTimes(0);
+      });
+
+      test('should be possible to collapse left column', () => {
+        (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+
+        render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn />);
+
+        expect(screen.queryByTestId(testIdCollapseIcon)).toBeInTheDocument();
+        userEvent.click(screen.getByTestId(testIdCollapseIcon));
+
+        expect(collapseLeftSpy).toHaveBeenCalledWith(0, 1);
+      });
+
+      test('should be not possible to collapse left column when active constraint is true', () => {
+        (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+        (data.constraints as stardust.Constraints).active = true;
+
+        render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn />);
+
+        expect(screen.queryByTestId(testIdCollapseIcon)).toBeInTheDocument();
+        userEvent.click(screen.getByTestId(testIdCollapseIcon));
+
+        expect(collapseLeftSpy).toHaveBeenCalledTimes(0);
+      });
+
+      test('should be not possible to collapse left column when selections is active', () => {
+        (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+        mockedSelectionContext.mockReturnValue({ select: () => () => {}, isSelected: () => false, isActive: true, isLocked: () => false });
+
+        render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn />);
+
+        expect(screen.queryByTestId(testIdCollapseIcon)).toBeInTheDocument();
+        userEvent.click(screen.getByTestId(testIdCollapseIcon));
+
+        expect(collapseLeftSpy).toHaveBeenCalledTimes(0);
+      });
     });
 
-    test('should not be possible to expand left column when active constraint is true', () => {
-      (cell as EngineAPI.INxPivotDimensionCell).qCanExpand = true;
-      (data.constraints as stardust.Constraints).active = true;
+    describe('selections', () => {
+      test('should select cell', () => {
+        const rowIdx = 0;
+        const colIdx = 1;
+        const selectHandlerSpy = jest.fn();
+        const onClickHandlerSpy = jest.fn();
+        selectHandlerSpy.mockReturnValue(onClickHandlerSpy);
+        (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+        mockedSelectionContext.mockReturnValue({ select: selectHandlerSpy, isSelected: () => false, isActive: true, isLocked: () => false });
 
-      render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn />);
+        render(<DimensionCell cell={cell} data={data} rowIndex={rowIdx} colIndex={colIdx} style={style} isLeftColumn />);
 
-      expect(screen.queryByTestId(testIdExpandIcon)).toBeInTheDocument();
-      userEvent.click(screen.getByText(qText));
+        userEvent.click(screen.getByText(qText));
 
-      expect(expandLeftSpy).toHaveBeenCalledTimes(0);
-    });
+        expect(selectHandlerSpy).toHaveBeenCalledWith(NxSelectionCellType.NX_CELL_LEFT, rowIdx, colIdx);
+        expect(onClickHandlerSpy).toHaveBeenCalledTimes(1);
+      });
 
-    test('should be possible to collapse left column', () => {
-      (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+      test('should not be possible to select cell when cell is locked due to selections in top column', () => {
+        const rowIdx = 0;
+        const colIdx = 1;
+        const selectHandlerSpy = jest.fn();
+        const onClickHandlerSpy = jest.fn();
+        selectHandlerSpy.mockReturnValue(onClickHandlerSpy);
+        (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+        mockedSelectionContext.mockReturnValue({ select: selectHandlerSpy, isSelected: () => false, isActive: true, isLocked: () => true });
 
-      render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn />);
+        render(<DimensionCell cell={cell} data={data} rowIndex={rowIdx} colIndex={colIdx} style={style} isLeftColumn />);
 
-      expect(screen.queryByTestId(testIdCollapseIcon)).toBeInTheDocument();
-      userEvent.click(screen.getByText(qText));
+        userEvent.click(screen.getByText(qText));
 
-      expect(collapseLeftSpy).toHaveBeenCalledWith(0, 1);
-    });
+        expect(selectHandlerSpy).toHaveBeenCalledTimes(0);
+        expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
+      });
 
-    test('should be not possible to collapse left column when active constraint is true', () => {
-      (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
-      (data.constraints as stardust.Constraints).active = true;
+      test('should not be possible to select cell when dimension is locked', () => {
+        const rowIdx = 0;
+        const colIdx = 1;
+        const selectHandlerSpy = jest.fn();
+        const onClickHandlerSpy = jest.fn();
+        const isDimensionLockedSpy = jest.fn();
+        isDimensionLockedSpy.mockReturnValue(true);
+        dataModel.isDimensionLocked = isDimensionLockedSpy;
+        selectHandlerSpy.mockReturnValue(onClickHandlerSpy);
+        (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+        mockedSelectionContext.mockReturnValue({ select: selectHandlerSpy, isSelected: () => false, isActive: true, isLocked: () => false });
 
-      render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn />);
+        render(<DimensionCell cell={cell} data={data} rowIndex={rowIdx} colIndex={colIdx} style={style} isLeftColumn />);
 
-      expect(screen.queryByTestId(testIdCollapseIcon)).toBeInTheDocument();
-      userEvent.click(screen.getByText(qText));
+        userEvent.click(screen.getByText(qText));
 
-      expect(collapseLeftSpy).toHaveBeenCalledTimes(0);
+        expect(isDimensionLockedSpy).toHaveBeenCalledWith(NxSelectionCellType.NX_CELL_LEFT, rowIdx, colIdx);
+        expect(selectHandlerSpy).toHaveBeenCalledTimes(0);
+        expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
+      });
     });
   });
 
   describe('top row interactions', () => {
-    test('should be possible to expand top row', () => {
-      (cell as EngineAPI.INxPivotDimensionCell).qCanExpand = true;
+    describe('expand/collapse', () => {
+      test('should be possible to expand top row', () => {
+        (cell as EngineAPI.INxPivotDimensionCell).qCanExpand = true;
 
-      render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn={false} />);
+        render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn={false} />);
 
-      expect(screen.queryByTestId(testIdExpandIcon)).toBeInTheDocument();
-      userEvent.click(screen.getByText(qText));
+        expect(screen.queryByTestId(testIdExpandIcon)).toBeInTheDocument();
+        userEvent.click(screen.getByTestId(testIdExpandIcon));
 
-      expect(expandTopSpy).toHaveBeenCalledWith(0, 1);
+        expect(expandTopSpy).toHaveBeenCalledWith(0, 1);
+      });
+
+      test('should not be possible to expand top row when active constraint is true', () => {
+        (cell as EngineAPI.INxPivotDimensionCell).qCanExpand = true;
+        (data.constraints as stardust.Constraints).active = true;
+
+        render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn={false} />);
+
+        expect(screen.queryByTestId(testIdExpandIcon)).toBeInTheDocument();
+        userEvent.click(screen.getByTestId(testIdExpandIcon));
+
+        expect(expandTopSpy).toHaveBeenCalledTimes(0);
+      });
+
+      test('should not be possible to expand top row when selections is active', () => {
+        (cell as EngineAPI.INxPivotDimensionCell).qCanExpand = true;
+        mockedSelectionContext.mockReturnValue({ select: () => () => {}, isSelected: () => false, isActive: true, isLocked: () => false });
+
+        render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn={false} />);
+
+        expect(screen.queryByTestId(testIdExpandIcon)).toBeInTheDocument();
+        userEvent.click(screen.getByTestId(testIdExpandIcon));
+
+        expect(expandTopSpy).toHaveBeenCalledTimes(0);
+      });
+
+      test('should be possible to collapse top row', () => {
+        (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+
+        render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn={false} />);
+
+        expect(screen.queryByTestId(testIdCollapseIcon)).toBeInTheDocument();
+        userEvent.click(screen.getByTestId(testIdCollapseIcon));
+
+        expect(collapseTopSpy).toHaveBeenCalledWith(0, 1);
+      });
+
+      test('should be not possible to collapse top row when active constraint is true', () => {
+        (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+        (data.constraints as stardust.Constraints).active = true;
+
+        render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn={false} />);
+
+        expect(screen.queryByTestId(testIdCollapseIcon)).toBeInTheDocument();
+        userEvent.click(screen.getByTestId(testIdCollapseIcon));
+
+        expect(collapseTopSpy).toHaveBeenCalledTimes(0);
+      });
+
+      test('should be not possible to collapse top row when selections is active', () => {
+        (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+        mockedSelectionContext.mockReturnValue({ select: () => () => {}, isSelected: () => false, isActive: true, isLocked: () => false });
+
+        render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn={false} />);
+
+        expect(screen.queryByTestId(testIdCollapseIcon)).toBeInTheDocument();
+        userEvent.click(screen.getByTestId(testIdCollapseIcon));
+
+        expect(collapseTopSpy).toHaveBeenCalledTimes(0);
+      });
     });
 
-    test('should not be possible to expand top row when active constraint is true', () => {
-      (cell as EngineAPI.INxPivotDimensionCell).qCanExpand = true;
-      (data.constraints as stardust.Constraints).active = true;
+    describe('selections', () => {
+      test('should select cell', () => {
+        const rowIdx = 0;
+        const colIdx = 1;
+        const selectHandlerSpy = jest.fn();
+        const onClickHandlerSpy = jest.fn();
+        selectHandlerSpy.mockReturnValue(onClickHandlerSpy);
+        (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+        mockedSelectionContext.mockReturnValue({ select: selectHandlerSpy, isSelected: () => false, isActive: true, isLocked: () => false });
 
-      render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn={false} />);
+        render(<DimensionCell cell={cell} data={data} rowIndex={rowIdx} colIndex={colIdx} style={style} isLeftColumn={false} />);
 
-      expect(screen.queryByTestId(testIdExpandIcon)).toBeInTheDocument();
-      userEvent.click(screen.getByText(qText));
+        userEvent.click(screen.getByText(qText));
 
-      expect(expandTopSpy).toHaveBeenCalledTimes(0);
-    });
+        expect(selectHandlerSpy).toHaveBeenCalledWith(NxSelectionCellType.NX_CELL_TOP, rowIdx, colIdx);
+        expect(onClickHandlerSpy).toHaveBeenCalledTimes(1);
+      });
 
-    test('should be possible to collapse top row', () => {
-      (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+      test('should not be possible to select cell when cell is locked due to selections in left column', () => {
+        const rowIdx = 0;
+        const colIdx = 1;
+        const selectHandlerSpy = jest.fn();
+        const onClickHandlerSpy = jest.fn();
+        selectHandlerSpy.mockReturnValue(onClickHandlerSpy);
+        (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+        mockedSelectionContext.mockReturnValue({ select: selectHandlerSpy, isSelected: () => false, isActive: true, isLocked: () => true });
 
-      render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn={false} />);
+        render(<DimensionCell cell={cell} data={data} rowIndex={rowIdx} colIndex={colIdx} style={style} isLeftColumn={false} />);
 
-      expect(screen.queryByTestId(testIdCollapseIcon)).toBeInTheDocument();
-      userEvent.click(screen.getByText(qText));
+        userEvent.click(screen.getByText(qText));
 
-      expect(collapseTopSpy).toHaveBeenCalledWith(0, 1);
-    });
+        expect(selectHandlerSpy).toHaveBeenCalledTimes(0);
+        expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
+      });
 
-    test('should be not possible to collapse top row when active constraint is true', () => {
-      (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
-      (data.constraints as stardust.Constraints).active = true;
+      test('should not be possible to select cell when dimension is locked', () => {
+        const rowIdx = 0;
+        const colIdx = 1;
+        const selectHandlerSpy = jest.fn();
+        const onClickHandlerSpy = jest.fn();
+        const isDimensionLockedSpy = jest.fn();
+        isDimensionLockedSpy.mockReturnValue(true);
+        dataModel.isDimensionLocked = isDimensionLockedSpy;
+        selectHandlerSpy.mockReturnValue(onClickHandlerSpy);
+        (cell as EngineAPI.INxPivotDimensionCell).qCanCollapse = true;
+        mockedSelectionContext.mockReturnValue({ select: selectHandlerSpy, isSelected: () => false, isActive: true, isLocked: () => false });
 
-      render(<DimensionCell cell={cell} data={data} rowIndex={0} colIndex={1} style={style} isLeftColumn={false} />);
+        render(<DimensionCell cell={cell} data={data} rowIndex={rowIdx} colIndex={colIdx} style={style} isLeftColumn={false} />);
 
-      expect(screen.queryByTestId(testIdCollapseIcon)).toBeInTheDocument();
-      userEvent.click(screen.getByText(qText));
+        userEvent.click(screen.getByText(qText));
 
-      expect(collapseTopSpy).toHaveBeenCalledTimes(0);
+        expect(isDimensionLockedSpy).toHaveBeenCalledWith(NxSelectionCellType.NX_CELL_TOP, rowIdx, colIdx);
+        expect(selectHandlerSpy).toHaveBeenCalledTimes(0);
+        expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
+      });
     });
   });
 });

--- a/src/pivot-table/components/__tests__/DimensionCell.test.tsx
+++ b/src/pivot-table/components/__tests__/DimensionCell.test.tsx
@@ -4,6 +4,9 @@ import userEvent from '@testing-library/user-event';
 import { stardust } from '@nebula.js/stardust';
 import DimensionCell, { testId, testIdCollapseIcon, testIdExpandIcon } from '../DimensionCell';
 import { CellValue, DataModel, ItemData } from '../../../types/types';
+import { useSelectionsContext } from '../../../contexts/SelectionsProvider';
+
+jest.mock('../../../contexts/SelectionsProvider');
 
 describe('DimensionCell', () => {
   let constraints: stardust.Constraints;
@@ -25,6 +28,9 @@ describe('DimensionCell', () => {
   let collapseTopSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    const mockedSelectionContext = useSelectionsContext as jest.MockedFunction<typeof useSelectionsContext>;
+    mockedSelectionContext.mockReturnValue({ select: () => () => {}, isSelected: () => false, isActive: false, isLocked: () => false });
+
     constraints = {
       active: false,
       passive: false,
@@ -57,6 +63,7 @@ describe('DimensionCell', () => {
       expandLeft: () => {},
       expandTop: () => {},
       hasData: true,
+      isLocked: () => false,
     };
 
     expandLeftSpy = jest.spyOn(dataModel, 'expandLeft');
@@ -79,7 +86,7 @@ describe('DimensionCell', () => {
     } as EngineAPI.INxPivotDimensionCell;
   });
 
-  test('should render', () => {
+  test.only('should render', () => {
     render(<DimensionCell
       cell={cell}
       data={data}

--- a/src/pivot-table/components/__tests__/PseudoDimensionCell.test.tsx
+++ b/src/pivot-table/components/__tests__/PseudoDimensionCell.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PseudoDimensionCell, { testId } from '../PseudoDimensionCell';
+import { CellValue } from '../../../types/types';
+
+test('should render on the top',  () => {
+  const cell: CellValue = { qText: 'test' } as EngineAPI.INxPivotDimensionCell;
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    left: '25px',
+    top: '35px',
+    width: '100px',
+    height: '150px',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  };
+
+  render(<PseudoDimensionCell cell={cell} style={style} isLeftColumn={false} />);
+
+  expect(screen.getByText('test')).toBeInTheDocument();
+  expect(screen.getByTestId(testId)).toHaveStyle(style as Record<string, unknown>);
+});
+
+
+test('should render on the left',  () => {
+  const cell: CellValue = { qText: 'test' } as EngineAPI.INxPivotDimensionCell;
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    left: '25px',
+    top: '35px',
+    width: '100px',
+    height: '150px',
+    display: 'flex',
+    alignItems: 'center',
+  };
+
+  render(<PseudoDimensionCell cell={cell} style={style} isLeftColumn />);
+
+  expect(screen.getByText('test')).toBeInTheDocument();
+  expect(screen.getByTestId(testId)).toHaveStyle(style as Record<string, unknown>);
+  expect(screen.getByTestId(testId)).not.toHaveStyle({ justifyContent: 'center' } as Record<string, unknown>);
+});

--- a/src/types/QIX.ts
+++ b/src/types/QIX.ts
@@ -11,4 +11,10 @@ enum NxDimCellType {
   NX_DIM_CELL_GENERATED = 'G',
 }
 
+export enum NxSelectionCellType {
+  NX_CELL_DATA = 'D',
+  NX_CELL_TOP = 'T',
+  NX_CELL_LEFT = 'L'
+}
+
 export default NxDimCellType;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -24,6 +24,7 @@ export interface DataModel {
   expandLeft: ExpandOrCollapser;
   expandTop: ExpandOrCollapser;
   hasData: boolean;
+  isLocked: (qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => boolean;
 }
 
 export interface ItemData {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -28,7 +28,7 @@ export interface DataModel {
 
 export interface ItemData {
   constraints?: stardust.Constraints;
-  dataModel: DataModel;
+  dataModel?: DataModel;
   matrix: CellValue[][] | EngineAPI.INxPivotValuePoint[][];
   isLeftColumn?: boolean;
   isHeader?: boolean;
@@ -49,4 +49,9 @@ export interface PivotData {
     totalColumns: number;
     totalRows: number;
   }
+}
+
+export interface ExtendedSelections extends stardust.ObjectSelections {
+  on: (name: string, callback: () => void) => void;
+  removeListener: (name: string, callback: () => void) => void;
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -24,7 +24,7 @@ export interface DataModel {
   expandLeft: ExpandOrCollapser;
   expandTop: ExpandOrCollapser;
   hasData: boolean;
-  isLocked: (qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => boolean;
+  isDimensionLocked: (qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => boolean;
 }
 
 export interface ItemData {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2121,6 +2121,17 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"
+  integrity sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@12.1.2":
   version "12.1.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.2.tgz#f1bc9a45943461fa2a598bb4597df1ae044cfc76"
@@ -2298,10 +2309,24 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
+  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-is@^16.7.1 || ^17.0.0":
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
   integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
   dependencies:
     "@types/react" "*"
 
@@ -2332,6 +2357,15 @@
   version "17.0.24"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.24.tgz#7e1b3f78d0fc53782543f9bce6d949959a5880bd"
   integrity sha512-eIpyco99gTH+FTI3J7Oi/OH8MZoFMJuztNRimDOJwH4iGIsKV2qkGnk4M9VzlaVWeEEWLWSQRy0FEA0Kz218cg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.39"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
+  integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -7212,6 +7246,13 @@ react-dom@17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"


### PR DESCRIPTION
Add support for selection by clicking on a dimension value. There is room for improvements on the implementation, most notably by reducing the complexity of the DimensionCell component and handling styling better. But that will have to be for targeted for another PR. I did end up using a context to provide the selections model api to components needing it. It had the lowest number of re-renders when I debug different approaches. Thought I expect that might change in the future as more features are added.

- A cell cannot be selected if dimension is locked 
- A cell cannot be selected if a cell from the opposite side (top or left) is already selected
- A cell cannot be selected if an active selection is on another row or column
- A cell cannot be expanded/collapsed while selection mode is active

![Screenshot 2022-02-16 at 09 43 45](https://user-images.githubusercontent.com/16608020/154481407-6b594210-8609-4c26-9524-3d5b6c8950d8.png)
