### PR TITLE
fix: expand or collapse data fetch

### DIFF
--- a/src/hooks/use-load-data-pages.ts
+++ b/src/hooks/use-load-data-pages.ts
@@ -9,75 +9,6 @@ interface UseLoadDataPages {
   qPivotDataPages: EngineAPI.INxPivotPage[];
 }
 
-const MAX_GRID_SIZE = 10000;
-
-const safeGuardGridSize = (viewService: ViewService): boolean => {
-  const { gridWidth, gridHeight } = viewService;
-  if (!gridWidth) return true;
-  if (!gridHeight) return true;
-  if (gridWidth < 0) return true;
-  if (gridHeight < 0) return true;
-  return false;
-};
-
-const getPagesToTheTop = (viewService: ViewService, maxHeight: number): EngineAPI.IRect[] => {
-  const { gridColumnStartIndex, gridRowStartIndex, gridWidth, gridHeight } = viewService;
-  const pages = [] as EngineAPI.IRect[];
-
-  if (safeGuardGridSize(viewService)) {
-    // handle zero size and when viewService has not yet been initialized
-    return pages;
-  }
-
-  const totalHeight = Math.min(gridRowStartIndex + gridHeight * 2, maxHeight);
-  const batchSize = Math.floor(MAX_GRID_SIZE / gridWidth);
-  let batchTop = Math.max(0, totalHeight - batchSize);
-  let batchHeight = totalHeight - batchTop;
-
-  do {
-    pages.unshift({
-      qLeft: gridColumnStartIndex,
-      qTop: Math.max(0, batchTop),
-      qWidth: gridWidth,
-      qHeight: batchHeight,
-    });
-
-    batchHeight = Math.min(batchHeight, batchTop);
-    batchTop -= batchSize;
-  } while (pages[0]?.qTop > 0);
-
-  return pages;
-};
-
-const getPagesToTheLeft = (viewService: ViewService, maxWidth: number): EngineAPI.IRect[] => {
-  const { gridColumnStartIndex, gridRowStartIndex, gridWidth, gridHeight } = viewService;
-  const pages = [] as EngineAPI.IRect[];
-
-  if (safeGuardGridSize(viewService)) {
-    // handle zero size and when viewService has not yet been initialized
-    return pages;
-  }
-
-  const totalWidth = Math.min(gridColumnStartIndex + gridWidth * 2, maxWidth);
-  const batchSize = Math.floor(MAX_GRID_SIZE / gridHeight);
-  let batchLeft = Math.max(0, totalWidth - batchSize);
-  let batchWidth = totalWidth - batchLeft;
-
-  do {
-    pages.unshift({
-      qLeft: Math.max(0, batchLeft),
-      qTop: gridRowStartIndex,
-      qWidth: batchWidth,
-      qHeight: gridHeight,
-    });
-
-    batchWidth = Math.min(batchWidth, batchLeft);
-    batchLeft -= batchSize;
-  } while (pages[0]?.qLeft > 0);
-
-  return pages;
-};
-
 const shouldFetchAdditionalData = (
   qLastExpandedPos: EngineAPI.INxCellPosition | undefined,
   viewService: ViewService
@@ -105,10 +36,16 @@ const useLoadDataPages = (model: Model, layoutService: LayoutService, viewServic
     if ((model as EngineAPI.IGenericObject)?.getHyperCubePivotData && !snapshotData) {
       // If a cell have been expanded. Fetch data to the last scrolled position.
       if (shouldFetchAdditionalData(qLastExpandedPos, viewService)) {
-        const pages = [...getPagesToTheLeft(viewService, qSize.qcx), ...getPagesToTheTop(viewService, qSize.qcy)];
-
         try {
-          const pivotPages = await (model as EngineAPI.IGenericObject).getHyperCubePivotData(Q_PATH, pages);
+          const pivotPages = await (model as EngineAPI.IGenericObject).getHyperCubePivotData(Q_PATH, [
+            {
+              qLeft: viewService.gridColumnStartIndex,
+              qTop: viewService.gridRowStartIndex,
+              qWidth: viewService.gridWidth,
+              qHeight: viewService.gridHeight,
+            },
+          ]);
+
           setDataPages(pivotPages);
         } catch (error) {
           // TODO handle error


### PR DESCRIPTION
When a node was expanded or collapsed, all data before it was fetched again so that the scroll position would not be lost. But this would fetch +100 000 rows if a user had scroll to row 100 000 and expanded that node. So not ideal.

This PR removes that code since it is no longer needed after #237 to keep the scroll position. If the user scroll, for example row 100 000 and expand that node. The scroll position is keep there but all those 100k rows above are empty until the user scroll up. At which point the nodes currently rendered on screen are fetched.