### PR TITLE
chore: enable sys js build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/project
   docker:
-    - image: cimg/node:16.18.1
+    - image: cimg/node:lts
 
 aliases:
   - &restore_yarn_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,8 @@ jobs:
     <<: *defaults
     docker:
       - image: mcr.microsoft.com/playwright:focal
+    environment:
+      NODE_ENV: development
     steps:
       - attach_workspace:
           at: ~/project

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sn-pivot-table-ext"
   ],
   "engines": {
-    "node": "^16"
+    "node": ">=16"
   },
   "main": "dist/sn-pivot-table.js",
   "systemjs": "dist/sn-pivot-table.systemjs.js",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "sn-pivot-table-ext"
   ],
   "engines": {
-    "node": "^16"
+    "node": "^18"
   },
   "main": "dist/sn-pivot-table.js",
+  "systemjs": "dist/sn-pivot-table.systemjs.js",
   "scripts": {
     "build": "node ./scripts/build.js --core --ext",
     "build:dev": "node ./scripts/build.js --core --mode development",
@@ -36,6 +37,7 @@
     "copy:ext": "node ./scripts/copy-ext.js",
     "lint": "eslint src/",
     "start": "nebula serve  --type sn-pivot-table",
+    "start:mfe": "nebula serve --mfe  --type sn-pivot-table",
     "sense": "nebula sense",
     "types:check": "tsc --noEmit",
     "test:unit": "jest --runInBand",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sn-pivot-table-ext"
   ],
   "engines": {
-    "node": "^18"
+    "node": "^16"
   },
   "main": "dist/sn-pivot-table.js",
   "systemjs": "dist/sn-pivot-table.systemjs.js",


### PR DESCRIPTION
Some trouble with Node versions, so had to fiddle a bit. Seems like playwright installs v16 and the new Nebula serve version needs 18. So I set it to >=16 for now.