### PR TITLE
fix: dimension title cell key

### DIFF
--- a/src/pivot-table/components/grids/HeaderGrid.tsx
+++ b/src/pivot-table/components/grids/HeaderGrid.tsx
@@ -1,5 +1,5 @@
 import React, { memo } from "react";
-import type { HeadersData } from "../../../types/types";
+import type { HeaderTitle, HeadersData } from "../../../types/types";
 import DimensionTitleCell from "../cells/DimensionTitleCell";
 
 interface HeaderGridProps {
@@ -20,15 +20,18 @@ const HeaderGrid = ({ columnWidthCallback, rowHight, headersData }: HeaderGridPr
 
   return (
     <div style={containerStyle}>
-      {headersData.data.map((col, colIndex) => (
-        <DimensionTitleCell
-          // eslint-disable-next-line react/no-array-index-key
-          key={`${colIndex}-${col[col.length - 1] as string}`} // TODO Use a better key
-          cell={col[col.length - 1] as string}
-          style={{ width: columnWidthCallback(colIndex), height: rowHight }}
-          isLastColumn={colIndex === headersData.size.x - 1}
-        />
-      ))}
+      {headersData.data.map((col, colIndex) => {
+        const cell = col[col.length - 1] as HeaderTitle;
+
+        return (
+          <DimensionTitleCell
+            key={cell.id}
+            cell={cell.title}
+            style={{ width: columnWidthCallback(colIndex), height: rowHight }}
+            isLastColumn={colIndex === headersData.size.x - 1}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/src/pivot-table/data/__tests__/extract-headers.test.ts
+++ b/src/pivot-table/data/__tests__/extract-headers.test.ts
@@ -1,4 +1,5 @@
 import { PSEUDO_DIMENSION_INDEX } from "../../../constants";
+import type { ExtendedDimensionInfo } from "../../../types/QIX";
 import extractHeaders from "../extract-headers";
 
 function createDimInfo(length: number): EngineAPI.INxDimensionInfo[] {
@@ -14,7 +15,8 @@ describe("extractHeaders", () => {
 
     expect(headers).toHaveLength(1);
     expect(headers[0]).toHaveLength(1);
-    expect(headers[0][0]).toBe("dim 0");
+    expect(headers[0][0]?.title).toBe("dim 0");
+    expect(headers[0][0]?.id).toBe("0-dim 0");
   });
 
   test("should extract headers with row count 1 and column count 2", () => {
@@ -24,8 +26,10 @@ describe("extractHeaders", () => {
 
     expect(headers).toHaveLength(2);
     expect(headers[0]).toHaveLength(1);
-    expect(headers[0][0]).toBe("dim 0");
-    expect(headers[1][0]).toBe("dim 1");
+    expect(headers[0][0]?.title).toBe("dim 0");
+    expect(headers[0][0]?.id).toBe("0-dim 0");
+    expect(headers[1][0]?.title).toBe("dim 1");
+    expect(headers[1][0]?.id).toBe("1-dim 1");
   });
 
   test("should extract headers with row count 1 and column count 2 and a pseudo dimension on first column", () => {
@@ -35,8 +39,10 @@ describe("extractHeaders", () => {
 
     expect(headers).toHaveLength(2);
     expect(headers[0]).toHaveLength(1);
-    expect(headers[0][0]).toBe("");
-    expect(headers[1][0]).toBe("dim 0");
+    expect(headers[0][0]?.title).toBe("");
+    expect(headers[0][0]?.id).toBe("PSEUDO-DIM");
+    expect(headers[1][0]?.title).toBe("dim 0");
+    expect(headers[1][0]?.id).toBe("0-dim 0");
   });
 
   test("should extract headers with row count 1 and column count 2 and a pseudo dimension on last column", () => {
@@ -46,8 +52,10 @@ describe("extractHeaders", () => {
 
     expect(headers).toHaveLength(2);
     expect(headers[0]).toHaveLength(1);
-    expect(headers[0][0]).toBe("dim 0");
-    expect(headers[1][0]).toBe("");
+    expect(headers[0][0]?.title).toBe("dim 0");
+    expect(headers[0][0]?.id).toBe("0-dim 0");
+    expect(headers[1][0]?.title).toBe("");
+    expect(headers[1][0]?.id).toBe("PSEUDO-DIM");
   });
 
   test("should extract headers with row count 2 and column count 1", () => {
@@ -58,7 +66,8 @@ describe("extractHeaders", () => {
     expect(headers).toHaveLength(1);
     expect(headers[0]).toHaveLength(2);
     expect(headers[0][0]).toBe(null);
-    expect(headers[0][1]).toBe("dim 0");
+    expect(headers[0][1]?.title).toBe("dim 0");
+    expect(headers[0][1]?.id).toBe("0-dim 0");
   });
 
   test("should extract headers with row count 2 and column count 2", () => {
@@ -70,7 +79,33 @@ describe("extractHeaders", () => {
     expect(headers[0]).toHaveLength(2);
     expect(headers[0][0]).toBe(null);
     expect(headers[1][0]).toBe(null);
-    expect(headers[0][1]).toBe("dim 0");
-    expect(headers[1][1]).toBe("dim 1");
+    expect(headers[0][1]?.title).toBe("dim 0");
+    expect(headers[0][1]?.id).toBe("0-dim 0");
+    expect(headers[1][1]?.title).toBe("dim 1");
+    expect(headers[1][1]?.id).toBe("1-dim 1");
+  });
+
+  test("should use cId as header title id when available", () => {
+    const dimensionInfoIndex = [0];
+    const dimInfos = createDimInfo(1);
+    (dimInfos[0] as ExtendedDimensionInfo).cId = "1337";
+    const headers = extractHeaders(dimInfos, 1, dimensionInfoIndex);
+
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toHaveLength(1);
+    expect(headers[0][0]?.title).toBe("dim 0");
+    expect(headers[0][0]?.id).toBe("1337");
+  });
+
+  test("should use qLibraryId as header title id when available", () => {
+    const dimensionInfoIndex = [0];
+    const dimInfos = createDimInfo(1);
+    (dimInfos[0] as ExtendedDimensionInfo).qLibraryId = "1337";
+    const headers = extractHeaders(dimInfos, 1, dimensionInfoIndex);
+
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toHaveLength(1);
+    expect(headers[0][0]?.title).toBe("dim 0");
+    expect(headers[0][0]?.id).toBe("1337");
   });
 });

--- a/src/pivot-table/data/__tests__/headers-data.test.ts
+++ b/src/pivot-table/data/__tests__/headers-data.test.ts
@@ -1,3 +1,4 @@
+import type { HeaderTitle } from "../../../types/types";
 import extractHeaders from "../extract-headers";
 import createHeadersData from "../headers-data";
 
@@ -12,7 +13,12 @@ describe("create headers data", () => {
   });
 
   test("should return correct headers data", () => {
-    const headers = [["a", "b"]];
+    const headers = [
+      [
+        { id: "a", title: "a" },
+        { id: "b", title: "b" },
+      ],
+    ];
     mockedExtractHeaders.mockReturnValue(headers);
 
     const headersData = createHeadersData(qHyperCube, 1, [0, 1]);
@@ -23,7 +29,7 @@ describe("create headers data", () => {
   });
 
   test("should handle when there are no headers", () => {
-    const headers = [] as string[][];
+    const headers = [] as HeaderTitle[][];
     mockedExtractHeaders.mockReturnValue(headers);
 
     const headersData = createHeadersData(qHyperCube, 1, [0, 1]);

--- a/src/pivot-table/data/extract-headers.ts
+++ b/src/pivot-table/data/extract-headers.ts
@@ -1,19 +1,23 @@
 import { PSEUDO_DIMENSION_INDEX } from "../../constants";
+import type { ExtendedDimensionInfo } from "../../types/QIX";
+import type { HeaderTitle } from "../../types/types";
 
 const extractHeaders = (
   qDim: EngineAPI.INxDimensionInfo[],
   rowCount: number,
   dimensionInfoIndex: number[]
-): (null | string)[][] => {
-  const matrix: (null | string)[][] = Array(dimensionInfoIndex.length)
+): (null | HeaderTitle)[][] => {
+  const matrix: (null | HeaderTitle)[][] = Array(dimensionInfoIndex.length)
     .fill(null)
     .map(() => Array.from({ length: rowCount }, () => null));
 
   dimensionInfoIndex.forEach((dimIndex, colIdx) => {
     if (dimIndex === PSEUDO_DIMENSION_INDEX) {
-      matrix[colIdx][rowCount - 1] = "";
+      matrix[colIdx][rowCount - 1] = { id: "PSEUDO-DIM", title: "" };
     } else {
-      matrix[colIdx][rowCount - 1] = qDim[dimIndex].qFallbackTitle;
+      const dimInfo = qDim[dimIndex] as ExtendedDimensionInfo;
+      const id: string = dimInfo.cId ?? dimInfo.qLibraryId ?? `${dimIndex}-${dimInfo.qFallbackTitle}`;
+      matrix[colIdx][rowCount - 1] = { id, title: qDim[dimIndex].qFallbackTitle };
     }
   });
 

--- a/src/pivot-table/hooks/__tests__/use-data.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-data.test.ts
@@ -95,7 +95,7 @@ describe("useData", () => {
     } as TopDimensionData;
 
     headersData = {
-      data: [["value"]],
+      data: [[{ id: "value", title: "value" }]],
       size: { x: 3, y: 4 },
     } as HeadersData;
 

--- a/src/types/QIX.ts
+++ b/src/types/QIX.ts
@@ -97,6 +97,11 @@ export interface SnapshotLayout extends EngineAPI.IGenericObjectLayout {
   snapshotData?: SnapshotData;
 }
 
+export interface ExtendedDimensionInfo extends EngineAPI.INxDimensionInfo {
+  cId?: string;
+  qLibraryId?: string;
+}
+
 export type Model = EngineAPI.IGenericObject | EngineAPI.IGenericBookmark | undefined;
 
 export default NxDimCellType;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -11,6 +11,11 @@ export type List = Record<number, Cell>;
 
 export type Grid = List[];
 
+export type HeaderTitle = {
+  id: string;
+  title: string;
+};
+
 export type MeasureData = EngineAPI.INxPivotValuePoint[][];
 
 export interface Rect {
@@ -97,7 +102,7 @@ export interface LeftDimensionData {
 }
 
 export interface HeadersData {
-  data: (null | string)[][];
+  data: (null | HeaderTitle)[][];
   size: Point;
 }
 


### PR DESCRIPTION
Extract the dimenssion title cell key from qDimensionInfo instead of using column index.