### PR TITLE
feat: dynamic column width

### DIFF
--- a/src/hooks/__tests__/use-column-width.test.ts
+++ b/src/hooks/__tests__/use-column-width.test.ts
@@ -113,6 +113,33 @@ describe('useColumnWidth', () => {
       expect(result.current.getDataColumnWidth(2)).toBe(190);
     });
 
+    test('should not return data column width based of available right grid width when total data column width is larger than available right grid width', () => {
+      const m0 = { qFallbackTitle: 'm0', qApprMaxGlyphCount: 0 } as unknown as EngineAPI.INxMeasureInfo;
+      const m1 = { qFallbackTitle: 'm1', qApprMaxGlyphCount: 0 } as unknown as EngineAPI.INxMeasureInfo;
+      const m2 = { qFallbackTitle: 'm2', qApprMaxGlyphCount: 0 } as unknown as EngineAPI.INxMeasureInfo;
+      mockedDataModel.getMeasureInfo = () => [m0, m1, m2];
+      (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(10);
+      (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockImplementation((title) => {
+        switch (title) {
+          case 'm0':
+            return 600;
+          case 'm1':
+            return 200;
+          case 'm2':
+            return 150;
+          default:
+            throw new Error;
+        }
+      });
+      mockedDataModel.pivotData.size.data.x = 3;
+      rect.width = 600;
+
+      const { result } = renderHook(() => useColumnWidth(mockedDataModel, rect));
+      expect(result.current.getDataColumnWidth(0)).toBe(600);
+      expect(result.current.getDataColumnWidth(1)).toBe(200);
+      expect(result.current.getDataColumnWidth(2)).toBe(150);
+    });
+
     test('should return data column width based of estimated width', () => {
       (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(150);
       (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValue(10);

--- a/src/hooks/__tests__/use-column-width.test.ts
+++ b/src/hooks/__tests__/use-column-width.test.ts
@@ -1,0 +1,151 @@
+import { renderHook } from '@testing-library/react-hooks';
+import NxDimCellType from '../../types/QIX';
+import { DataModel, Rect } from '../../types/types';
+import useColumnWidth from '../use-column-width';
+import useMeasureText, { MeasureTextHook } from '../use-measure-text';
+
+jest.mock('../use-measure-text');
+
+describe('useColumnWidth', () => {
+  let rect: Rect;
+  let mockedUseMeasureText: jest.MockedFunction<(size: string, fam: string) => MeasureTextHook>;
+  let mockedDataModel: DataModel;
+  let mockedMeasureText: MeasureTextHook;
+
+  beforeEach(() => {
+    const cell = { qType: NxDimCellType.NX_DIM_CELL_NORMAL } as EngineAPI.INxPivotDimensionCell;
+    const dimInfo = { qApprMaxGlyphCount: 1 } as EngineAPI.INxDimensionInfo;
+    const meaInfo = { qFallbackTitle: 1, qApprMaxGlyphCount: 0 } as unknown as EngineAPI.INxMeasureInfo;
+    rect = { width: 200, height: 100 };
+    mockedUseMeasureText = useMeasureText as jest.MockedFunction<typeof useMeasureText>;
+    mockedDataModel = {
+      getDimensionInfo: () => [dimInfo, dimInfo, dimInfo],
+      getMeasureInfo: () => [meaInfo, meaInfo, meaInfo],
+      pivotData: {
+        left: [[cell], [cell], [cell]],
+        size: {
+          data: {
+            x: 3
+          }
+        }
+      }
+    } as unknown as DataModel;
+
+    mockedMeasureText = {
+      measureText: jest.fn() as jest.MockedFunction<(text: string) => number>,
+      estimateWidth: jest.fn() as jest.MockedFunction<(length: number) => number>
+    };
+    mockedUseMeasureText.mockReturnValue(mockedMeasureText);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('grid width', () => {
+    test('should return left and right grid widths with only dimension cells', () => {
+      (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(50);
+
+      const { result } = renderHook(() => useColumnWidth(mockedDataModel, rect));
+      expect(result.current.leftGridWidth).toBe(150);
+      expect(result.current.rightGridWidth).toBe(50);
+    });
+
+    test('should return left and right grid width with dimension and pseudo dimension cells', () => {
+      const cell = { qType: NxDimCellType.NX_DIM_CELL_NORMAL } as EngineAPI.INxPivotDimensionCell;
+      const pCell = { qType: NxDimCellType.NX_DIM_CELL_PSEUDO } as EngineAPI.INxPivotDimensionCell;
+      const dimInfo = { qApprMaxGlyphCount: 1 } as EngineAPI.INxDimensionInfo;
+      const meaInfo = { qFallbackTitle: 1 } as unknown as EngineAPI.INxMeasureInfo;
+      mockedDataModel.pivotData.left = [[cell], [pCell], [cell]];
+      mockedDataModel.getDimensionInfo = () => [dimInfo, dimInfo, dimInfo];
+      mockedDataModel.getMeasureInfo = () => [meaInfo];
+      (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(50);
+      (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValue(35);
+
+      const { result } = renderHook(() => useColumnWidth(mockedDataModel, rect));
+      expect(result.current.leftGridWidth).toBe(135);
+      expect(result.current.rightGridWidth).toBe(65);
+    });
+
+    test('left grid can not take more space then 75% of the total width available', () => {
+      (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(100);
+
+      const { result } = renderHook(() => useColumnWidth(mockedDataModel, rect));
+      expect(result.current.leftGridWidth).toBe(rect.width * 0.75);
+      expect(result.current.rightGridWidth).toBe(rect.width * 0.25);
+    });
+  });
+
+  describe('getLeftColumnWidth', () => {
+    test('should return left column width', () => {
+      (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValueOnce(25);
+      (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValueOnce(50);
+      (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValueOnce(75);
+
+      const { result } = renderHook(() => useColumnWidth(mockedDataModel, rect));
+      expect(result.current.getLeftColumnWidth(0)).toBe(25);
+      expect(result.current.getLeftColumnWidth(1)).toBe(50);
+      expect(result.current.getLeftColumnWidth(2)).toBe(75);
+    });
+  });
+
+  describe('getDataColumnWidth', () => {
+    test('should return minimum data column width of 100', () => {
+      (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(50);
+      (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValue(50);
+      mockedDataModel.pivotData.size.data.x = 3;
+
+      const { result } = renderHook(() => useColumnWidth(mockedDataModel, rect));
+      expect(result.current.getDataColumnWidth(0)).toBe(100);
+      expect(result.current.getDataColumnWidth(1)).toBe(100);
+      expect(result.current.getDataColumnWidth(2)).toBe(100);
+    });
+
+    test('should return data column width based of available right grid width', () => {
+      (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(10);
+      (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValue(10);
+      mockedDataModel.pivotData.size.data.x = 3;
+      rect.width = 600;
+
+      const { result } = renderHook(() => useColumnWidth(mockedDataModel, rect));
+      expect(result.current.getDataColumnWidth(0)).toBe(190);
+      expect(result.current.getDataColumnWidth(1)).toBe(190);
+      expect(result.current.getDataColumnWidth(2)).toBe(190);
+    });
+
+    test('should return data column width based of estimated width', () => {
+      (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(150);
+      (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValue(10);
+      mockedDataModel.pivotData.size.data.x = 3;
+      rect.width = 600;
+
+      const { result } = renderHook(() => useColumnWidth(mockedDataModel, rect));
+      expect(result.current.getDataColumnWidth(0)).toBe(150);
+      expect(result.current.getDataColumnWidth(1)).toBe(150);
+      expect(result.current.getDataColumnWidth(2)).toBe(150);
+    });
+
+    test('should return data column width based of measured title width', () => {
+      (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(50);
+      (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValue(250);
+      mockedDataModel.pivotData.size.data.x = 3;
+      rect.width = 600;
+
+      const { result } = renderHook(() => useColumnWidth(mockedDataModel, rect));
+      expect(result.current.getDataColumnWidth(0)).toBe(250);
+      expect(result.current.getDataColumnWidth(1)).toBe(250);
+      expect(result.current.getDataColumnWidth(2)).toBe(250);
+    });
+  });
+
+  describe('getTotalWidth', () => {
+    test('should return total width', () => {
+      (mockedMeasureText.estimateWidth as jest.MockedFunction<(length: number) => number>).mockReturnValue(100);
+      (mockedMeasureText.measureText as jest.MockedFunction<(text: string) => number>).mockReturnValue(100);
+      mockedDataModel.pivotData.size.data.x = 30;
+
+      const { result } = renderHook(() => useColumnWidth(mockedDataModel, rect));
+      expect(result.current.getTotalWidth()).toBe(150 + (30 * 100));
+    });
+  });
+});

--- a/src/hooks/__tests__/use-measure-text.test.ts
+++ b/src/hooks/__tests__/use-measure-text.test.ts
@@ -1,0 +1,45 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import useMeasureText from '../use-measure-text';
+
+jest.mock('../use-data-model');
+
+describe('useMeasureText', () => {
+  let measureTextMock: jest.Mock<{ width: number }>;
+
+  beforeEach(() => {
+    measureTextMock = jest.fn();
+    const context = {
+      measureText: measureTextMock
+    } as unknown as CanvasRenderingContext2D;
+    jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(context);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('estimateWidth', () => {
+    test('should estimate width', () => {
+      measureTextMock.mockReturnValue({ width: 150 });
+      const { result } = renderHook(() => useMeasureText('13px', 'font'));
+
+      expect(result.current.estimateWidth(2)).toBe(300);
+    });
+
+    test('should have a minimum width limit', () => {
+      measureTextMock.mockReturnValue({ width: 1 });
+      const { result } = renderHook(() => useMeasureText('13px', 'font'));
+
+      expect(result.current.estimateWidth(2)).toBe(100);
+    });
+  });
+
+  describe('measureText', () => {
+    test('should measure width', () => {
+      measureTextMock.mockReturnValue({ width: 150 });
+      const { result } = renderHook(() => useMeasureText('13px', 'font'));
+
+      expect(result.current.measureText('some string')).toBe(175);
+    });
+  });
+});

--- a/src/hooks/__tests__/use-measure-text.test.ts
+++ b/src/hooks/__tests__/use-measure-text.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks';
 import useMeasureText from '../use-measure-text';
 
 jest.mock('../use-data-model');

--- a/src/hooks/use-column-width.ts
+++ b/src/hooks/use-column-width.ts
@@ -62,17 +62,31 @@ export default function useColumnWidth(dataModel: DataModel, rect: Rect): Column
     [leftGridWidth, rect.width]
   );
 
+  const totalDataColumnWidth = useMemo(() => {
+    const totalWidth = getMeasureInfo().reduce((width, qMeasureInfo) => {
+      const { qApprMaxGlyphCount, qFallbackTitle } = qMeasureInfo;
+      return width + Math.max(
+        MIN_COLUMN_WIDTH,
+        estimateWidth(qApprMaxGlyphCount),
+        measureText(qFallbackTitle),
+      );
+    }, 0);
+
+    return totalWidth;
+  }, [getMeasureInfo, estimateWidth, measureText]);
+
   const getDataColumnWidth = useCallback((colIndex: number) => {
     const measureInfoIndex = colIndex % getMeasureInfo().length;
     const { qApprMaxGlyphCount, qFallbackTitle } = getMeasureInfo()[measureInfoIndex];
+    const availableWidth = totalDataColumnWidth >= rightGridWidth ? 0 : rightGridWidth;
 
     return Math.max(
       MIN_COLUMN_WIDTH,
-      rightGridWidth / pivotData.size.data.x,
+      availableWidth / pivotData.size.data.x,
       estimateWidth(qApprMaxGlyphCount),
       measureText(qFallbackTitle),
     );
-  }, [rightGridWidth, pivotData, estimateWidth, measureText, getMeasureInfo]);
+  }, [rightGridWidth, pivotData, totalDataColumnWidth, estimateWidth, measureText, getMeasureInfo]);
 
   const getTotalWidth = useCallback(() => Array
       .from({ length: pivotData.size.data.x }, () => null)

--- a/src/hooks/use-column-width.ts
+++ b/src/hooks/use-column-width.ts
@@ -1,0 +1,90 @@
+import { useCallback, useMemo } from 'react';
+import NxDimCellType from '../types/QIX';
+import { DataModel, Rect } from '../types/types';
+import useMeasureText from './use-measure-text';
+
+interface ColumnWidthHook {
+  leftGridWidth: number;
+  rightGridWidth: number;
+  getLeftColumnWidth: (index: number) => number;
+  getDataColumnWidth: (index: number) => number;
+  getTotalWidth: () => number;
+}
+
+const MIN_COLUMN_WIDTH = 100;
+const MAX_RATIO_OF_TOTAL_WIDTH = 0.75;
+
+export default function useColumnWidth(dataModel: DataModel, rect: Rect): ColumnWidthHook {
+  const { estimateWidth, measureText } = useMeasureText('13px', '"Source Sans Pro", sans-serif'); // TODO Hard-coded...
+  const { getDimensionInfo, getMeasureInfo, pivotData } = dataModel;
+
+  const leftColumnWidthsRatios = useMemo(() => {
+    const ratios = pivotData.left
+      .reduce<number[]>((tmpRatios, cells, index) => {
+        const { qType } = (cells[0] as EngineAPI.INxPivotDimensionCell);
+
+        if (qType === NxDimCellType.NX_DIM_CELL_PSEUDO) {
+          const pseudoDimensionWidth = getMeasureInfo()
+          .map(qMeasureInfo => qMeasureInfo.qFallbackTitle)
+          .reduce((max, qFallbackTitle) => Math.max(max, measureText(qFallbackTitle)), 0);
+
+          tmpRatios.push(pseudoDimensionWidth / rect.width);
+
+          return tmpRatios;
+        }
+
+        const w = estimateWidth(getDimensionInfo()[index].qApprMaxGlyphCount);
+        tmpRatios.push(w / rect.width);
+
+        return tmpRatios;
+      }, []);
+
+    const sumOfRatios = ratios.reduce((sum, r) => sum + r, 0);
+    if (sumOfRatios < MAX_RATIO_OF_TOTAL_WIDTH) return ratios;
+
+    const multiplier = MAX_RATIO_OF_TOTAL_WIDTH / sumOfRatios;
+    return ratios.map(r => r * multiplier);
+
+  }, [estimateWidth, measureText, pivotData, getDimensionInfo, rect, getMeasureInfo]);
+
+  const getLeftColumnWidth = useCallback(
+    (index) => leftColumnWidthsRatios[index] * rect.width,
+    [leftColumnWidthsRatios, rect]
+  );
+
+  const leftGridWidth = useMemo(
+    () => pivotData.left.reduce((width, _, index) => width + getLeftColumnWidth(index), 0),
+    [pivotData, getLeftColumnWidth]
+  );
+
+  const rightGridWidth = useMemo(
+    () => Math.max(rect.width - leftGridWidth),
+    [leftGridWidth, rect.width]
+  );
+
+  const getDataColumnWidth = useCallback((colIndex: number) => {
+    const measureInfoIndex = colIndex % getMeasureInfo().length;
+    const { qApprMaxGlyphCount, qFallbackTitle } = getMeasureInfo()[measureInfoIndex];
+
+    return Math.max(
+      MIN_COLUMN_WIDTH,
+      rightGridWidth / pivotData.size.data.x,
+      estimateWidth(qApprMaxGlyphCount),
+      measureText(qFallbackTitle),
+    );
+  }, [rightGridWidth, pivotData, estimateWidth, measureText, getMeasureInfo]);
+
+  const getTotalWidth = useCallback(() => Array
+      .from({ length: pivotData.size.data.x }, () => null)
+      .reduce((width, _, index) => width + getDataColumnWidth(index), leftGridWidth),
+    [getDataColumnWidth, leftGridWidth, pivotData]
+  );
+
+  return {
+    leftGridWidth,
+    rightGridWidth,
+    getLeftColumnWidth,
+    getDataColumnWidth,
+    getTotalWidth
+  };
+}

--- a/src/hooks/use-column-width.ts
+++ b/src/hooks/use-column-width.ts
@@ -25,8 +25,8 @@ export default function useColumnWidth(dataModel: DataModel, rect: Rect): Column
 
         if (qType === NxDimCellType.NX_DIM_CELL_PSEUDO) {
           const pseudoDimensionWidth = getMeasureInfo()
-          .map(qMeasureInfo => qMeasureInfo.qFallbackTitle)
-          .reduce((max, qFallbackTitle) => Math.max(max, measureText(qFallbackTitle)), 0);
+            .map(qMeasureInfo => qMeasureInfo.qFallbackTitle)
+            .reduce((max, qFallbackTitle) => Math.max(max, measureText(qFallbackTitle)), 0);
 
           tmpRatios.push(pseudoDimensionWidth / rect.width);
 

--- a/src/hooks/use-data-model.ts
+++ b/src/hooks/use-data-model.ts
@@ -91,6 +91,10 @@ export default function useDataModel(layout: EngineAPI.IGenericHyperCubeLayout, 
     return false;
   }, [qDimInfo, layout.qHyperCube.qNoOfLeftDims]);
 
+  const getDimensionInfo = useNebulaCallback(() => qDimInfo, [qDimInfo]);
+
+  const getMeasureInfo = useNebulaCallback(() => layout.qHyperCube.qMeasureInfo, [layout]);
+
   const dataModel = useMemo<DataModel>(() => ({
     fetchNextPage,
     hasMoreColumns,
@@ -101,7 +105,9 @@ export default function useDataModel(layout: EngineAPI.IGenericHyperCubeLayout, 
     expandTop,
     pivotData,
     hasData: pivotData !== NOOP_PIVOT_DATA,
-    isDimensionLocked
+    isDimensionLocked,
+    getDimensionInfo,
+    getMeasureInfo,
   }),[fetchNextPage,
     hasMoreColumns,
     hasMoreRows,
@@ -110,7 +116,9 @@ export default function useDataModel(layout: EngineAPI.IGenericHyperCubeLayout, 
     expandLeft,
     expandTop,
     pivotData,
-    isDimensionLocked
+    isDimensionLocked,
+    getDimensionInfo,
+    getMeasureInfo,
   ]);
 
   return dataModel;

--- a/src/hooks/use-measure-text.ts
+++ b/src/hooks/use-measure-text.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef } from 'react';
 
-interface MeasureTextHook {
+export interface MeasureTextHook {
   estimateWidth: (length: number) => number;
   measureText: (text: string) => number;
 }

--- a/src/hooks/use-measure-text.ts
+++ b/src/hooks/use-measure-text.ts
@@ -1,0 +1,40 @@
+import { useCallback, useMemo, useRef } from 'react';
+
+interface MeasureTextHook {
+  estimateWidth: (length: number) => number;
+  measureText: (text: string) => number;
+}
+
+const MAGIC_DEFAULT_CHAR = 'M';
+
+const LEEWAY_WIDTH = 25; // Used to make sure there is some leeway in the measurement of a text
+
+export default function useMeasureText(fontSize: string, fontFamily: string): MeasureTextHook {
+  const context = useRef<CanvasRenderingContext2D | null>(null);
+
+  useMemo(() => {
+    if (context.current === null) {
+      context.current = document.createElement('canvas').getContext('2d');
+    }
+  }, [context.current]);
+
+  useMemo(() => {
+    if (context.current === null) return;
+
+    context.current.font = `${fontSize} ${fontFamily}`;
+  }, [context.current, fontSize, fontFamily]);
+
+  const estimateWidth = useCallback((length: number) => {
+    if (context.current === null) return 0;
+
+    return Math.max(context.current.measureText(MAGIC_DEFAULT_CHAR).width * length, 100);
+  }, [context.current]);
+
+  const measureText = useCallback((text: string) => {
+    if (context.current === null) return 0;
+
+    return context.current.measureText(text).width + LEEWAY_WIDTH;
+  }, [context.current]);
+
+  return { estimateWidth, measureText };
+}

--- a/src/pivot-table/components/DataGrid.tsx
+++ b/src/pivot-table/components/DataGrid.tsx
@@ -7,7 +7,7 @@ import DataCell from './DataCell';
 interface DataGridProps {
   dataModel: DataModel;
   dataGridRef: React.RefObject<VariableSizeGrid>;
-  columnWidthCallback: () => number;
+  columnWidthCallback: (index: number) => number;
   height: number;
   rowHightCallback: () => number;
   width: number;

--- a/src/pivot-table/components/HeaderGrid.tsx
+++ b/src/pivot-table/components/HeaderGrid.tsx
@@ -7,7 +7,7 @@ import { gridBorderStyle } from './shared-styles';
 
 interface HeaderGridProps {
   dataModel: DataModel;
-  columnWidthCallback: () => number;
+  columnWidthCallback: (index: number) => number;
   height: number;
   rowHightCallback: () => number;
   width: number;

--- a/src/pivot-table/components/LeftGrid.tsx
+++ b/src/pivot-table/components/LeftGrid.tsx
@@ -9,7 +9,7 @@ import { gridBorderStyle } from './shared-styles';
 interface LeftGridProps {
   dataModel: DataModel;
   leftGridRef: React.RefObject<VariableSizeGrid>;
-  columnWidthCallback: () => number;
+  columnWidthCallback: (index: number) => number;
   rowHightCallback: () => number;
   width: number;
   height: number;

--- a/src/pivot-table/components/PivotTable.tsx
+++ b/src/pivot-table/components/PivotTable.tsx
@@ -1,5 +1,5 @@
 import { stardust } from '@nebula.js/stardust';
-import React, { useRef, useCallback } from 'react';
+import React, { useRef } from 'react';
 import { VariableSizeGrid } from 'react-window';
 import { DataModel, Rect } from '../../types/types';
 // import useDebug from '../../hooks/use-debug';
@@ -10,6 +10,7 @@ import HeaderGrid from './HeaderGrid';
 import TopGrid from './TopGrid';
 import LeftGrid from './LeftGrid';
 import DataGrid from './DataGrid';
+import useColumnWidth from '../../hooks/use-column-width';
 
 export interface PivotTableProps {
   rect: Rect;
@@ -17,11 +18,7 @@ export interface PivotTableProps {
   dataModel: DataModel;
 }
 
-const MIN_COLUMN_WIDTH = 100;
-
 const DEFAULT_ROW_HEIGHT = 28;
-
-const getColumnWidth = (rect: Rect, columnCount: number) => Math.max(MIN_COLUMN_WIDTH, rect.width / columnCount);
 
 const rowHightCallback = () => DEFAULT_ROW_HEIGHT;
 
@@ -33,6 +30,13 @@ export const StickyPivotTable = ({
   const topGridRef = useRef<VariableSizeGrid>(null);
   const leftGridRef = useRef<VariableSizeGrid>(null);
   const dataGridRef = useRef<VariableSizeGrid>(null);
+  const {
+    leftGridWidth,
+    rightGridWidth,
+    getDataColumnWidth,
+    getLeftColumnWidth,
+    getTotalWidth,
+  } = useColumnWidth(dataModel, rect);
   const { size } = dataModel.pivotData;
 
   const onScroll = (event: React.SyntheticEvent) => {
@@ -49,20 +53,10 @@ export const StickyPivotTable = ({
     }
   };
 
-  const columnWidth = getColumnWidth(rect, size.totalColumns);
-
-  const columnWidthCallback = useCallback(() => columnWidth, [columnWidth]);
-
   // useDebug('PivotTable', {
   //   rect,
   //   dataModel,
-  //   columnWidth,
   // });
-
-  const leftGridWidth = columnWidth * size.left.x;
-  const headerGridWidth = columnWidth * size.headers.x;
-  const topGridWidth = rect.width - leftGridWidth;
-  const dataGridWidth = rect.width - leftGridWidth;
 
   const headerGridHeight = DEFAULT_ROW_HEIGHT * size.headers.y;
   const leftGridHeight = rect.height - headerGridHeight;
@@ -71,19 +65,19 @@ export const StickyPivotTable = ({
 
   return (
     <ScrollableContainer rect={rect} onScroll={onScroll} constraints={constraints} >
-      <FullSizeContainer width={columnWidth * size.totalColumns} height={DEFAULT_ROW_HEIGHT * size.totalRows}>
+      <FullSizeContainer width={getTotalWidth()} height={DEFAULT_ROW_HEIGHT * size.totalRows}>
         <StickyContainer
           rect={rect}
-          leftColumnsWidth={columnWidth * size.left.x}
-          rightColumnsWidth={columnWidth * size.data.x}
+          leftColumnsWidth={leftGridWidth}
+          rightColumnsWidth={rightGridWidth}
           topRowsHeight={DEFAULT_ROW_HEIGHT * size.top.y}
           bottomRowsHeight={DEFAULT_ROW_HEIGHT * size.data.y}
         >
           <HeaderGrid
             dataModel={dataModel}
-            columnWidthCallback={columnWidthCallback}
+            columnWidthCallback={getLeftColumnWidth}
             rowHightCallback={rowHightCallback}
-            width={headerGridWidth}
+            width={leftGridWidth}
             height={headerGridHeight}
           />
 
@@ -91,9 +85,9 @@ export const StickyPivotTable = ({
             dataModel={dataModel}
             constraints={constraints}
             topGridRef={topGridRef}
-            columnWidthCallback={columnWidthCallback}
+            columnWidthCallback={getDataColumnWidth}
             rowHightCallback={rowHightCallback}
-            width={topGridWidth}
+            width={rightGridWidth}
             height={topGridHeight}
           />
 
@@ -101,7 +95,7 @@ export const StickyPivotTable = ({
             dataModel={dataModel}
             constraints={constraints}
             leftGridRef={leftGridRef}
-            columnWidthCallback={columnWidthCallback}
+            columnWidthCallback={getLeftColumnWidth}
             rowHightCallback={rowHightCallback}
             width={leftGridWidth}
             height={leftGridHeight}
@@ -110,9 +104,9 @@ export const StickyPivotTable = ({
           <DataGrid
             dataModel={dataModel}
             dataGridRef={dataGridRef}
-            columnWidthCallback={columnWidthCallback}
+            columnWidthCallback={getDataColumnWidth}
             rowHightCallback={rowHightCallback}
-            width={dataGridWidth}
+            width={rightGridWidth}
             height={dataGridHeight}
           />
         </StickyContainer>

--- a/src/pivot-table/components/TopGrid.tsx
+++ b/src/pivot-table/components/TopGrid.tsx
@@ -9,7 +9,7 @@ import { gridBorderStyle } from './shared-styles';
 interface TopGridProps {
   dataModel: DataModel;
   topGridRef: React.RefObject<VariableSizeGrid>;
-  columnWidthCallback: () => number;
+  columnWidthCallback: (index: number) => number;
   rowHightCallback: () => number;
   width: number;
   height: number;

--- a/src/pivot-table/components/__tests__/CellFactory.test.tsx
+++ b/src/pivot-table/components/__tests__/CellFactory.test.tsx
@@ -61,6 +61,8 @@ describe('CellFactory', () => {
       expandTop: () => {},
       hasData: true,
       isDimensionLocked: () => false,
+      getDimensionInfo: () => [],
+      getMeasureInfo: () => [],
     };
 
     data = {

--- a/src/pivot-table/components/__tests__/DimensionCell.test.tsx
+++ b/src/pivot-table/components/__tests__/DimensionCell.test.tsx
@@ -87,6 +87,8 @@ describe('DimensionCell', () => {
       expandTop: () => {},
       hasData: true,
       isDimensionLocked: () => false,
+      getDimensionInfo: () => [],
+      getMeasureInfo: () => [],
     };
 
     expandLeftSpy = jest.spyOn(dataModel, 'expandLeft');

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -25,6 +25,8 @@ export interface DataModel {
   expandTop: ExpandOrCollapser;
   hasData: boolean;
   isDimensionLocked: (qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => boolean;
+  getDimensionInfo: () => EngineAPI.INxDimensionInfo[];
+  getMeasureInfo: () => EngineAPI.INxMeasureInfo[];
 }
 
 export interface ItemData {


### PR DESCRIPTION
Adds a sizing logic to columns. Where those dimension column on the left is based of approach glyph count, the data column are either based on glyph count, approx. title width, min width or size available.

![Screenshot 2022-02-23 at 09 41 32](https://user-images.githubusercontent.com/16608020/155286069-5e55b15d-0e0f-448a-a51c-4dd4b9db2900.png)
