### PR TITLE
chore: require approval for qlik dev tool packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,15 @@
     {
       "depTypeList": ["engines"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": [
+        "@qlik/eslint-config",
+        "@qlik/eslint-config-react",
+        "@qlik/prettier-config",
+        "@qlik/tsconfig"
+      ],
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
The qlik dev tool packages are currently causing some issues in #286 which is blocking that PR. Lets skip updating those for now.

Using `dependencyDashboardApproval` here is a bit of a test. I'm expecting it to remove those packages from #286 until approved in the dashboard but that feels like a 50/50 if it will happen or not.