### PR TITLE
fix: icon size

### DIFF
--- a/src/pivot-table/components/icons/Minus.tsx
+++ b/src/pivot-table/components/icons/Minus.tsx
@@ -18,6 +18,7 @@ const MinusIcon = ({ color, opacity, testid, onClick }: IconProps): JSX.Element 
     xmlns="http://www.w3.org/2000/svg"
     onClick={onClick}
     data-testid={testid}
+    style={{ minWidth: "fit-content", minHeight: "fit-content" }}
   >
     <path
       opacity={opacity}

--- a/src/pivot-table/components/icons/Plus.tsx
+++ b/src/pivot-table/components/icons/Plus.tsx
@@ -18,6 +18,7 @@ const PlusIcon = ({ color, opacity, testid, onClick }: IconProps): JSX.Element =
     xmlns="http://www.w3.org/2000/svg"
     onClick={onClick}
     data-testid={testid}
+    style={{ minWidth: "fit-content", minHeight: "fit-content" }}
   >
     <path
       opacity={opacity}


### PR DESCRIPTION
Fixes an issue where expand and collapse icons would scale down if the cell had long text.

Before:
![Skärmavbild 2023-04-27 kl  07 53 01](https://user-images.githubusercontent.com/16608020/234779160-b8ae5cb6-c3a1-453f-bbd8-03839603b181.png)


After:
![Skärmavbild 2023-04-27 kl  08 29 52](https://user-images.githubusercontent.com/16608020/234779199-40d63006-0451-4665-b688-514f75d76621.png)
