### PR TITLE
fix: extract memoized component out of functional components

### DIFF
--- a/src/pivot-table/components/cells/DataCell.tsx
+++ b/src/pivot-table/components/cells/DataCell.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { areEqual } from "react-window";
 import NxDimCellType from "../../../types/QIX";
 import { GridItemData } from "../../../types/types";
 import { useStyleContext } from "../../contexts/StyleProvider";
@@ -63,4 +64,4 @@ const MeasureCell = ({ columnIndex, rowIndex, style, data }: MeasureCellProps): 
   );
 };
 
-export default MeasureCell;
+export default React.memo(MeasureCell, areEqual);

--- a/src/pivot-table/components/cells/ListCellFactory.tsx
+++ b/src/pivot-table/components/cells/ListCellFactory.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { areEqual } from "react-window";
 import { TOTALS_CELL } from "../../../constants";
 import NxDimCellType from "../../../types/QIX";
 import { ListItemData } from "../../../types/types";
@@ -43,4 +44,4 @@ const ListCellFactory = ({ index, style, data }: ListCallbackProps): JSX.Element
   );
 };
 
-export default ListCellFactory;
+export default React.memo(ListCellFactory, areEqual);

--- a/src/pivot-table/components/grids/DataGrid.tsx
+++ b/src/pivot-table/components/grids/DataGrid.tsx
@@ -1,9 +1,9 @@
 /*  eslint-disable no-param-reassign */
 import { debouncer } from "qlik-chart-modules";
 import React, { memo, useCallback, useLayoutEffect, useMemo } from "react";
-import { GridOnItemsRenderedProps, VariableSizeGrid, areEqual } from "react-window";
+import { GridOnItemsRenderedProps, VariableSizeGrid } from "react-window";
 import { DataModel, GridItemData, LayoutService, MeasureData, ViewService } from "../../../types/types";
-import DataCell from "../cells/DataCell";
+import MemoizedDataCell from "../cells/DataCell";
 // import useDebug from '../../hooks/use-debug';
 
 interface DataGridProps {
@@ -101,8 +101,6 @@ const DataGrid = ({
   hasMoreRows,
   hasMoreColumns,
 }: DataGridProps): JSX.Element | null => {
-  const MemoizedDataCell = memo(DataCell, areEqual);
-
   useLayoutEffect(() => {
     if (dataGridRef.current) {
       dataGridRef.current.resetAfterColumnIndex(0); // Needs to be re-computed every time the data changes

--- a/src/pivot-table/components/grids/HeaderGrid.tsx
+++ b/src/pivot-table/components/grids/HeaderGrid.tsx
@@ -30,7 +30,7 @@ const gridStyle: React.CSSProperties = {
   ...gridBorderStyle,
 };
 
-const HeaderCellFactory = ({ columnIndex, rowIndex, style, data }: GridCallbackProps): JSX.Element | null => {
+const MemoizedCellFactory = memo(({ columnIndex, rowIndex, style, data }: GridCallbackProps): JSX.Element | null => {
   const cell = data.matrix[columnIndex][rowIndex];
 
   if (typeof cell === "string") {
@@ -38,7 +38,7 @@ const HeaderCellFactory = ({ columnIndex, rowIndex, style, data }: GridCallbackP
   }
 
   return null;
-};
+}, areEqual);
 
 const HeaderGrid = ({
   columnWidthCallback,
@@ -48,7 +48,6 @@ const HeaderGrid = ({
   headersData,
 }: HeaderGridProps): JSX.Element | null => {
   const headerGridRef = useRef<VariableSizeGrid>(null);
-  const MemoizedCellFactory = memo(HeaderCellFactory, areEqual);
 
   useLayoutEffect(() => {
     if (headerGridRef.current) {

--- a/src/pivot-table/components/grids/LeftGrid.tsx
+++ b/src/pivot-table/components/grids/LeftGrid.tsx
@@ -1,9 +1,9 @@
 import { stardust } from "@nebula.js/stardust";
 import React, { memo, useLayoutEffect } from "react";
-import { VariableSizeList, areEqual } from "react-window";
+import { VariableSizeList } from "react-window";
 import { PSEUDO_DIMENSION_INDEX } from "../../../constants";
 import { Cell, DataModel, LayoutService, LeftDimensionData } from "../../../types/types";
-import ListCellFactory from "../cells/ListCellFactory";
+import MemoizedListCellFactory from "../cells/ListCellFactory";
 import getItemKey from "../helpers/get-item-key";
 import setListRef from "../helpers/set-list-ref";
 // import useDebug from '../../hooks/use-debug';
@@ -58,8 +58,6 @@ const LeftGrid = ({
   layoutService,
   leftDimensionData,
 }: LeftGridProps): JSX.Element | null => {
-  const MemoizedListCellFactory = memo(ListCellFactory, areEqual);
-
   const { qDimensionInfo } = layoutService.layout.qHyperCube;
 
   useLayoutEffect(() => {

--- a/src/pivot-table/components/grids/TopGrid.tsx
+++ b/src/pivot-table/components/grids/TopGrid.tsx
@@ -1,9 +1,9 @@
 import { stardust } from "@nebula.js/stardust";
 import React, { memo, useLayoutEffect, useMemo } from "react";
-import { VariableSizeList, areEqual } from "react-window";
+import { VariableSizeList } from "react-window";
 import { PSEUDO_DIMENSION_INDEX } from "../../../constants";
 import { Cell, DataModel, LayoutService, TopDimensionData } from "../../../types/types";
-import ListCellFactory from "../cells/ListCellFactory";
+import MemoizedListCellFactory from "../cells/ListCellFactory";
 import getItemKey from "../helpers/get-item-key";
 import setListRef from "../helpers/set-list-ref";
 import { gridBorderStyle } from "../shared-styles";
@@ -42,8 +42,6 @@ const TopGrid = ({
   layoutService,
   topDimensionData,
 }: TopGridProps): JSX.Element | null => {
-  const MemoizedListCellFactory = memo(ListCellFactory, areEqual);
-
   const { qMeasureInfo, qDimensionInfo } = layoutService.layout.qHyperCube;
 
   useLayoutEffect(() => {


### PR DESCRIPTION
The usage of `memo()` inside of our grid components like this one for example: https://github.com/qlik-oss/sn-pivot-table/blob/main/src/pivot-table/components/grids/DataGrid.tsx#L104

is not taking effect and my guess is that in each rerender of grids it’s being recreated because it’s just a variable inside of component which does not memoised using `useMemo`  => then react probably ignoring to memoise it and creates a memo component in every rerender

This PR aims to fix it!