### PR TITLE
fix: missing page

### DIFF
--- a/src/hooks/__tests__/use-pagination.test.ts
+++ b/src/hooks/__tests__/use-pagination.test.ts
@@ -50,7 +50,7 @@ describe("usePagination", () => {
     const { result, rerender } = renderer();
 
     // get total pages based on layout info
-    const totalPages = layoutService.layout.qHyperCube.qSize.qcy / layoutService.size.y;
+    const totalPages = Math.ceil(layoutService.layout.qHyperCube.qSize.qcy / MAX_ROW_COUNT);
 
     // update the page to last page + 100 more pages (some thing out of curr pagination boundary)
     act(() => {

--- a/src/hooks/__tests__/use-pagination.test.ts
+++ b/src/hooks/__tests__/use-pagination.test.ts
@@ -1,5 +1,5 @@
 import * as nebula from "@nebula.js/stardust";
-import { renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { MAX_ROW_COUNT } from "../../pivot-table/constants";
 import type { LayoutService } from "../../types/types";
@@ -10,7 +10,7 @@ jest.mock("@nebula.js/stardust");
 describe("usePagination", () => {
   let layoutService: LayoutService;
 
-  const renderer = () => renderHook(() => usePagination(layoutService)).result.current;
+  const renderer = () => renderHook(() => usePagination(layoutService));
 
   beforeEach(() => {
     layoutService = {
@@ -30,7 +30,11 @@ describe("usePagination", () => {
   });
 
   test("should return correct pagination info for given values", () => {
-    const { pageInfo } = renderer();
+    const {
+      result: {
+        current: { pageInfo },
+      },
+    } = renderer();
     const { qcy } = layoutService.layout.qHyperCube.qSize;
 
     expect(pageInfo).toMatchObject({
@@ -39,6 +43,25 @@ describe("usePagination", () => {
       shouldShowPagination: true,
       totalPages: Math.ceil(qcy / Math.min(qcy, MAX_ROW_COUNT)),
       totalRowCount: qcy,
+    });
+  });
+
+  test("should reset to last page in case of collapsing rows ends up reducing row counts tremendusly", async () => {
+    const { result, rerender } = renderer();
+
+    // get total pages based on layout info
+    const totalPages = layoutService.layout.qHyperCube.qSize.qcy / layoutService.size.y;
+
+    // update the page to last page + 100 more pages (some thing out of curr pagination boundary)
+    act(() => {
+      result.current.updatePageInfo({ ...result.current.pageInfo, currentPage: totalPages + 100 });
+    });
+
+    rerender();
+
+    // check the the currPage to be the last page (considering that page count is based 0)
+    await waitFor(() => {
+      expect(result.current.pageInfo.currentPage).toBe(totalPages - 1);
     });
   });
 });

--- a/src/hooks/use-pagination.ts
+++ b/src/hooks/use-pagination.ts
@@ -42,6 +42,16 @@ const usePagination: UsePagination = (layoutService) => {
     }));
   }, [layoutService.layout.qHyperCube.qSize.qcy, setPageInfo]);
 
+  useEffect(() => {
+    const { currentPage, totalPages } = pageInfo;
+
+    // currPage is base 0 and totalPages always includes remainder rows in last page
+    // so we need to consider both of them for prevent landing in missing page
+    if (currentPage + 1 > totalPages) {
+      setPageInfo({ ...pageInfo, currentPage: totalPages - 1 });
+    }
+  }, [pageInfo]);
+
   const updatePageInfo: UpdatePageInfo = (args) => setPageInfo({ ...pageInfo, ...args });
 
   return {


### PR DESCRIPTION
if you expand rows and consecutively end up having more pages than when you opened the app, collapsing a row in last page may cause to land in a empty page (still being the last page even though having less than that). this happens because of how engine works on expand and collapsing the rows. 

### solution:
in case of collapsing and page loss, land user in the actual last page. 

Here is the demo for fix:

https://github.com/qlik-oss/sn-pivot-table/assets/29652890/67f53c68-3b06-417f-bc7d-608364753c6c

