### PR TITLE
refactor: `dataY` and `y`

### DIFF
--- a/src/pivot-table/components/cells/DimensionCell.tsx
+++ b/src/pivot-table/components/cells/DimensionCell.tsx
@@ -100,10 +100,10 @@ const DimensionCell = ({
   const isNull = qType === NxDimCellType.NX_DIM_CELL_NULL;
   const selectionCellType = isLeftColumn ? NxSelectionCellType.NX_CELL_LEFT : NxSelectionCellType.NX_CELL_TOP;
   const isCellLocked =
-    isLocked(selectionCellType, cell.dataY, colIndex) ||
-    layoutService.isDimensionLocked(selectionCellType, cell.dataY, colIndex);
+    isLocked(selectionCellType, cell.y, colIndex) ||
+    layoutService.isDimensionLocked(selectionCellType, cell.y, colIndex);
   const isNonSelectableCell = isCellLocked || qType === NxDimCellType.NX_DIM_CELL_EMPTY || constraints.active || isNull;
-  const isCellSelected = isSelected(selectionCellType, cell.dataY, colIndex);
+  const isCellSelected = isSelected(selectionCellType, cell.y, colIndex);
   const resolvedTextStyle = getTextStyle({
     isLeftColumn,
     styleService,
@@ -125,7 +125,7 @@ const DimensionCell = ({
     isLeftColumn,
     showLastRowBorderBottom,
   });
-  const onClickHandler = isNonSelectableCell ? undefined : select(selectionCellType, cell.dataY, colIndex);
+  const onClickHandler = isNonSelectableCell ? undefined : select(selectionCellType, cell.y, colIndex);
   const text = isNull ? layoutService.getNullValueText() : qText;
   const serviceStyle = isLeftColumn ? styleService.rowContent : styleService.columnContent;
   let cellIcon = null;
@@ -136,7 +136,7 @@ const DimensionCell = ({
         color={isNull ? serviceStyle.nullValue.color : serviceStyle.color}
         opacity={isActive ? 0.4 : 1.0}
         testid={testIdExpandIcon}
-        onClick={createOnExpand({ dataModel, isLeftColumn, rowIndex: cell.dataY, colIndex, constraints, isActive })}
+        onClick={createOnExpand({ dataModel, isLeftColumn, rowIndex: cell.y, colIndex, constraints, isActive })}
       />
     );
   } else if (qCanCollapse) {
@@ -145,7 +145,7 @@ const DimensionCell = ({
         color={isNull ? serviceStyle.nullValue.color : serviceStyle.color}
         opacity={isActive ? 0.4 : 1.0}
         testid={testIdCollapseIcon}
-        onClick={createOnCollapse({ dataModel, isLeftColumn, rowIndex: cell.dataY, colIndex, constraints, isActive })}
+        onClick={createOnCollapse({ dataModel, isLeftColumn, rowIndex: cell.y, colIndex, constraints, isActive })}
       />
     );
   }

--- a/src/pivot-table/components/cells/ListCellFactory.tsx
+++ b/src/pivot-table/components/cells/ListCellFactory.tsx
@@ -72,7 +72,7 @@ const ListCellFactory = ({ index, style, data }: ListCallbackProps): JSX.Element
     <DimensionCell
       cell={cell}
       data={data}
-      rowIndex={cell.dataY}
+      rowIndex={cell.pageY}
       colIndex={cell.x}
       style={style}
       isLeftColumn={isLeftColumn}

--- a/src/pivot-table/components/cells/ListCellFactory.tsx
+++ b/src/pivot-table/components/cells/ListCellFactory.tsx
@@ -72,7 +72,7 @@ const ListCellFactory = ({ index, style, data }: ListCallbackProps): JSX.Element
     <DimensionCell
       cell={cell}
       data={data}
-      rowIndex={cell.y}
+      rowIndex={cell.dataY}
       colIndex={cell.x}
       style={style}
       isLeftColumn={isLeftColumn}

--- a/src/pivot-table/components/cells/__tests__/DimensionCell.test.tsx
+++ b/src/pivot-table/components/cells/__tests__/DimensionCell.test.tsx
@@ -84,7 +84,7 @@ describe("DimensionCell", () => {
     } as ListItemData;
 
     cell = {
-      dataY: 0,
+      y: 0,
       ref: {
         qText,
         qCanExpand: false,

--- a/src/pivot-table/components/cells/__tests__/ListCellFactory.test.tsx
+++ b/src/pivot-table/components/cells/__tests__/ListCellFactory.test.tsx
@@ -58,7 +58,7 @@ describe("ListCellFactory", () => {
     const index = 0;
     const mockDimensionCell = DimensionCell as jest.MockedFunction<typeof DimensionCell>;
     mockDimensionCell.mockReturnValue(<div />);
-    cell = { x: 1, y: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
+    cell = { x: 1, dataY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
     data.list[index] = cell;
 
     render(<ListCellFactory index={index} style={style} data={data} />);
@@ -148,7 +148,7 @@ describe("ListCellFactory", () => {
         const index = 0;
         const mockDimensionCell = DimensionCell as jest.MockedFunction<typeof DimensionCell>;
         mockDimensionCell.mockReturnValue(<div />);
-        cell = { x: 1, y: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
+        cell = { x: 1, dataY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
         data.list[index] = cell;
         data.isLeftColumn = true;
         data.isLast = true;
@@ -165,7 +165,7 @@ describe("ListCellFactory", () => {
         const index = 0;
         const mockDimensionCell = DimensionCell as jest.MockedFunction<typeof DimensionCell>;
         mockDimensionCell.mockReturnValue(<div />);
-        cell = { x: 1, y: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
+        cell = { x: 1, dataY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
         data.list[index] = cell;
         data.isLeftColumn = true;
         data.isLast = false;
@@ -185,7 +185,7 @@ describe("ListCellFactory", () => {
         const index = 0;
         const mockDimensionCell = DimensionCell as jest.MockedFunction<typeof DimensionCell>;
         mockDimensionCell.mockReturnValue(<div />);
-        cell = { x: 1, y: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
+        cell = { x: 1, dataY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
         data.list[index] = cell;
 
         render(<ListCellFactory index={index} style={style} data={data} />);
@@ -200,7 +200,7 @@ describe("ListCellFactory", () => {
         const index = 0;
         const mockDimensionCell = DimensionCell as jest.MockedFunction<typeof DimensionCell>;
         mockDimensionCell.mockReturnValue(<div />);
-        cell = { x: 1, y: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
+        cell = { x: 1, dataY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
         data.list[index] = cell;
         data.isLast = false;
         data.itemCount = 2;

--- a/src/pivot-table/components/cells/__tests__/ListCellFactory.test.tsx
+++ b/src/pivot-table/components/cells/__tests__/ListCellFactory.test.tsx
@@ -58,7 +58,7 @@ describe("ListCellFactory", () => {
     const index = 0;
     const mockDimensionCell = DimensionCell as jest.MockedFunction<typeof DimensionCell>;
     mockDimensionCell.mockReturnValue(<div />);
-    cell = { x: 1, dataY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
+    cell = { x: 1, pageY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
     data.list[index] = cell;
 
     render(<ListCellFactory index={index} style={style} data={data} />);
@@ -148,7 +148,7 @@ describe("ListCellFactory", () => {
         const index = 0;
         const mockDimensionCell = DimensionCell as jest.MockedFunction<typeof DimensionCell>;
         mockDimensionCell.mockReturnValue(<div />);
-        cell = { x: 1, dataY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
+        cell = { x: 1, pageY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
         data.list[index] = cell;
         data.isLeftColumn = true;
         data.isLast = true;
@@ -165,7 +165,7 @@ describe("ListCellFactory", () => {
         const index = 0;
         const mockDimensionCell = DimensionCell as jest.MockedFunction<typeof DimensionCell>;
         mockDimensionCell.mockReturnValue(<div />);
-        cell = { x: 1, dataY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
+        cell = { x: 1, pageY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
         data.list[index] = cell;
         data.isLeftColumn = true;
         data.isLast = false;
@@ -185,7 +185,7 @@ describe("ListCellFactory", () => {
         const index = 0;
         const mockDimensionCell = DimensionCell as jest.MockedFunction<typeof DimensionCell>;
         mockDimensionCell.mockReturnValue(<div />);
-        cell = { x: 1, dataY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
+        cell = { x: 1, pageY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
         data.list[index] = cell;
 
         render(<ListCellFactory index={index} style={style} data={data} />);
@@ -200,7 +200,7 @@ describe("ListCellFactory", () => {
         const index = 0;
         const mockDimensionCell = DimensionCell as jest.MockedFunction<typeof DimensionCell>;
         mockDimensionCell.mockReturnValue(<div />);
-        cell = { x: 1, dataY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
+        cell = { x: 1, pageY: 2, ref: { qText, qCanCollapse: false, qCanExpand: false } } as Cell;
         data.list[index] = cell;
         data.isLast = false;
         data.itemCount = 2;

--- a/src/pivot-table/components/helpers/__tests__/get-item-size-handler.test.ts
+++ b/src/pivot-table/components/helpers/__tests__/get-item-size-handler.test.ts
@@ -47,14 +47,14 @@ describe("getItemSizeHandler", () => {
     test("should return a size for cell when first row does not exist in list", () => {
       const index = 1;
       const leafCount = 10;
-      const dataY = 1;
+      const pageY = 1;
       list[index] = {
         leafCount,
-        dataY,
+        pageY,
       } as Cell;
       const handler = getRowHeightHandler(list, cellHeight, false, qcy);
 
-      expect(handler(0)).toEqual(cellHeight * (leafCount + dataY));
+      expect(handler(0)).toEqual(cellHeight * (leafCount + pageY));
     });
   });
 

--- a/src/pivot-table/components/helpers/__tests__/get-item-size-handler.test.ts
+++ b/src/pivot-table/components/helpers/__tests__/get-item-size-handler.test.ts
@@ -47,14 +47,14 @@ describe("getItemSizeHandler", () => {
     test("should return a size for cell when first row does not exist in list", () => {
       const index = 1;
       const leafCount = 10;
-      const y = 1;
+      const dataY = 1;
       list[index] = {
         leafCount,
-        y,
+        dataY,
       } as Cell;
       const handler = getRowHeightHandler(list, cellHeight, false, qcy);
 
-      expect(handler(0)).toEqual(cellHeight * (leafCount + y));
+      expect(handler(0)).toEqual(cellHeight * (leafCount + dataY));
     });
   });
 

--- a/src/pivot-table/components/helpers/get-item-size-handler.ts
+++ b/src/pivot-table/components/helpers/get-item-size-handler.ts
@@ -15,12 +15,12 @@ export const getRowHeightHandler =
   (rowIndex: number) => {
     const cell = isLastColumn ? list[rowIndex] : Object.values(list)[rowIndex];
 
-    if (rowIndex === 0 && cell?.y > 0) {
-      return (cell.leafCount + cell.y) * cellHeight;
+    if (rowIndex === 0 && cell?.dataY > 0) {
+      return (cell.leafCount + cell.dataY) * cellHeight;
     }
 
     if (cell?.leafCount > 0) {
-      const isLastRow = cell.dataY === qcy - cell.leafCount;
+      const isLastRow = cell.y === qcy - cell.leafCount;
 
       // if it is last row -> consider subtracting cell.ref.qUp from leafcounts
       // for cases when some of the leafnodes rendered in one page and rest in next/last page

--- a/src/pivot-table/components/helpers/get-item-size-handler.ts
+++ b/src/pivot-table/components/helpers/get-item-size-handler.ts
@@ -15,8 +15,8 @@ export const getRowHeightHandler =
   (rowIndex: number) => {
     const cell = isLastColumn ? list[rowIndex] : Object.values(list)[rowIndex];
 
-    if (rowIndex === 0 && cell?.dataY > 0) {
-      return (cell.leafCount + cell.dataY) * cellHeight;
+    if (rowIndex === 0 && cell?.pageY > 0) {
+      return (cell.leafCount + cell.pageY) * cellHeight;
     }
 
     if (cell?.leafCount > 0) {

--- a/src/pivot-table/data/__tests__/__snapshots__/extract-left.test.ts.snap
+++ b/src/pivot-table/data/__tests__/__snapshots__/extract-left.test.ts.snap
@@ -4,10 +4,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
 [
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 0,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -37,10 +38,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "y": 0,
     },
     "1": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 0,
+      "pageY": 1,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -70,10 +72,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "y": 1,
     },
     "2": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 6,
+      "pageX": 0,
+      "pageY": 2,
       "parent": null,
       "ref": {
         "qCanCollapse": true,
@@ -127,10 +130,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "y": 2,
     },
     "3": {
-      "dataY": 3,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 0,
+      "pageY": 3,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -146,15 +150,17 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
   },
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 1,
+      "pageY": 0,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -199,10 +205,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -235,15 +242,17 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "y": 0,
     },
     "1": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 1,
+      "pageY": 1,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 1,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -288,10 +297,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "qUp": 1,
       },
       "root": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 1,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -324,15 +334,17 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "y": 1,
     },
     "2": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 1,
+      "pageY": 2,
       "parent": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -401,10 +413,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "qUp": 1,
       },
       "root": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -461,15 +474,17 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "y": 2,
     },
     "3": {
-      "dataY": 3,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 5,
+      "pageX": 1,
+      "pageY": 3,
       "parent": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -546,10 +561,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "qUp": 1,
       },
       "root": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -608,20 +624,23 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
   },
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 0,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 0,
         "parent": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 0,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -666,10 +685,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
           "qUp": 1,
         },
         "root": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 0,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -709,10 +729,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -745,20 +766,23 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "y": 0,
     },
     "1": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 1,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 1,
         "parent": {
-          "dataY": 1,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 0,
+          "pageY": 1,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -803,10 +827,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
           "qUp": 1,
         },
         "root": {
-          "dataY": 1,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 0,
+          "pageY": 1,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -846,10 +871,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "qUp": 1,
       },
       "root": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 1,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -882,20 +908,23 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "y": 1,
     },
     "2": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 2,
       "parent": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 2,
         "parent": {
-          "dataY": 2,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 0,
+          "pageY": 2,
           "parent": null,
           "ref": {
             "qCanCollapse": true,
@@ -964,10 +993,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
           "qUp": 1,
         },
         "root": {
-          "dataY": 2,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 0,
+          "pageY": 2,
           "parent": null,
           "ref": {
             "qCanCollapse": true,
@@ -1031,10 +1061,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "qUp": 1,
       },
       "root": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -1091,20 +1122,23 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "y": 2,
     },
     "3": {
-      "dataY": 3,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 3,
       "parent": {
-        "dataY": 3,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 1,
+        "pageY": 3,
         "parent": {
-          "dataY": 2,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 0,
+          "pageY": 2,
           "parent": null,
           "ref": {
             "qCanCollapse": true,
@@ -1181,10 +1215,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
           "qUp": 1,
         },
         "root": {
-          "dataY": 2,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 0,
+          "pageY": 2,
           "parent": null,
           "ref": {
             "qCanCollapse": true,
@@ -1248,10 +1283,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "qUp": 1,
       },
       "root": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -1308,20 +1344,23 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "y": 3,
     },
     "4": {
-      "dataY": 4,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 4,
       "parent": {
-        "dataY": 3,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 1,
+        "pageY": 3,
         "parent": {
-          "dataY": 2,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 0,
+          "pageY": 2,
           "parent": null,
           "ref": {
             "qCanCollapse": true,
@@ -1398,10 +1437,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
           "qUp": 1,
         },
         "root": {
-          "dataY": 2,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 0,
+          "pageY": 2,
           "parent": null,
           "ref": {
             "qCanCollapse": true,
@@ -1465,10 +1505,11 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "qUp": 1,
       },
       "root": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -1532,10 +1573,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
 [
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 0,
+      "pageX": 0,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -1549,10 +1591,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "y": 0,
     },
     "1": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 0,
+      "pageX": 0,
+      "pageY": 1,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -1566,10 +1609,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "y": 1,
     },
     "2": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 0,
+      "pageX": 0,
+      "pageY": 2,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -1583,10 +1627,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "y": 2,
     },
     "3": {
-      "dataY": 3,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 0,
+      "pageY": 3,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -1602,15 +1647,17 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
   },
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 1,
+      "pageY": 0,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1655,10 +1702,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1691,15 +1739,17 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "y": 0,
     },
     "1": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 1,
+      "pageY": 1,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 1,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1744,10 +1794,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 1,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1780,15 +1831,17 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "y": 1,
     },
     "2": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 1,
+      "pageY": 2,
       "parent": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -1857,10 +1910,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -1917,15 +1971,17 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "y": 2,
     },
     "3": {
-      "dataY": 3,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 5,
+      "pageX": 1,
+      "pageY": 3,
       "parent": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -2002,10 +2058,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -2064,20 +2121,23 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
   },
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 0,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 0,
         "parent": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 0,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2122,10 +2182,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 0,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2165,10 +2226,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -2201,20 +2263,23 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "y": 0,
     },
     "1": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 1,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 1,
         "parent": {
-          "dataY": 1,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 0,
+          "pageY": 1,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2259,10 +2324,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": 1,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 0,
+          "pageY": 1,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2302,10 +2368,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 1,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -2338,20 +2405,23 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "y": 1,
     },
     "2": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 2,
       "parent": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 2,
         "parent": {
-          "dataY": 2,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 0,
+          "pageY": 2,
           "parent": null,
           "ref": {
             "qCanCollapse": true,
@@ -2420,10 +2490,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": 2,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 0,
+          "pageY": 2,
           "parent": null,
           "ref": {
             "qCanCollapse": true,
@@ -2487,10 +2558,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -2547,20 +2619,23 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "y": 2,
     },
     "3": {
-      "dataY": 3,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 3,
       "parent": {
-        "dataY": 3,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 1,
+        "pageY": 3,
         "parent": {
-          "dataY": 2,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 0,
+          "pageY": 2,
           "parent": null,
           "ref": {
             "qCanCollapse": true,
@@ -2637,10 +2712,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": 2,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 0,
+          "pageY": 2,
           "parent": null,
           "ref": {
             "qCanCollapse": true,
@@ -2704,10 +2780,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -2764,20 +2841,23 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "y": 3,
     },
     "4": {
-      "dataY": 4,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 4,
       "parent": {
-        "dataY": 3,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 1,
+        "pageY": 3,
         "parent": {
-          "dataY": 2,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 0,
+          "pageY": 2,
           "parent": null,
           "ref": {
             "qCanCollapse": true,
@@ -2854,10 +2934,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": 2,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 0,
+          "pageY": 2,
           "parent": null,
           "ref": {
             "qCanCollapse": true,
@@ -2921,10 +3002,11 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 2,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 0,
+        "pageY": 2,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -2988,10 +3070,11 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
 [
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 5,
+      "pageX": 0,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qCanCollapse": true,
@@ -3021,10 +3104,11 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
       "y": 0,
     },
     "1": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 0,
+      "pageY": 1,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -3038,10 +3122,11 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
       "y": 1,
     },
     "2": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 0,
+      "pageY": 2,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -3055,10 +3140,11 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
       "y": 2,
     },
     "3": {
-      "dataY": 3,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 0,
+      "pageY": 3,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -3074,15 +3160,17 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
   },
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 1,
+      "pageY": 0,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -3119,10 +3207,11 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -3155,15 +3244,17 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
       "y": 0,
     },
     "1": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 1,
+      "pageY": 1,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -3200,10 +3291,11 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -3243,10 +3335,11 @@ exports[`extractLeftGrid should extract left data with no nodes expanded 1`] = `
 [
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 0,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -3260,10 +3353,11 @@ exports[`extractLeftGrid should extract left data with no nodes expanded 1`] = `
       "y": 0,
     },
     "1": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 0,
+      "pageY": 1,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -3277,10 +3371,11 @@ exports[`extractLeftGrid should extract left data with no nodes expanded 1`] = `
       "y": 1,
     },
     "2": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 0,
+      "pageY": 2,
       "parent": null,
       "ref": {
         "qDown": 2,

--- a/src/pivot-table/data/__tests__/__snapshots__/extract-top.test.ts.snap
+++ b/src/pivot-table/data/__tests__/__snapshots__/extract-top.test.ts.snap
@@ -4,10 +4,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
 [
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 0,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -37,10 +38,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 0,
     },
     "1": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 1,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -70,10 +72,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 0,
     },
     "2": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 6,
+      "pageX": 2,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -125,10 +128,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 0,
     },
     "3": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 3,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -144,15 +148,17 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
   },
   {
     "0": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 0,
+      "pageY": 1,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -197,10 +203,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -233,15 +240,17 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 1,
     },
     "1": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 1,
+      "pageY": 1,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -286,10 +295,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -322,15 +332,17 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 1,
     },
     "2": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 2,
+      "pageY": 1,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -397,10 +409,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -455,15 +468,17 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 1,
     },
     "3": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 5,
+      "pageX": 3,
+      "pageY": 1,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -537,10 +552,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -597,20 +613,23 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
   },
   {
     "0": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 0,
+      "pageY": 2,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 1,
         "parent": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 0,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -655,10 +674,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
           "qUp": 1,
         },
         "root": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 0,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -698,10 +718,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -734,20 +755,23 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 2,
     },
     "1": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 1,
+      "pageY": 2,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 1,
         "parent": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 1,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -792,10 +816,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
           "qUp": 1,
         },
         "root": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 1,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -835,10 +860,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -871,20 +897,23 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 2,
     },
     "2": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 2,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 2,
+        "pageY": 1,
         "parent": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 2,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -951,10 +980,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
           "qUp": 1,
         },
         "root": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 2,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -1016,10 +1046,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1074,20 +1105,23 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 2,
     },
     "3": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 3,
+      "pageY": 2,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 3,
+        "pageY": 1,
         "parent": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 2,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -1161,10 +1195,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
           "qUp": 1,
         },
         "root": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 2,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -1226,10 +1261,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1284,20 +1320,23 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "y": 2,
     },
     "4": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 4,
+      "pageY": 2,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 3,
+        "pageY": 1,
         "parent": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 2,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -1371,10 +1410,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
           "qUp": 1,
         },
         "root": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 2,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -1436,10 +1476,11 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1501,10 +1542,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
 [
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 0,
+      "pageX": 0,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -1518,10 +1560,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 0,
     },
     "1": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 0,
+      "pageX": 1,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -1535,10 +1578,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 0,
     },
     "2": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 0,
+      "pageX": 2,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -1552,10 +1596,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 0,
     },
     "3": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 3,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -1571,15 +1616,17 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
   },
   {
     "0": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 0,
+      "pageY": 1,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1624,10 +1671,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1660,15 +1708,17 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 1,
     },
     "1": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 1,
+      "pageY": 1,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1713,10 +1763,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1749,15 +1800,17 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 1,
     },
     "2": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 4,
+      "pageX": 2,
+      "pageY": 1,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1824,10 +1877,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1882,15 +1936,17 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 1,
     },
     "3": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 5,
+      "pageX": 3,
+      "pageY": 1,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -1964,10 +2020,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -2024,20 +2081,23 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
   },
   {
     "0": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 0,
+      "pageY": 2,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 1,
         "parent": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 0,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2082,10 +2142,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 0,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2125,10 +2186,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -2161,20 +2223,23 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 2,
     },
     "1": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 1,
+      "pageY": 2,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 1,
         "parent": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 1,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2219,10 +2284,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 4,
+          "pageX": 1,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2262,10 +2328,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 1,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -2298,20 +2365,23 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 2,
     },
     "2": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 2,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 4,
+        "pageX": 2,
+        "pageY": 1,
         "parent": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 2,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2378,10 +2448,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 2,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2443,10 +2514,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -2501,20 +2573,23 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 2,
     },
     "3": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 3,
+      "pageY": 2,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 3,
+        "pageY": 1,
         "parent": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 2,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2588,10 +2663,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 2,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2653,10 +2729,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -2711,20 +2788,23 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "y": 2,
     },
     "4": {
-      "dataY": 2,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 4,
+      "pageY": 2,
       "parent": {
-        "dataY": 1,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 3,
+        "pageY": 1,
         "parent": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 2,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2798,10 +2878,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
           "qUp": 1,
         },
         "root": {
-          "dataY": 0,
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
           "leafCount": 6,
+          "pageX": 2,
+          "pageY": 0,
           "parent": null,
           "ref": {
             "qDown": 2,
@@ -2863,10 +2944,11 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 6,
+        "pageX": 2,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qDown": 2,
@@ -2928,10 +3010,11 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
 [
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 5,
+      "pageX": 0,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qCanCollapse": true,
@@ -2961,10 +3044,11 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
       "y": 0,
     },
     "1": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 1,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -2978,10 +3062,11 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
       "y": 0,
     },
     "2": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -2995,10 +3080,11 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
       "y": 0,
     },
     "3": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 3,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -3014,15 +3100,17 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
   },
   {
     "0": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 0,
+      "pageY": 1,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -3059,10 +3147,11 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -3095,15 +3184,17 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
       "y": 1,
     },
     "1": {
-      "dataY": 1,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 1,
+      "pageY": 1,
       "parent": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -3140,10 +3231,11 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
         "qUp": 1,
       },
       "root": {
-        "dataY": 0,
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
         "leafCount": 5,
+        "pageX": 0,
+        "pageY": 0,
         "parent": null,
         "ref": {
           "qCanCollapse": true,
@@ -3183,10 +3275,11 @@ exports[`extractTop should extract top data with no nodes expanded 1`] = `
 [
   {
     "0": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 0,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -3200,10 +3293,11 @@ exports[`extractTop should extract top data with no nodes expanded 1`] = `
       "y": 0,
     },
     "1": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 1,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,
@@ -3217,10 +3311,11 @@ exports[`extractTop should extract top data with no nodes expanded 1`] = `
       "y": 0,
     },
     "2": {
-      "dataY": 0,
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
       "leafCount": 3,
+      "pageX": 2,
+      "pageY": 0,
       "parent": null,
       "ref": {
         "qDown": 2,

--- a/src/pivot-table/data/extract-left.ts
+++ b/src/pivot-table/data/extract-left.ts
@@ -31,11 +31,11 @@ const extractLeftGrid = (
       // consider items that might be skipped based on current page
       const startPosition = qArea.qTop - pageInfo.currentPage * pageInfo.rowsPerPage;
       // Start position + current page position - previous tail size,
-      const dataY = Math.max(0, startPosition + rowIdx - node.qUp);
+      const pageY = Math.max(0, startPosition + rowIdx - node.qUp);
       const y = qArea.qTop + rowIdx - node.qUp;
-      const cell = createCell(node, parent, root, colIdx, y, dataY, isSnapshot);
+      const cell = createCell(node, parent, root, colIdx, y, pageY, isSnapshot);
 
-      grid[colIdx][dataY] = cell;
+      grid[colIdx][pageY] = cell;
 
       if (node.qSubNodes.length) {
         recursiveExtract(root || cell, cell, node.qSubNodes, colIdx + 1);

--- a/src/pivot-table/data/extract-left.ts
+++ b/src/pivot-table/data/extract-left.ts
@@ -31,11 +31,11 @@ const extractLeftGrid = (
       // consider items that might be skipped based on current page
       const startPosition = qArea.qTop - pageInfo.currentPage * pageInfo.rowsPerPage;
       // Start position + current page position - previous tail size,
-      const y = Math.max(0, startPosition + rowIdx - node.qUp);
-      const dataY = qArea.qTop + rowIdx - node.qUp;
+      const dataY = Math.max(0, startPosition + rowIdx - node.qUp);
+      const y = qArea.qTop + rowIdx - node.qUp;
       const cell = createCell(node, parent, root, colIdx, y, dataY, isSnapshot);
 
-      grid[colIdx][y] = cell;
+      grid[colIdx][dataY] = cell;
 
       if (node.qSubNodes.length) {
         recursiveExtract(root || cell, cell, node.qSubNodes, colIdx + 1);

--- a/src/pivot-table/data/helpers/assign-distance-to-next-cell.ts
+++ b/src/pivot-table/data/helpers/assign-distance-to-next-cell.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import type { Grid, PageInfo, Point } from "../../../types/types";
 
-const assignDistanceToNextCell = (data: Grid, dirKey: "x" | "dataY", size: Point, pageInfo?: PageInfo) => {
+const assignDistanceToNextCell = (data: Grid, dirKey: "x" | "pageY", size: Point, pageInfo?: PageInfo) => {
   data.slice(0, -1).forEach((list) => {
     Object.values(list).forEach((cell, index, cells) => {
       const nextSibling = cells[index + 1];
@@ -14,13 +14,13 @@ const assignDistanceToNextCell = (data: Grid, dirKey: "x" | "dataY", size: Point
         const gridLen = Object.values(data[data.length - 1]).length;
         const isLastPage = pageInfo && pageInfo.currentPage === pageInfo.totalPages - 1;
         // if in last page + grid length (total rows) is less than rows per page => distanceToNextCell should be 0
-        if (dirKey === "dataY" && isLastPage && gridLen < pageInfo.rowsPerPage) {
+        if (dirKey === "pageY" && isLastPage && gridLen < pageInfo.rowsPerPage) {
           cell.distanceToNextCell = 0;
         } else {
           // This is what enables the dimensions with branch nodes to be fully scrollable.
           // By "faking" the distanceToNextCell for the last cell to include all other cells
           // the react-window list can render with a full size.
-          const sizeDirectionKey: keyof Point = dirKey === "dataY" ? "y" : "x";
+          const sizeDirectionKey: keyof Point = dirKey === "pageY" ? "y" : "x";
           cell.distanceToNextCell = size[sizeDirectionKey] - (cell[dirKey] + cell.leafCount);
         }
       }

--- a/src/pivot-table/data/helpers/assign-distance-to-next-cell.ts
+++ b/src/pivot-table/data/helpers/assign-distance-to-next-cell.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import type { Grid, PageInfo, Point } from "../../../types/types";
 
-const assignDistanceToNextCell = (data: Grid, direction: "x" | "y", size: Point, pageInfo?: PageInfo) => {
+const assignDistanceToNextCell = (data: Grid, dirKey: "x" | "dataY", size: Point, pageInfo?: PageInfo) => {
   data.slice(0, -1).forEach((list) => {
     Object.values(list).forEach((cell, index, cells) => {
       const nextSibling = cells[index + 1];
@@ -9,18 +9,19 @@ const assignDistanceToNextCell = (data: Grid, direction: "x" | "y", size: Point,
         // If a node a position 1 and another node at position 1337, but no other nodes between that.
         // The node at position 1 is using "distanceToNextCell" streched all the way to the node at
         // position 1337.
-        cell.distanceToNextCell = nextSibling[direction] - (cell[direction] + cell.leafCount);
+        cell.distanceToNextCell = nextSibling[dirKey] - (cell[dirKey] + cell.leafCount);
       } else {
         const gridLen = Object.values(data[data.length - 1]).length;
         const isLastPage = pageInfo && pageInfo.currentPage === pageInfo.totalPages - 1;
         // if in last page + grid length (total rows) is less than rows per page => distanceToNextCell should be 0
-        if (direction === "y" && isLastPage && gridLen < pageInfo.rowsPerPage) {
+        if (dirKey === "dataY" && isLastPage && gridLen < pageInfo.rowsPerPage) {
           cell.distanceToNextCell = 0;
         } else {
           // This is what enables the dimensions with branch nodes to be fully scrollable.
           // By "faking" the distanceToNextCell for the last cell to include all other cells
           // the react-window list can render with a full size.
-          cell.distanceToNextCell = size[direction] - (cell[direction] + cell.leafCount);
+          const sizeDirectionKey: keyof Point = dirKey === "dataY" ? "y" : "x";
+          cell.distanceToNextCell = size[sizeDirectionKey] - (cell[dirKey] + cell.leafCount);
         }
       }
     });

--- a/src/pivot-table/data/helpers/assign-distance-to-next-cell.ts
+++ b/src/pivot-table/data/helpers/assign-distance-to-next-cell.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import type { Grid, PageInfo, Point } from "../../../types/types";
 
-const assignDistanceToNextCell = (data: Grid, dirKey: "x" | "pageY", size: Point, pageInfo?: PageInfo) => {
+const assignDistanceToNextCell = (data: Grid, dirKey: "pageX" | "pageY", size: Point, pageInfo?: PageInfo) => {
   data.slice(0, -1).forEach((list) => {
     Object.values(list).forEach((cell, index, cells) => {
       const nextSibling = cells[index + 1];

--- a/src/pivot-table/data/helpers/create-cell.ts
+++ b/src/pivot-table/data/helpers/create-cell.ts
@@ -6,13 +6,17 @@ const createCell = (
   root: Cell | null,
   x: number,
   y: number,
-  dataY: number,
+  pageY: number,
   isSnapshot: boolean
 ): Cell => ({
   ref: node,
   x,
-  y, // Y index of cell in dataset
-  dataY, // Y index of cell in page
+  y,
+  // TODO:
+  // pageX might change to reflect x in current x axis page
+  // when we implement horizontal pagination feature (exactly like the relation btw y and pageY)
+  pageX: x,
+  pageY,
   parent,
   root,
   leafCount: isSnapshot ? 0 : node.qUp + node.qDown,

--- a/src/pivot-table/data/helpers/create-cell.ts
+++ b/src/pivot-table/data/helpers/create-cell.ts
@@ -11,8 +11,8 @@ const createCell = (
 ): Cell => ({
   ref: node,
   x,
-  y, // position of cell in page
-  dataY, // position of cell in dataset
+  y, // Y index of cell in dataset
+  dataY, // Y index of cell in page
   parent,
   root,
   leafCount: isSnapshot ? 0 : node.qUp + node.qDown,

--- a/src/pivot-table/data/helpers/create-cell.ts
+++ b/src/pivot-table/data/helpers/create-cell.ts
@@ -12,7 +12,6 @@ const createCell = (
   ref: node,
   x,
   y,
-  // TODO:
   // pageX might change to reflect x in current x axis page
   // when we implement horizontal pagination feature (exactly like the relation btw y and pageY)
   pageX: x,

--- a/src/pivot-table/data/left-dimension-data.ts
+++ b/src/pivot-table/data/left-dimension-data.ts
@@ -19,7 +19,7 @@ export const addPageToLeftDimensionData = ({
   if (!qLeft.length) return prevData;
 
   const grid = extractLeftGrid(prevData.grid, qLeft, qArea, pageInfo, false);
-  assignDistanceToNextCell(grid, "y", prevData.layoutSize, pageInfo);
+  assignDistanceToNextCell(grid, "dataY", prevData.layoutSize, pageInfo);
 
   return {
     ...prevData,
@@ -37,7 +37,7 @@ export const createLeftDimensionData = (
   const { qArea, qLeft } = dataPage;
   const { qEffectiveInterColumnSortOrder } = qHyperCube;
   const grid = extractLeftGrid([], qLeft, qArea, pageInfo, layoutService.isSnapshot);
-  assignDistanceToNextCell(grid, "y", layoutService.size, pageInfo);
+  assignDistanceToNextCell(grid, "dataY", layoutService.size, pageInfo);
   const dimensionInfoIndexMap = grid.map(createDimInfoToIndexMapCallback(0, qEffectiveInterColumnSortOrder));
 
   return {

--- a/src/pivot-table/data/left-dimension-data.ts
+++ b/src/pivot-table/data/left-dimension-data.ts
@@ -19,7 +19,7 @@ export const addPageToLeftDimensionData = ({
   if (!qLeft.length) return prevData;
 
   const grid = extractLeftGrid(prevData.grid, qLeft, qArea, pageInfo, false);
-  assignDistanceToNextCell(grid, "dataY", prevData.layoutSize, pageInfo);
+  assignDistanceToNextCell(grid, "pageY", prevData.layoutSize, pageInfo);
 
   return {
     ...prevData,
@@ -37,7 +37,7 @@ export const createLeftDimensionData = (
   const { qArea, qLeft } = dataPage;
   const { qEffectiveInterColumnSortOrder } = qHyperCube;
   const grid = extractLeftGrid([], qLeft, qArea, pageInfo, layoutService.isSnapshot);
-  assignDistanceToNextCell(grid, "dataY", layoutService.size, pageInfo);
+  assignDistanceToNextCell(grid, "pageY", layoutService.size, pageInfo);
   const dimensionInfoIndexMap = grid.map(createDimInfoToIndexMapCallback(0, qEffectiveInterColumnSortOrder));
 
   return {

--- a/src/pivot-table/data/top-dimension-data.ts
+++ b/src/pivot-table/data/top-dimension-data.ts
@@ -16,7 +16,7 @@ export const addPageToTopDimensionData = ({
   if (!qTop.length) return prevData;
 
   const grid = extractTopGrid(prevData.grid, qTop, qArea, false);
-  assignDistanceToNextCell(grid, "x", prevData.layoutSize);
+  assignDistanceToNextCell(grid, "pageX", prevData.layoutSize);
 
   return {
     ...prevData,
@@ -33,7 +33,7 @@ export const createTopDimensionData = (
   const { qArea, qTop } = dataPage;
   const { qEffectiveInterColumnSortOrder, qNoOfLeftDims } = qHyperCube;
   const grid = extractTopGrid([], qTop, qArea, layoutService.isSnapshot);
-  assignDistanceToNextCell(grid, "x", layoutService.size);
+  assignDistanceToNextCell(grid, "pageX", layoutService.size);
   const dimensionInfoIndexMap = grid.map(
     createDimInfoToIndexMapCallback(qNoOfLeftDims, qEffectiveInterColumnSortOrder)
   );

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -58,9 +58,10 @@ export interface ListItemData extends ItemData {
 
 export interface Cell {
   ref: EngineAPI.INxPivotDimensionCell;
-  x: number;
-  y: number; // position of cell in page
-  dataY: number; // position of cell in dataset
+  x: number; // x position of cell in dataset
+  y: number; // y position of cell in dataset
+  pageX: number; // X position of cell in page
+  pageY: number; // Y position of cell in page
   parent: Cell | null;
   root: Cell | null;
   leafCount: number;


### PR DESCRIPTION
with this change, in a Cell object:
`x` reflects the x index of row in entire dataset
`y` reflects the y index of row in entire dataset
`pageX` reflects x index of row in page (currently its value is same as `x` -> because we don't have horizontal pagination)
`pageY` reflects y index of row in page 


<img width="2117" alt="Screenshot 2023-07-20 at 10 27 13" src="https://github.com/qlik-oss/sn-pivot-table/assets/29652890/96b6f684-20ad-4e9c-9e59-933533f3ed88">
