### PR TITLE
feat: show totals above or below

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,5 @@
 export const Q_PATH = '/qHyperCubeDef';
 
 export const DEFAULT_PAGE_SIZE = 50;
+
+export const TOTALS_CELL = -1;

--- a/src/pivot-table/components/CellFactory.tsx
+++ b/src/pivot-table/components/CellFactory.tsx
@@ -6,6 +6,8 @@ import EmptyHeaderCell from './EmptyHeaderCell';
 import EmptyCell from './EmptyCell';
 import NxDimCellType from '../../types/QIX';
 import PseudoDimensionCell from './PseudoDimensionCell';
+import TotalsCell from './TotalsCell';
+import { TOTALS_CELL } from '../../constants';
 // import useDebug from '../../hooks/use-debug';
 
 interface GridCallbackProps {
@@ -31,6 +33,10 @@ const CellFactory = ({ columnIndex, rowIndex, style, data }: GridCallbackProps):
         style={style}
         isLeftColumn={isLeftColumn}
       />;
+    }
+
+    if (cell.qType === NxDimCellType.NX_DIM_CELL_TOTAL && cell.qElemNo === TOTALS_CELL) {
+      return <TotalsCell style={style} />;
     }
 
     return <DimensionCell

--- a/src/pivot-table/components/TotalsCell.tsx
+++ b/src/pivot-table/components/TotalsCell.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { borderStyle, textStyle } from './shared-styles';
+
+interface LabelCellProps {
+  style: React.CSSProperties;
+}
+
+const labelTextStyle: React.CSSProperties = {
+  ...textStyle,
+  fontWeight: 'bold'
+};
+
+export const testId = 'totals-cell';
+
+export const label = 'Totals'; // TODO translate
+
+const TotalsCell = ({ style }: LabelCellProps): JSX.Element => (
+  <div style={{ ...style, ...borderStyle }} data-testid={testId}>
+    <div style={labelTextStyle}>{label}</div>
+  </div>
+);
+
+export default TotalsCell;

--- a/src/pivot-table/components/__tests__/CellFactory.test.tsx
+++ b/src/pivot-table/components/__tests__/CellFactory.test.tsx
@@ -8,6 +8,7 @@ import DimensionTitleCell from '../DimensionTitleCell';
 import EmptyHeaderCell from '../EmptyHeaderCell';
 import EmptyCell from '../EmptyCell';
 import PseudoDimensionCell from '../PseudoDimensionCell';
+import TotalsCell from '../TotalsCell';
 import NxDimCellType from '../../../types/QIX';
 
 jest.mock('../DimensionCell');
@@ -15,6 +16,7 @@ jest.mock('../DimensionTitleCell');
 jest.mock('../EmptyHeaderCell');
 jest.mock('../EmptyCell');
 jest.mock('../PseudoDimensionCell');
+jest.mock('../TotalsCell');
 
 describe('CellFactory', () => {
   const style: React.CSSProperties = {
@@ -119,6 +121,18 @@ describe('CellFactory', () => {
     render(<CellFactory columnIndex={0} rowIndex={0} style={style} data={data} />);
 
     expect(mockPseudoDimensionCell).toHaveBeenCalledWith({ style, cell, isLeftColumn: false }, {});
+  });
+
+  test('should render totals cell', () => {
+    const mockedTotalsCell = TotalsCell as jest.MockedFunction<typeof TotalsCell>;
+    mockedTotalsCell.mockReturnValue(<div />);
+    cell = { qText, qType: NxDimCellType.NX_DIM_CELL_TOTAL, qElemNo: -1 } as EngineAPI.INxPivotDimensionCell;
+    data.matrix[0][0] = cell;
+    data.isLeftColumn = false;
+
+    render(<CellFactory columnIndex={0} rowIndex={0} style={style} data={data} />);
+
+    expect(mockedTotalsCell).toHaveBeenCalledWith({ style }, {});
   });
 
   test('should render empty header cell', () => {

--- a/src/pivot-table/components/__tests__/TotalsCell.test.tsx
+++ b/src/pivot-table/components/__tests__/TotalsCell.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TotalsCell, { label, testId } from '../TotalsCell';
+
+test('should render',  () => {
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    left: '25px',
+    top: '35px',
+    width: '100px',
+    height: '150px'
+  };
+
+  render(<TotalsCell style={style} />);
+
+  expect(screen.getByText(label)).toBeInTheDocument();
+  expect(screen.getByTestId(testId)).toHaveStyle(style as Record<string, unknown>);
+});

--- a/src/pivot-table/components/shared-styles.ts
+++ b/src/pivot-table/components/shared-styles.ts
@@ -15,6 +15,7 @@ const textStyle: React.CSSProperties = {
   textOverflow: 'ellipsis',
   overflow: 'hidden',
   whiteSpace: 'nowrap',
+  color: '#595959'
 };
 
 const gridBorderStyle: React.CSSProperties = {


### PR DESCRIPTION
Adds support for displaying totals value either below or above using the `qShowTotalsAbove` toggle and `qTotalMode = "TOTAL_EXPR"`

![Screenshot 2022-02-28 at 10 47 54](https://user-images.githubusercontent.com/16608020/155961566-4814ba95-4f5f-4d7f-8269-dc6003135329.png)
