### PR TITLE
feat: line clamp for header cell

### DIFF
--- a/src/pivot-table/components/cells/DimensionCell.tsx
+++ b/src/pivot-table/components/cells/DimensionCell.tsx
@@ -44,11 +44,20 @@ const stickyCell: React.CSSProperties = {
   top: 4,
 };
 
-const dimTextStyle: React.CSSProperties = {
+const getDimTextStyle = (isLeftColumn: boolean, clampCount: number): React.CSSProperties => ({
   ...textStyle,
+  whiteSpace: "unset",
   fontWeight: "bold",
   marginLeft: 4,
-};
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  display: "-webkit-box",
+  ...(!isLeftColumn && {
+    lineClamp: clampCount,
+    WebkitLineClamp: clampCount,
+    WebkitBoxOrient: "vertical",
+  }),
+});
 
 const nullStyle: React.CSSProperties = {
   backgroundColor: "#f2f2f2",
@@ -180,7 +189,7 @@ const DimensionCell = ({ cell, rowIndex, colIndex, style, isLeftColumn, data }: 
     >
       <div style={{ ...cellStyle, ...stickyCell, alignSelf: isLeftColumn ? "flex-start" : "flex-end" }}>
         {cellIcon}
-        <span style={{ ...dimTextStyle, ...serviceStyle }}>{text}</span>
+        <span style={{ ...getDimTextStyle(isLeftColumn, styleService.lineClamp), ...serviceStyle }}>{text}</span>
       </div>
     </div>
   );

--- a/src/pivot-table/contexts/StyleProvider.tsx
+++ b/src/pivot-table/contexts/StyleProvider.tsx
@@ -20,9 +20,10 @@ const StyleProvider = ({ children, styleService, layoutService }: StyleProviderP
     [layoutService.layout.components]
   );
 
-  const memoisedProps = useMemo(() => {
-    const cellHeight = DEFAULT_ROW_HEIGHT * (rowHeight?.linesCount || 1);
-    return { ...styleService, cellHeight };
+  const memoisedProps: StyleService = useMemo(() => {
+    const lineClamp = rowHeight?.linesCount || 1;
+    const cellHeight = DEFAULT_ROW_HEIGHT * lineClamp;
+    return { ...styleService, cellHeight, lineClamp };
   }, [styleService, rowHeight?.linesCount]);
 
   return <StyleContext.Provider value={memoisedProps}>{children}</StyleContext.Provider>;

--- a/src/pivot-table/contexts/__tests__/StyleProvider.test.tsx
+++ b/src/pivot-table/contexts/__tests__/StyleProvider.test.tsx
@@ -5,11 +5,12 @@ import { DEFAULT_ROW_HEIGHT } from "../../constants";
 import StyleProvider, { useStyleContext } from "../StyleProvider";
 
 const DummyTestComponent = () => {
-  const { cellHeight } = useStyleContext();
+  const { cellHeight, lineClamp } = useStyleContext();
 
   return (
     <div>
       <p data-testid="cell-height">{cellHeight}</p>
+      <p data-testid="line-clamp">{lineClamp}</p>
     </div>
   );
 };
@@ -34,12 +35,13 @@ describe("StyleProvider", () => {
       } as LayoutService;
     });
 
-    test("should return default cell height", () => {
+    test("should return default values", () => {
       const { getByTestId } = renderer();
       expect(getByTestId("cell-height").textContent).toEqual(`${DEFAULT_ROW_HEIGHT}`);
+      expect(getByTestId("line-clamp").textContent).toEqual("1");
     });
 
-    test("should return correct cell height for 'n' lines", () => {
+    test("should return calculated values for 'n' lines", () => {
       const n = 2;
       layoutService = {
         layout: {
@@ -49,6 +51,7 @@ describe("StyleProvider", () => {
 
       const { getByTestId } = renderer();
       expect(getByTestId("cell-height").textContent).toEqual(`${n * DEFAULT_ROW_HEIGHT}`);
+      expect(getByTestId("line-clamp").textContent).toEqual(`${n}`);
     });
   });
 });

--- a/src/services/style-service.ts
+++ b/src/services/style-service.ts
@@ -23,6 +23,7 @@ const createStyleService = (theme: stardust.Theme): StyleService => {
     content: {},
     backgroundColor: DEFAULT_BACKGROUND_COLOR,
     cellHeight: DEFAULT_ROW_HEIGHT,
+    lineClamp: 1,
   };
 
   THEME_STYLES.forEach(({ basePath, path, attribute, defaultValue }) => {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -148,6 +148,7 @@ export interface StyleService {
   content: StyleProperties;
   backgroundColor: string;
   cellHeight: number;
+  lineClamp: number;
 }
 
 export interface Galaxy {


### PR DESCRIPTION
This PR fixes Line clamp for header cells, basically the idea is to tie row height we get from styling panel to the lines we show in header (dim) cells. 

Below is a quick demo of what will happen: 

https://user-images.githubusercontent.com/29652890/233600222-d71049bc-5795-4381-88be-10a2b46ddf83.mov

