### PR TITLE
fix: expand top grid issue

### DIFF
--- a/src/pivot-table/data/__tests__/__snapshots__/extract-top.test.ts.snap
+++ b/src/pivot-table/data/__tests__/__snapshots__/extract-top.test.ts.snap
@@ -4,7 +4,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
 [
   {
     "0": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
@@ -37,7 +37,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 0,
     },
     "1": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
@@ -70,7 +70,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 0,
     },
     "2": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 6,
@@ -125,7 +125,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 0,
     },
     "3": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
@@ -144,12 +144,12 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
   },
   {
     "0": {
-      "dataY": -1,
+      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
       "parent": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
@@ -197,7 +197,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
@@ -233,12 +233,12 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 1,
     },
     "1": {
-      "dataY": -1,
+      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
       "parent": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
@@ -286,7 +286,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
@@ -322,12 +322,12 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 1,
     },
     "2": {
-      "dataY": -1,
+      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
       "parent": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -397,7 +397,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -455,12 +455,12 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 1,
     },
     "3": {
-      "dataY": -1,
+      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 5,
       "parent": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -537,7 +537,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -597,17 +597,17 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
   },
   {
     "0": {
-      "dataY": -1,
+      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
       "parent": {
-        "dataY": -1,
+        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
         "parent": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
@@ -655,7 +655,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
           "qUp": 1,
         },
         "root": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
@@ -698,7 +698,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
@@ -734,17 +734,17 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 2,
     },
     "1": {
-      "dataY": -1,
+      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
       "parent": {
-        "dataY": -1,
+        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
         "parent": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
@@ -792,7 +792,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
           "qUp": 1,
         },
         "root": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
@@ -835,7 +835,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
@@ -871,17 +871,17 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 2,
     },
     "2": {
-      "dataY": -1,
+      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
       "parent": {
-        "dataY": -1,
+        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
         "parent": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
@@ -951,7 +951,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
           "qUp": 1,
         },
         "root": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
@@ -1016,7 +1016,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -1074,17 +1074,17 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 2,
     },
     "3": {
-      "dataY": -1,
+      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
       "parent": {
-        "dataY": -1,
+        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
         "parent": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
@@ -1161,7 +1161,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
           "qUp": 1,
         },
         "root": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
@@ -1226,7 +1226,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -1284,17 +1284,17 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 2,
     },
     "4": {
-      "dataY": -1,
+      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
       "parent": {
-        "dataY": -1,
+        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
         "parent": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
@@ -1371,7 +1371,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
           "qUp": 1,
         },
         "root": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
@@ -1436,7 +1436,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -1501,7 +1501,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
 [
   {
     "0": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 0,
@@ -1518,7 +1518,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 0,
     },
     "1": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 0,
@@ -1535,7 +1535,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 0,
     },
     "2": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 0,
@@ -1552,7 +1552,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 0,
     },
     "3": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
@@ -1571,12 +1571,12 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
   },
   {
     "0": {
-      "dataY": -1,
+      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
       "parent": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
@@ -1624,7 +1624,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
@@ -1660,12 +1660,12 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 1,
     },
     "1": {
-      "dataY": -1,
+      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
       "parent": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
@@ -1713,7 +1713,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
@@ -1749,12 +1749,12 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 1,
     },
     "2": {
-      "dataY": -1,
+      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
       "parent": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -1824,7 +1824,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -1882,12 +1882,12 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 1,
     },
     "3": {
-      "dataY": -1,
+      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 5,
       "parent": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -1964,7 +1964,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -2024,17 +2024,17 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
   },
   {
     "0": {
-      "dataY": -1,
+      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
       "parent": {
-        "dataY": -1,
+        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
         "parent": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
@@ -2082,7 +2082,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
@@ -2125,7 +2125,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
@@ -2161,17 +2161,17 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 2,
     },
     "1": {
-      "dataY": -1,
+      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
       "parent": {
-        "dataY": -1,
+        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
         "parent": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
@@ -2219,7 +2219,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
@@ -2262,7 +2262,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
@@ -2298,17 +2298,17 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 2,
     },
     "2": {
-      "dataY": -1,
+      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
       "parent": {
-        "dataY": -1,
+        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
         "parent": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
@@ -2378,7 +2378,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
@@ -2443,7 +2443,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -2501,17 +2501,17 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 2,
     },
     "3": {
-      "dataY": -1,
+      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
       "parent": {
-        "dataY": -1,
+        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
         "parent": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
@@ -2588,7 +2588,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
@@ -2653,7 +2653,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -2711,17 +2711,17 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 2,
     },
     "4": {
-      "dataY": -1,
+      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
       "parent": {
-        "dataY": -1,
+        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
         "parent": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
@@ -2798,7 +2798,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": -1,
+          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
@@ -2863,7 +2863,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
@@ -2928,7 +2928,7 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
 [
   {
     "0": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 5,
@@ -2961,7 +2961,7 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
       "y": 0,
     },
     "1": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
@@ -2978,7 +2978,7 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
       "y": 0,
     },
     "2": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
@@ -2995,7 +2995,7 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
       "y": 0,
     },
     "3": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
@@ -3014,12 +3014,12 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
   },
   {
     "0": {
-      "dataY": -1,
+      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
       "parent": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
@@ -3059,7 +3059,7 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
@@ -3095,12 +3095,12 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
       "y": 1,
     },
     "1": {
-      "dataY": -1,
+      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
       "parent": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
@@ -3140,7 +3140,7 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": -1,
+        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
@@ -3183,7 +3183,7 @@ exports[`extractTop should extract top data with no nodes expanded 1`] = `
 [
   {
     "0": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
@@ -3200,7 +3200,7 @@ exports[`extractTop should extract top data with no nodes expanded 1`] = `
       "y": 0,
     },
     "1": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
@@ -3217,7 +3217,7 @@ exports[`extractTop should extract top data with no nodes expanded 1`] = `
       "y": 0,
     },
     "2": {
-      "dataY": -1,
+      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,

--- a/src/pivot-table/data/extract-top.ts
+++ b/src/pivot-table/data/extract-top.ts
@@ -28,7 +28,7 @@ const extractTopGrid = (
     nodes.forEach((node, currColIdx) => {
       colIdx += currColIdx === 0 ? 0 : 1;
       const x = qArea.qLeft + colIdx - node.qUp; // Start position + current page position - previous tail size
-      const cell = createCell(node, parent, root, x, rowIdx, -1, isSnapshot);
+      const cell = createCell(node, parent, root, x, rowIdx, rowIdx, isSnapshot);
 
       grid[rowIdx][x] = cell;
 


### PR DESCRIPTION
passing `rowIdx` instead of 0 while creating cells in top grid