### PR TITLE
fix: replace anti-pattern usuage of `useMemo` with `useOnPropsChange`

### DIFF
--- a/src/pivot-table/hooks/use-data.ts
+++ b/src/pivot-table/hooks/use-data.ts
@@ -5,6 +5,7 @@ import createHeadersData from "../data/headers-data";
 import { addPageToLeftDimensionData, createLeftDimensionData } from "../data/left-dimension-data";
 import { addPageToMeasureData, createMeasureData } from "../data/measure-data";
 import { addPageToTopDimensionData, createTopDimensionData } from "../data/top-dimension-data";
+import useOnPropsChange from "./use-on-props-change";
 
 const useData = (
   qPivotDataPages: EngineAPI.INxPivotPage[],
@@ -38,26 +39,26 @@ const useData = (
     deriveLeftDimensionDataFromProps()
   );
 
-  useMemo(() => {
+  useOnPropsChange(() => {
     setMeasureData(deriveMeasureDataFromProps());
   }, [deriveMeasureDataFromProps]);
 
-  useMemo(() => {
+  useOnPropsChange(() => {
     setTopDimensionData(deriveTopDimensionDataFromProps());
   }, [deriveTopDimensionDataFromProps]);
 
-  useMemo(() => {
+  useOnPropsChange(() => {
     setLeftDimensionData(deriveLeftDimensionDataFromProps());
   }, [deriveLeftDimensionDataFromProps]);
 
-  useMemo(() => {
+  useOnPropsChange(() => {
     if (!nextPage) return;
     setMeasureData((prev) => addPageToMeasureData(prev, nextPage));
     setTopDimensionData((prev) => addPageToTopDimensionData(prev, nextPage));
     setLeftDimensionData((prev) => addPageToLeftDimensionData(prev, nextPage));
   }, [nextPage]);
 
-  useMemo(() => {
+  useOnPropsChange(() => {
     if (!moreDataPage) return;
     setMeasureData((prev) => addPageToMeasureData(prev, moreDataPage));
   }, [moreDataPage]);

--- a/src/pivot-table/hooks/use-on-props-change.ts
+++ b/src/pivot-table/hooks/use-on-props-change.ts
@@ -1,0 +1,12 @@
+import { useState } from "react";
+
+// Act as a wrapper for https://beta.reactjs.org/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+export default function useOnPropsChange<T>(callback: () => void, props: T[]) {
+  const [prev, setPrev] = useState<T[]>(props);
+  const hasChanged = prev.some((prevProp, index) => prevProp !== props[index]);
+
+  if (hasChanged) {
+    setPrev(props);
+    callback();
+  }
+}


### PR DESCRIPTION
replacing direct useMemo usage in component body with a new hook hijacked from sn-table called `useOnPropsChange`