### PR TITLE
refactor: item size handler

### DIFF
--- a/src/pivot-table/components/grids/LeftGrid.tsx
+++ b/src/pivot-table/components/grids/LeftGrid.tsx
@@ -1,11 +1,12 @@
 import type { stardust } from "@nebula.js/stardust";
 import React, { memo, useLayoutEffect } from "react";
 import { VariableSizeList } from "react-window";
-import type { DataModel, LayoutService, LeftDimensionData, List } from "../../../types/types";
+import type { DataModel, LayoutService, LeftDimensionData } from "../../../types/types";
 import { useStyleContext } from "../../contexts/StyleProvider";
 import useOnPropsChange from "../../hooks/use-on-props-change";
 import MemoizedListCellFactory from "../cells/ListCellFactory";
 import getItemKey from "../helpers/get-item-key";
+import { getRowHeightHandler } from "../helpers/get-item-size-handler";
 import getKey from "../helpers/get-key";
 import getListMeta from "../helpers/get-list-meta";
 import setListRef from "../helpers/set-list-ref";
@@ -42,20 +43,6 @@ const listStyle: React.CSSProperties = {
    * be fixed in some other way.
    */
   willChange: "auto",
-};
-
-const getItemSizeCallback = (list: List, cellHeight: number, isLast: boolean) => (rowIndex: number) => {
-  const cell = isLast ? list[rowIndex] : Object.values(list)[rowIndex];
-
-  if (rowIndex === 0 && cell?.y > 0) {
-    return (cell.leafCount + cell.y) * cellHeight;
-  }
-
-  if (cell?.leafCount > 0) {
-    return (cell.leafCount + cell.distanceToNextCell) * cellHeight;
-  }
-
-  return cellHeight;
 };
 
 const LeftGrid = ({
@@ -105,7 +92,7 @@ const LeftGrid = ({
             height={height}
             width={getLeftColumnWidth(colIndex)}
             itemCount={itemCount}
-            itemSize={getItemSizeCallback(list, contentCellHeight, isLastColumn)}
+            itemSize={getRowHeightHandler(list, contentCellHeight, isLastColumn)}
             layout="vertical"
             itemData={{
               layoutService,

--- a/src/pivot-table/components/grids/TopGrid.tsx
+++ b/src/pivot-table/components/grids/TopGrid.tsx
@@ -1,10 +1,11 @@
 import type { stardust } from "@nebula.js/stardust";
 import React, { memo, useLayoutEffect, useMemo } from "react";
 import { VariableSizeList } from "react-window";
-import type { DataModel, LayoutService, List, TopDimensionData } from "../../../types/types";
+import type { DataModel, LayoutService, TopDimensionData } from "../../../types/types";
 import useOnPropsChange from "../../hooks/use-on-props-change";
 import MemoizedListCellFactory from "../cells/ListCellFactory";
 import getItemKey from "../helpers/get-item-key";
+import { getColumnWidthHandler } from "../helpers/get-item-size-handler";
 import getKey from "../helpers/get-key";
 import getListMeta from "../helpers/get-list-meta";
 import setListRef from "../helpers/set-list-ref";
@@ -68,21 +69,6 @@ const TopGrid = ({
     [getMeasureInfoWidth, qMeasureInfo]
   );
 
-  const getItemSizeCallback = (list: List, isLast: boolean) => (colIndex: number) => {
-    const cell = isLast ? list[colIndex] : Object.values(list)[colIndex];
-    const measureInfoCount = qMeasureInfo.length;
-
-    if (colIndex === 0 && cell?.x > 0) {
-      return ((cell.leafCount + cell.x) / measureInfoCount) * allMeasuresWidth;
-    }
-
-    if (cell?.leafCount > 0) {
-      return ((cell.leafCount + cell.distanceToNextCell) / measureInfoCount) * allMeasuresWidth;
-    }
-
-    return getMeasureInfoWidth(layoutService.getMeasureInfoIndexFromCellIndex(cell?.x ?? colIndex));
-  };
-
   const totalWidth = layoutService.size.x * (allMeasuresWidth / qMeasureInfo.length);
 
   if (topDimensionData.rowCount === 0) {
@@ -105,7 +91,7 @@ const TopGrid = ({
             height={rowHightCallback()}
             width={width}
             itemCount={itemCount}
-            itemSize={getItemSizeCallback(list, isLastRow)}
+            itemSize={getColumnWidthHandler({ list, isLastRow, layoutService, getMeasureInfoWidth, allMeasuresWidth })}
             layout="horizontal"
             itemData={{
               layoutService,

--- a/src/pivot-table/components/helpers/__tests__/get-item-size-handler.test.ts
+++ b/src/pivot-table/components/helpers/__tests__/get-item-size-handler.test.ts
@@ -1,0 +1,184 @@
+import type { PivotLayout } from "../../../../types/QIX";
+import type { Cell, LayoutService, List } from "../../../../types/types";
+import { getColumnWidthHandler, getRowHeightHandler } from "../get-item-size-handler";
+
+describe("getItemSizeHandler", () => {
+  let list: List;
+
+  beforeEach(() => {
+    list = {};
+  });
+
+  describe("getRowHeightHandler", () => {
+    const cellHeight = 24;
+
+    test("should return a size when cell is undefined", () => {
+      const handler = getRowHeightHandler(list, cellHeight, false);
+
+      expect(handler(0)).toEqual(cellHeight);
+    });
+
+    test("should return a size when cell has leaf nodes", () => {
+      const index = 0;
+      const leafCount = 10;
+      list[index] = {
+        leafCount,
+        distanceToNextCell: 0,
+      } as Cell;
+      const handler = getRowHeightHandler(list, cellHeight, false);
+
+      expect(handler(0)).toEqual(cellHeight * leafCount);
+    });
+
+    test("should return a size when cell has leaf nodes and distanceToNextCell", () => {
+      const index = 0;
+      const leafCount = 10;
+      const distanceToNextCell = 5;
+      list[index] = {
+        leafCount,
+        distanceToNextCell,
+      } as Cell;
+      const handler = getRowHeightHandler(list, cellHeight, false);
+
+      expect(handler(0)).toEqual(cellHeight * (leafCount + distanceToNextCell));
+    });
+
+    test("should return a size for cell when first row does not exist in list", () => {
+      const index = 1;
+      const leafCount = 10;
+      const y = 1;
+      list[index] = {
+        leafCount,
+        y,
+      } as Cell;
+      const handler = getRowHeightHandler(list, cellHeight, false);
+
+      expect(handler(0)).toEqual(cellHeight * (leafCount + y));
+    });
+  });
+
+  describe("getColumnWidthHandler", () => {
+    const allMeasuresWidth = 10;
+    const measureInfoWidth = 33;
+    let layoutService: LayoutService;
+    let layout: PivotLayout;
+    let getMeasureInfoWidth: (index: number) => number;
+
+    beforeEach(() => {
+      layout = {
+        qHyperCube: {
+          qMeasureInfo: [{}, {}],
+        },
+      } as PivotLayout;
+
+      layoutService = {
+        layout,
+        getMeasureInfoIndexFromCellIndex: (idx) => idx,
+      } as LayoutService;
+
+      getMeasureInfoWidth = () => measureInfoWidth;
+    });
+
+    test("should return a size when cell is undefined", () => {
+      list = {};
+
+      const handler = getColumnWidthHandler({
+        list,
+        isLastRow: false,
+        layoutService,
+        getMeasureInfoWidth,
+        allMeasuresWidth,
+      });
+
+      expect(handler(0)).toEqual(measureInfoWidth);
+    });
+
+    test("should return a size when cell has no leaf nodes", () => {
+      const index = 0;
+      list[index] = {
+        leafCount: 0,
+        x: 0,
+      } as Cell;
+
+      const handler = getColumnWidthHandler({
+        list,
+        isLastRow: false,
+        layoutService,
+        getMeasureInfoWidth,
+        allMeasuresWidth,
+      });
+
+      expect(handler(index)).toEqual(measureInfoWidth);
+    });
+
+    test("should return a size when cell has leaf nodes", () => {
+      const index = 0;
+      const leafCount = 10;
+      const distanceToNextCell = 0;
+      list[index] = {
+        leafCount,
+        distanceToNextCell,
+        x: 0,
+      } as Cell;
+
+      const handler = getColumnWidthHandler({
+        list,
+        isLastRow: false,
+        layoutService,
+        getMeasureInfoWidth,
+        allMeasuresWidth,
+      });
+
+      expect(handler(index)).toEqual(
+        allMeasuresWidth * (leafCount / layoutService.layout.qHyperCube.qMeasureInfo.length)
+      );
+    });
+
+    test("should return a size when cell has leaf nodes and distanceToNextCell", () => {
+      const index = 0;
+      const leafCount = 10;
+      const distanceToNextCell = 5;
+      list[index] = {
+        leafCount,
+        distanceToNextCell,
+        x: 0,
+      } as Cell;
+
+      const handler = getColumnWidthHandler({
+        list,
+        isLastRow: false,
+        layoutService,
+        getMeasureInfoWidth,
+        allMeasuresWidth,
+      });
+
+      expect(handler(index)).toEqual(
+        (allMeasuresWidth * (leafCount + distanceToNextCell)) / layoutService.layout.qHyperCube.qMeasureInfo.length
+      );
+    });
+
+    test("should return a size for cell when first column does not exist in list", () => {
+      const index = 0;
+      const leafCount = 10;
+      const distanceToNextCell = 0;
+      const x = 10;
+      list[index] = {
+        leafCount,
+        distanceToNextCell,
+        x,
+      } as Cell;
+
+      const handler = getColumnWidthHandler({
+        list,
+        isLastRow: false,
+        layoutService,
+        getMeasureInfoWidth,
+        allMeasuresWidth,
+      });
+
+      expect(handler(index)).toEqual(
+        (allMeasuresWidth * (leafCount + x)) / layoutService.layout.qHyperCube.qMeasureInfo.length
+      );
+    });
+  });
+});

--- a/src/pivot-table/components/helpers/get-item-size-handler.ts
+++ b/src/pivot-table/components/helpers/get-item-size-handler.ts
@@ -1,0 +1,50 @@
+import type { LayoutService, List } from "../../../types/types";
+
+interface ColumnWidthHandlerProps {
+  list: List;
+  layoutService: LayoutService;
+  isLastRow: boolean;
+  allMeasuresWidth: number;
+  getMeasureInfoWidth: (index: number) => number;
+}
+
+type ItemSizeHandler = (index: number) => number;
+
+export const getRowHeightHandler =
+  (list: List, cellHeight: number, isLast: boolean): ItemSizeHandler =>
+  (rowIndex: number) => {
+    const cell = isLast ? list[rowIndex] : Object.values(list)[rowIndex];
+
+    if (rowIndex === 0 && cell?.y > 0) {
+      return (cell.leafCount + cell.y) * cellHeight;
+    }
+
+    if (cell?.leafCount > 0) {
+      return (cell.leafCount + cell.distanceToNextCell) * cellHeight;
+    }
+
+    return cellHeight;
+  };
+
+export const getColumnWidthHandler =
+  ({
+    list,
+    isLastRow,
+    layoutService,
+    allMeasuresWidth,
+    getMeasureInfoWidth,
+  }: ColumnWidthHandlerProps): ItemSizeHandler =>
+  (colIndex: number) => {
+    const cell = isLastRow ? list[colIndex] : Object.values(list)[colIndex];
+    const measureInfoCount = layoutService.layout.qHyperCube.qMeasureInfo.length;
+
+    if (colIndex === 0 && cell?.x > 0) {
+      return ((cell.leafCount + cell.x) / measureInfoCount) * allMeasuresWidth;
+    }
+
+    if (cell?.leafCount > 0) {
+      return ((cell.leafCount + cell.distanceToNextCell) / measureInfoCount) * allMeasuresWidth;
+    }
+
+    return getMeasureInfoWidth(layoutService.getMeasureInfoIndexFromCellIndex(cell?.x ?? colIndex));
+  };


### PR DESCRIPTION
Moves the functions for handling item size in react-window list compont to a util-file. It allows us to test rather complex logic without running the whole components.