### PR TITLE
refactor: fix dupl warnings

### DIFF
--- a/src/pivot-table/components/grids/LeftGrid.tsx
+++ b/src/pivot-table/components/grids/LeftGrid.tsx
@@ -1,12 +1,12 @@
 import type { stardust } from "@nebula.js/stardust";
 import React, { memo, useLayoutEffect } from "react";
 import { VariableSizeList } from "react-window";
-import { PSEUDO_DIMENSION_INDEX } from "../../../constants";
 import type { DataModel, LayoutService, LeftDimensionData, List } from "../../../types/types";
 import { useStyleContext } from "../../contexts/StyleProvider";
 import useOnPropsChange from "../../hooks/use-on-props-change";
 import MemoizedListCellFactory from "../cells/ListCellFactory";
 import getItemKey from "../helpers/get-item-key";
+import getKey from "../helpers/get-key";
 import getListMeta from "../helpers/get-list-meta";
 import setListRef from "../helpers/set-list-ref";
 import { gridBorderStyle } from "../shared-styles";
@@ -80,14 +80,6 @@ const LeftGrid = ({
     }
   }, [getScrollTop, layoutService, leftGridRef]);
 
-  const getKey = (colIndex: number): string => {
-    const dimIndex = leftDimensionData.dimensionInfoIndexMap[colIndex];
-    if (dimIndex === PSEUDO_DIMENSION_INDEX) {
-      return "-1";
-    }
-    return `${qDimensionInfo[dimIndex].qFallbackTitle}-${dimIndex}`;
-  };
-
   const totalHeight = layoutService.size.y * contentCellHeight;
 
   if (leftDimensionData.columnCount === 0) {
@@ -99,10 +91,11 @@ const LeftGrid = ({
       {leftDimensionData.grid.map((list, colIndex) => {
         const isLastColumn = colIndex === leftDimensionData.columnCount - 1;
         const { itemCount, estimatedItemSize } = getListMeta(list, totalHeight, layoutService.size.y, isLastColumn);
+        const key = getKey(leftDimensionData.dimensionInfoIndexMap[colIndex], qDimensionInfo);
 
         return (
           <VariableSizeList
-            key={getKey(colIndex)}
+            key={key}
             ref={setListRef(leftGridRef, colIndex)}
             style={listStyle}
             height={height}

--- a/src/pivot-table/components/grids/TopGrid.tsx
+++ b/src/pivot-table/components/grids/TopGrid.tsx
@@ -1,11 +1,11 @@
 import type { stardust } from "@nebula.js/stardust";
 import React, { memo, useLayoutEffect, useMemo } from "react";
 import { VariableSizeList } from "react-window";
-import { PSEUDO_DIMENSION_INDEX } from "../../../constants";
 import type { DataModel, LayoutService, List, TopDimensionData } from "../../../types/types";
 import useOnPropsChange from "../../hooks/use-on-props-change";
 import MemoizedListCellFactory from "../cells/ListCellFactory";
 import getItemKey from "../helpers/get-item-key";
+import getKey from "../helpers/get-key";
 import getListMeta from "../helpers/get-list-meta";
 import setListRef from "../helpers/set-list-ref";
 import { gridBorderStyle } from "../shared-styles";
@@ -79,14 +79,6 @@ const TopGrid = ({
     return getMeasureInfoWidth(layoutService.getMeasureInfoIndexFromCellIndex(cell?.x ?? colIndex));
   };
 
-  const getKey = (rowIndex: number): string => {
-    const dimIndex = topDimensionData.dimensionInfoIndexMap[rowIndex];
-    if (dimIndex === PSEUDO_DIMENSION_INDEX) {
-      return "-1";
-    }
-    return `${qDimensionInfo[dimIndex].qFallbackTitle}-${dimIndex}`;
-  };
-
   const totalWidth = layoutService.size.x * (allMeasuresWidth / qMeasureInfo.length);
 
   if (topDimensionData.rowCount === 0) {
@@ -99,10 +91,11 @@ const TopGrid = ({
       {topDimensionData.grid.map((list, topRowIndex) => {
         const isLastRow = topRowIndex === topDimensionData.rowCount - 1;
         const { itemCount, estimatedItemSize } = getListMeta(list, totalWidth, layoutService.size.x, isLastRow);
+        const key = getKey(topDimensionData.dimensionInfoIndexMap[topRowIndex], qDimensionInfo);
 
         return (
           <VariableSizeList
-            key={getKey(topRowIndex)}
+            key={key}
             ref={setListRef(topGridRef, topRowIndex)}
             style={listStyle}
             height={rowHightCallback()}

--- a/src/pivot-table/components/helpers/get-key.ts
+++ b/src/pivot-table/components/helpers/get-key.ts
@@ -1,0 +1,6 @@
+import { PSEUDO_DIMENSION_INDEX } from "../../../constants";
+
+const getKey = (dimIndex: number, qDimensionInfo: EngineAPI.INxDimensionInfo[]): string =>
+  dimIndex === PSEUDO_DIMENSION_INDEX ? "-1" : `${qDimensionInfo[dimIndex].qFallbackTitle}-${dimIndex}`;
+
+export default getKey;

--- a/src/pivot-table/hooks/use-selections-model.ts
+++ b/src/pivot-table/hooks/use-selections-model.ts
@@ -40,17 +40,17 @@ export default function useSelectionsModel(selections: ExtendedSelections): Sele
     (qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => {
       switch (qType) {
         case NxSelectionCellType.NX_CELL_LEFT:
-          return !!selected.find((cell) => {
-            if (cell.qType === NxSelectionCellType.NX_CELL_TOP) return true;
-            if (cell.qType === NxSelectionCellType.NX_CELL_LEFT && cell.qCol !== qCol) return true;
-            return false;
-          });
+          return !!selected.find(
+            (cell) =>
+              cell.qType === NxSelectionCellType.NX_CELL_TOP ||
+              (cell.qType === NxSelectionCellType.NX_CELL_LEFT && cell.qCol !== qCol)
+          );
         case NxSelectionCellType.NX_CELL_TOP:
-          return !!selected.find((cell) => {
-            if (cell.qType === NxSelectionCellType.NX_CELL_LEFT) return true;
-            if (cell.qType === NxSelectionCellType.NX_CELL_TOP && cell.qRow !== qRow) return true;
-            return false;
-          });
+          return !!selected.find(
+            (cell) =>
+              cell.qType === NxSelectionCellType.NX_CELL_LEFT ||
+              (cell.qType === NxSelectionCellType.NX_CELL_TOP && cell.qRow !== qRow)
+          );
         default:
           return false;
       }


### PR DESCRIPTION
I took a look at the duplicate warnings on code climate. There is generally a lot of similar code, a lot due to some of the grids having do to the same things, but with different qTop/qLeft x/y row/col stuff. No real easy way of generalizing without making it hard to read.

We could potentially raise the simiilar-code threshold. But I mean it depends on what we want code climate to do. Catch all errors including things we don't want to change, or have a looser check that might miss some things that actually needs refactoring?