### PR TITLE
fix: data fetch frequency on scroll

### DIFF
--- a/src/pivot-table/components/grids/DataGrid.tsx
+++ b/src/pivot-table/components/grids/DataGrid.tsx
@@ -63,7 +63,7 @@ const isMissingData = (
   return false;
 };
 
-const debouncedFetchMoreData: FetchModeData = throttler(
+const throttledFetchMoreData: FetchModeData = throttler(
   async (
     dataModel: DataModel,
     measureData: MeasureData,
@@ -140,7 +140,7 @@ const DataGrid = ({
       viewService.gridWidth = overscanColumnStopIndex - overscanColumnStartIndex + 1;
       viewService.gridHeight = overscanRowStopIndex - overscanRowStartIndex + 1;
 
-      await debouncedFetchMoreData(
+      await throttledFetchMoreData(
         dataModel,
         measureData,
         overscanColumnStartIndex,

--- a/src/pivot-table/components/grids/DataGrid.tsx
+++ b/src/pivot-table/components/grids/DataGrid.tsx
@@ -1,5 +1,5 @@
 /*  eslint-disable no-param-reassign */
-import { debouncer } from "qlik-chart-modules";
+import { throttler } from "qlik-chart-modules";
 import React, { memo, useCallback, useLayoutEffect, useMemo } from "react";
 import { VariableSizeGrid, type GridOnItemsRenderedProps } from "react-window";
 import type { DataModel, GridItemData, LayoutService, MeasureData, ViewService } from "../../../types/types";
@@ -63,7 +63,7 @@ const isMissingData = (
   return false;
 };
 
-const debouncedFetchMoreData: FetchModeData = debouncer(
+const debouncedFetchMoreData: FetchModeData = throttler(
   async (
     dataModel: DataModel,
     measureData: MeasureData,
@@ -89,7 +89,7 @@ const debouncedFetchMoreData: FetchModeData = debouncer(
       );
     }
   },
-  150
+  100
 );
 
 const DataGrid = ({

--- a/src/types/qlik-chart-models.d.ts
+++ b/src/types/qlik-chart-models.d.ts
@@ -2,8 +2,10 @@ declare module "qlik-chart-modules" {
   type SetValue = (propTree: unknown, path: string, value: unknown) => void;
   type Memoize = <T>(callback: T) => T;
   type Debouncer = <T>(callback: T, timeout?: number) => T;
+  type Throttler = <T>(callback: T, timeout?: number) => T;
 
   export const setValue: SetValue;
   export const memoize: Memoize;
   export const debouncer: Debouncer;
+  export const throttler: Throttler;
 }


### PR DESCRIPTION
As discussed some time ago. Change debouncer into a throttler to improve the experience when scrolling while still trying to keep the number of calls to Engine at a healthy level.