### PR TITLE
fix: locked dimension styling

### DIFF
--- a/src/pivot-table/components/cells/DimensionCell.tsx
+++ b/src/pivot-table/components/cells/DimensionCell.tsx
@@ -99,9 +99,7 @@ const DimensionCell = ({
   const { select, isSelected, isActive, isLocked } = useSelectionsContext();
   const isNull = qType === NxDimCellType.NX_DIM_CELL_NULL;
   const selectionCellType = isLeftColumn ? NxSelectionCellType.NX_CELL_LEFT : NxSelectionCellType.NX_CELL_TOP;
-  const isCellLocked =
-    isLocked(selectionCellType, cell.y, colIndex) ||
-    layoutService.isDimensionLocked(selectionCellType, cell.y, colIndex);
+  const isCellLocked = isLocked(selectionCellType, cell.y, colIndex) || cell.isLockedByDimension;
   const isNonSelectableCell = isCellLocked || qType === NxDimCellType.NX_DIM_CELL_EMPTY || constraints.active || isNull;
   const isCellSelected = isSelected(selectionCellType, cell.y, colIndex);
   const resolvedTextStyle = getTextStyle({

--- a/src/pivot-table/components/cells/__tests__/DimensionCell.test.tsx
+++ b/src/pivot-table/components/cells/__tests__/DimensionCell.test.tsx
@@ -384,7 +384,7 @@ describe("DimensionCell", () => {
       test("should not be possible to select cell when dimension is locked", async () => {
         const rowIdx = 0;
         const colIdx = 1;
-        (layoutService.isDimensionLocked as jest.Mock<unknown, unknown[]>).mockReturnValue(true);
+        cell.isLockedByDimension = true;
         cell.ref.qCanCollapse = true;
 
         render(
@@ -402,7 +402,6 @@ describe("DimensionCell", () => {
 
         await userEvent.click(screen.getByText(qText));
 
-        expect(layoutService.isDimensionLocked).toHaveBeenCalledWith(NxSelectionCellType.NX_CELL_LEFT, rowIdx, colIdx);
         expect(selectSpy).toHaveBeenCalledTimes(0);
         expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
         expect(screen.getByTestId(testId)).toHaveStyle(lockedFromSelectionStyle as Record<string, string>);
@@ -662,7 +661,7 @@ describe("DimensionCell", () => {
       test("should not be possible to select cell when dimension is locked", async () => {
         const rowIdx = 0;
         const colIdx = 1;
-        (layoutService.isDimensionLocked as jest.Mock<unknown, unknown[]>).mockReturnValue(true);
+        cell.isLockedByDimension = true;
         cell.ref.qCanCollapse = true;
 
         render(
@@ -680,7 +679,6 @@ describe("DimensionCell", () => {
 
         await userEvent.click(screen.getByText(qText));
 
-        expect(layoutService.isDimensionLocked).toHaveBeenCalledWith(NxSelectionCellType.NX_CELL_TOP, rowIdx, colIdx);
         expect(selectSpy).toHaveBeenCalledTimes(0);
         expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
         expect(screen.getByTestId(testId)).toHaveStyle(lockedFromSelectionStyle as Record<string, string>);

--- a/src/pivot-table/components/cells/utils/get-dimension-cell-style.ts
+++ b/src/pivot-table/components/cells/utils/get-dimension-cell-style.ts
@@ -33,9 +33,9 @@ export const selectableCellStyle: Pick<React.CSSProperties, "cursor"> = {
   cursor: "pointer",
 };
 
-// Locked background image does not work great with cells that have colorful backgrounds
-export const lockedFromSelectionStyle: Pick<React.CSSProperties, "color" | "backgroundImage"> = {
-  backgroundImage: "repeating-linear-gradient(-45deg, #f8f8f8, #f8f8f8 2px, transparent 2px, transparent 4px)",
+// Locked background does override any background color set by the user via theming or styling panel
+export const lockedFromSelectionStyle: Pick<React.CSSProperties, "color" | "background"> = {
+  background: "repeating-linear-gradient(-45deg, #f8f8f8, #f8f8f8 2px, transparent 2px, transparent 4px)",
   color: "#bebebe",
 };
 
@@ -66,11 +66,11 @@ export const getContainerStyle = ({
 
   return {
     ...style,
-    ...resolvedLockedSelectionStyle,
     ...resolvedSelectableCellStyle,
     ...getBorderStyle(isLastRow, isLastColumn, styleService.grid.border, showLastRowBorderBottom),
     ...resolvedNullStyle,
     ...resolvedSelectedStyle,
+    ...resolvedLockedSelectionStyle,
     display: "flex",
   };
 };

--- a/src/pivot-table/data/__tests__/__snapshots__/extract-left.test.ts.snap
+++ b/src/pivot-table/data/__tests__/__snapshots__/extract-left.test.ts.snap
@@ -6,6 +6,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 0,
       "pageY": 0,
@@ -40,6 +41,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 0,
       "pageY": 1,
@@ -74,6 +76,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 6,
       "pageX": 0,
       "pageY": 2,
@@ -132,6 +135,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 0,
       "pageY": 3,
@@ -152,12 +156,14 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 1,
       "pageY": 0,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 0,
@@ -207,6 +213,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 0,
@@ -244,12 +251,14 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 1,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 1,
@@ -299,6 +308,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 1,
@@ -336,12 +346,14 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 1,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -415,6 +427,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -476,12 +489,14 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 5,
       "pageX": 1,
       "pageY": 3,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -563,6 +578,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -626,18 +642,21 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 0,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 0,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 0,
           "pageY": 0,
@@ -687,6 +706,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 0,
           "pageY": 0,
@@ -731,6 +751,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 0,
@@ -768,18 +789,21 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 1,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 0,
           "pageY": 1,
@@ -829,6 +853,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 0,
           "pageY": 1,
@@ -873,6 +898,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 1,
@@ -910,18 +936,21 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 2,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 0,
           "pageY": 2,
@@ -995,6 +1024,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 0,
           "pageY": 2,
@@ -1063,6 +1093,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -1124,18 +1155,21 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 3,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 1,
         "pageY": 3,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 0,
           "pageY": 2,
@@ -1217,6 +1251,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 0,
           "pageY": 2,
@@ -1285,6 +1320,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -1346,18 +1382,21 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
     "4": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 4,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 1,
         "pageY": 3,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 0,
           "pageY": 2,
@@ -1439,6 +1478,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 0,
           "pageY": 2,
@@ -1507,6 +1547,7 @@ exports[`extractLeftGrid should extract left data when data tree has a depth of 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -1575,6 +1616,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 0,
       "pageX": 0,
       "pageY": 0,
@@ -1593,6 +1635,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 0,
       "pageX": 0,
       "pageY": 1,
@@ -1611,6 +1654,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 0,
       "pageX": 0,
       "pageY": 2,
@@ -1629,6 +1673,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 0,
       "pageY": 3,
@@ -1649,12 +1694,14 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 1,
       "pageY": 0,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 0,
@@ -1704,6 +1751,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 0,
@@ -1741,12 +1789,14 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 1,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 1,
@@ -1796,6 +1846,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 1,
@@ -1833,12 +1884,14 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 1,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -1912,6 +1965,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -1973,12 +2027,14 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 5,
       "pageX": 1,
       "pageY": 3,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -2060,6 +2116,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -2123,18 +2180,21 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 0,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 0,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 0,
           "pageY": 0,
@@ -2184,6 +2244,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 0,
           "pageY": 0,
@@ -2228,6 +2289,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 0,
@@ -2265,18 +2327,21 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 1,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 0,
           "pageY": 1,
@@ -2326,6 +2391,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 0,
           "pageY": 1,
@@ -2370,6 +2436,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 1,
@@ -2407,18 +2474,21 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 2,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 0,
           "pageY": 2,
@@ -2492,6 +2562,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 0,
           "pageY": 2,
@@ -2560,6 +2631,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -2621,18 +2693,21 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 3,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 1,
         "pageY": 3,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 0,
           "pageY": 2,
@@ -2714,6 +2789,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 0,
           "pageY": 2,
@@ -2782,6 +2858,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -2843,18 +2920,21 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
     "4": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 4,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 1,
         "pageY": 3,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 0,
           "pageY": 2,
@@ -2936,6 +3016,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 0,
           "pageY": 2,
@@ -3004,6 +3085,7 @@ exports[`extractLeftGrid should extract left data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 0,
         "pageY": 2,
@@ -3072,6 +3154,7 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 5,
       "pageX": 0,
       "pageY": 0,
@@ -3106,6 +3189,7 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 0,
       "pageY": 1,
@@ -3124,6 +3208,7 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 0,
       "pageY": 2,
@@ -3142,6 +3227,7 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 0,
       "pageY": 3,
@@ -3162,12 +3248,14 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 1,
       "pageY": 0,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 0,
         "pageY": 0,
@@ -3209,6 +3297,7 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 0,
         "pageY": 0,
@@ -3246,12 +3335,14 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 1,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 0,
         "pageY": 0,
@@ -3293,6 +3384,7 @@ exports[`extractLeftGrid should extract left data with first node expanded 1`] =
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 0,
         "pageY": 0,
@@ -3337,6 +3429,7 @@ exports[`extractLeftGrid should extract left data with no nodes expanded 1`] = `
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 0,
       "pageY": 0,
@@ -3355,6 +3448,7 @@ exports[`extractLeftGrid should extract left data with no nodes expanded 1`] = `
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 0,
       "pageY": 1,
@@ -3373,6 +3467,7 @@ exports[`extractLeftGrid should extract left data with no nodes expanded 1`] = `
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 0,
       "pageY": 2,

--- a/src/pivot-table/data/__tests__/__snapshots__/extract-top.test.ts.snap
+++ b/src/pivot-table/data/__tests__/__snapshots__/extract-top.test.ts.snap
@@ -6,6 +6,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 0,
       "pageY": 0,
@@ -40,6 +41,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 1,
       "pageY": 0,
@@ -74,6 +76,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 6,
       "pageX": 2,
       "pageY": 0,
@@ -130,6 +133,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 3,
       "pageY": 0,
@@ -150,12 +154,14 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 0,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 0,
@@ -205,6 +211,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 0,
@@ -242,12 +249,14 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 1,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 0,
@@ -297,6 +306,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 0,
@@ -334,12 +344,14 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 2,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -411,6 +423,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -470,12 +483,14 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 5,
       "pageX": 3,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -554,6 +569,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -615,18 +631,21 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 0,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 1,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 0,
           "pageY": 0,
@@ -676,6 +695,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 0,
           "pageY": 0,
@@ -720,6 +740,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 0,
@@ -757,18 +778,21 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 1,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 1,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 1,
           "pageY": 0,
@@ -818,6 +842,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 1,
           "pageY": 0,
@@ -862,6 +887,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 0,
@@ -899,18 +925,21 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 2,
         "pageY": 1,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 2,
           "pageY": 0,
@@ -982,6 +1011,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 2,
           "pageY": 0,
@@ -1048,6 +1078,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -1107,18 +1138,21 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 3,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 3,
         "pageY": 1,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 2,
           "pageY": 0,
@@ -1197,6 +1231,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 2,
           "pageY": 0,
@@ -1263,6 +1298,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -1322,18 +1358,21 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
     "4": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 4,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 3,
         "pageY": 1,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 2,
           "pageY": 0,
@@ -1412,6 +1451,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 2,
           "pageY": 0,
@@ -1478,6 +1518,7 @@ exports[`extractTop should extract top data when data tree has a depth of 2 1`] 
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -1544,6 +1585,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 0,
       "pageX": 0,
       "pageY": 0,
@@ -1562,6 +1604,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 0,
       "pageX": 1,
       "pageY": 0,
@@ -1580,6 +1623,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 0,
       "pageX": 2,
       "pageY": 0,
@@ -1598,6 +1642,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 3,
       "pageY": 0,
@@ -1618,12 +1663,14 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 0,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 0,
@@ -1673,6 +1720,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 0,
@@ -1710,12 +1758,14 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 1,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 0,
@@ -1765,6 +1815,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 0,
@@ -1802,12 +1853,14 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 4,
       "pageX": 2,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -1879,6 +1932,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -1938,12 +1992,14 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 5,
       "pageX": 3,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -2022,6 +2078,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -2083,18 +2140,21 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 0,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 1,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 0,
           "pageY": 0,
@@ -2144,6 +2204,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 0,
           "pageY": 0,
@@ -2188,6 +2249,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 0,
         "pageY": 0,
@@ -2225,18 +2287,21 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 1,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 1,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 1,
           "pageY": 0,
@@ -2286,6 +2351,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 4,
           "pageX": 1,
           "pageY": 0,
@@ -2330,6 +2396,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 1,
         "pageY": 0,
@@ -2367,18 +2434,21 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 4,
         "pageX": 2,
         "pageY": 1,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 2,
           "pageY": 0,
@@ -2450,6 +2520,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 2,
           "pageY": 0,
@@ -2516,6 +2587,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -2575,18 +2647,21 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 3,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 3,
         "pageY": 1,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 2,
           "pageY": 0,
@@ -2665,6 +2740,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 2,
           "pageY": 0,
@@ -2731,6 +2807,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -2790,18 +2867,21 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
     "4": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 4,
       "pageY": 2,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 3,
         "pageY": 1,
         "parent": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 2,
           "pageY": 0,
@@ -2880,6 +2960,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
         "root": {
           "distanceToNextCell": 0,
           "incrementLeafCount": [Function],
+          "isLockedByDimension": false,
           "leafCount": 6,
           "pageX": 2,
           "pageY": 0,
@@ -2946,6 +3027,7 @@ exports[`extractTop should extract top data when in snapshot mode 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 6,
         "pageX": 2,
         "pageY": 0,
@@ -3012,6 +3094,7 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 5,
       "pageX": 0,
       "pageY": 0,
@@ -3046,6 +3129,7 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 1,
       "pageY": 0,
@@ -3064,6 +3148,7 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 0,
@@ -3082,6 +3167,7 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
     "3": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 3,
       "pageY": 0,
@@ -3102,12 +3188,14 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 0,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 0,
         "pageY": 0,
@@ -3149,6 +3237,7 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 0,
         "pageY": 0,
@@ -3186,12 +3275,14 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 1,
       "pageY": 1,
       "parent": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 0,
         "pageY": 0,
@@ -3233,6 +3324,7 @@ exports[`extractTop should extract top data with first node expanded 1`] = `
       "root": {
         "distanceToNextCell": 0,
         "incrementLeafCount": [Function],
+        "isLockedByDimension": false,
         "leafCount": 5,
         "pageX": 0,
         "pageY": 0,
@@ -3277,6 +3369,7 @@ exports[`extractTop should extract top data with no nodes expanded 1`] = `
     "0": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 0,
       "pageY": 0,
@@ -3295,6 +3388,7 @@ exports[`extractTop should extract top data with no nodes expanded 1`] = `
     "1": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 1,
       "pageY": 0,
@@ -3313,6 +3407,7 @@ exports[`extractTop should extract top data with no nodes expanded 1`] = `
     "2": {
       "distanceToNextCell": 0,
       "incrementLeafCount": [Function],
+      "isLockedByDimension": false,
       "leafCount": 3,
       "pageX": 2,
       "pageY": 0,

--- a/src/pivot-table/data/__tests__/extract-left.test.ts
+++ b/src/pivot-table/data/__tests__/extract-left.test.ts
@@ -1,9 +1,10 @@
 import NxDimCellType from "../../../types/QIX";
-import type { Cell, PageInfo } from "../../../types/types";
+import type { Cell, LayoutService, PageInfo } from "../../../types/types";
 import extractLeftGrid from "../extract-left";
 import createNodes from "./test-helper";
 
 describe("extractLeftGrid", () => {
+  let layoutService: LayoutService;
   const qArea = { qTop: 1 } as EngineAPI.INxDataAreaPage;
   const grid = [] as Cell[][];
   const pageInfo = {
@@ -11,10 +12,17 @@ describe("extractLeftGrid", () => {
     rowsPerPage: 100,
   } as PageInfo;
 
+  beforeEach(() => {
+    layoutService = {
+      isSnapshot: false,
+      sortedLeftDimensionInfo: [],
+    } as unknown as LayoutService;
+  });
+
   test("should handle empty qLeft array", () => {
     const qLeft: EngineAPI.INxPivotDimensionCell[] = [];
 
-    const left = extractLeftGrid(grid, qLeft, qArea, pageInfo, false);
+    const left = extractLeftGrid(grid, qLeft, qArea, pageInfo, layoutService);
 
     expect(left).toHaveLength(0);
   });
@@ -22,7 +30,7 @@ describe("extractLeftGrid", () => {
   test("should extract left data with no nodes expanded", () => {
     const rowCount = 3;
     const qLeft = createNodes(rowCount, NxDimCellType.NX_DIM_CELL_NORMAL);
-    const left = extractLeftGrid(grid, qLeft, qArea, pageInfo, false);
+    const left = extractLeftGrid(grid, qLeft, qArea, pageInfo, layoutService);
 
     expect(left).toMatchSnapshot();
   });
@@ -34,7 +42,7 @@ describe("extractLeftGrid", () => {
     const subNodes = createNodes(subNodesCount, NxDimCellType.NX_DIM_CELL_NORMAL);
     qLeft[0].qSubNodes = subNodes;
     qLeft[0].qCanCollapse = true;
-    const left = extractLeftGrid(grid, qLeft, qArea, pageInfo, false);
+    const left = extractLeftGrid(grid, qLeft, qArea, pageInfo, layoutService);
 
     expect(left).toMatchSnapshot();
   });
@@ -56,15 +64,16 @@ describe("extractLeftGrid", () => {
     qLeft[2].qSubNodes[1].qSubNodes = createNodes(subNodesCount, NxDimCellType.NX_DIM_CELL_NORMAL);
     qLeft[2].qSubNodes[1].qCanCollapse = true;
 
-    const left = extractLeftGrid(grid, qLeft, qArea, pageInfo, false);
+    const left = extractLeftGrid(grid, qLeft, qArea, pageInfo, layoutService);
 
     expect(left).toMatchSnapshot();
   });
 
   test("should extract left data when in snapshot mode", () => {
+    layoutService.isSnapshot = true;
     const rowCount = 3;
     const qLeft = createNodes(rowCount, NxDimCellType.NX_DIM_CELL_NORMAL);
-    const left = extractLeftGrid(grid, qLeft, qArea, pageInfo, true);
+    const left = extractLeftGrid(grid, qLeft, qArea, pageInfo, layoutService);
 
     expect(left).toMatchSnapshot();
   });

--- a/src/pivot-table/data/__tests__/extract-top.test.ts
+++ b/src/pivot-table/data/__tests__/extract-top.test.ts
@@ -1,16 +1,24 @@
 import NxDimCellType from "../../../types/QIX";
-import type { Cell } from "../../../types/types";
+import type { Cell, LayoutService } from "../../../types/types";
 import extractTopGrid from "../extract-top";
 import createNodes from "./test-helper";
 
 describe("extractTop", () => {
+  let layoutService: LayoutService;
   const qArea = { qLeft: 1 } as EngineAPI.INxDataAreaPage;
   const grid = [] as Cell[][];
+
+  beforeEach(() => {
+    layoutService = {
+      isSnapshot: false,
+      sortedTopDimensionInfo: [],
+    } as unknown as LayoutService;
+  });
 
   test("should handle empty qTop array", () => {
     const qTop: EngineAPI.INxPivotDimensionCell[] = [];
 
-    const top = extractTopGrid(grid, qTop, qArea, false);
+    const top = extractTopGrid(grid, qTop, qArea, layoutService);
 
     expect(top).toHaveLength(0);
   });
@@ -19,7 +27,7 @@ describe("extractTop", () => {
     const colCount = 3;
     const qTop = createNodes(colCount, NxDimCellType.NX_DIM_CELL_NORMAL);
 
-    const top = extractTopGrid(grid, qTop, qArea, false);
+    const top = extractTopGrid(grid, qTop, qArea, layoutService);
 
     expect(top).toMatchSnapshot();
   });
@@ -32,7 +40,7 @@ describe("extractTop", () => {
     qTop[0].qSubNodes = subNodes;
     qTop[0].qCanCollapse = true;
 
-    const top = extractTopGrid(grid, qTop, qArea, false);
+    const top = extractTopGrid(grid, qTop, qArea, layoutService);
 
     expect(top).toMatchSnapshot();
   });
@@ -51,16 +59,17 @@ describe("extractTop", () => {
     qTop[2].qSubNodes[0].qSubNodes = createNodes(1, NxDimCellType.NX_DIM_CELL_EMPTY);
     qTop[2].qSubNodes[1].qSubNodes = createNodes(2, NxDimCellType.NX_DIM_CELL_NORMAL);
 
-    const top = extractTopGrid(grid, qTop, qArea, false);
+    const top = extractTopGrid(grid, qTop, qArea, layoutService);
 
     expect(top).toMatchSnapshot();
   });
 
   test("should extract top data when in snapshot mode", () => {
+    layoutService.isSnapshot = true;
     const colCount = 3;
     const qTop = createNodes(colCount, NxDimCellType.NX_DIM_CELL_NORMAL);
 
-    const top = extractTopGrid(grid, qTop, qArea, true);
+    const top = extractTopGrid(grid, qTop, qArea, layoutService);
 
     expect(top).toMatchSnapshot();
   });

--- a/src/pivot-table/data/__tests__/left-dimension-data.test.ts
+++ b/src/pivot-table/data/__tests__/left-dimension-data.test.ts
@@ -30,7 +30,8 @@ describe("left dimension data", () => {
     layout: {
       qHyperCube,
     },
-  } as LayoutService;
+    sortedLeftDimensionInfo: [],
+  } as unknown as LayoutService;
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -42,13 +43,7 @@ describe("left dimension data", () => {
       mockedExtractLeft.mockReturnValue(mockedReturnValue);
       const data = createLeftDimensionData(dataPage, layoutService, pageInfo);
 
-      expect(mockedExtractLeft).toHaveBeenCalledWith(
-        [],
-        dataPage.qLeft,
-        dataPage.qArea,
-        pageInfo,
-        layoutService.isSnapshot
-      );
+      expect(mockedExtractLeft).toHaveBeenCalledWith([], dataPage.qLeft, dataPage.qArea, pageInfo, layoutService);
       expect(data.grid).toEqual(mockedReturnValue);
       expect(data.dimensionInfoIndexMap).toEqual([0]);
       expect(data.columnCount).toEqual(1);
@@ -67,15 +62,9 @@ describe("left dimension data", () => {
           qTop: 3,
         },
       } as unknown as EngineAPI.INxPivotPage;
-      const nextData = addPageToLeftDimensionData({ prevData, nextDataPage, pageInfo });
+      const nextData = addPageToLeftDimensionData({ prevData, nextDataPage, pageInfo, layoutService });
 
-      expect(mockedExtractLeft).toHaveBeenCalledWith(
-        [],
-        dataPage.qLeft,
-        dataPage.qArea,
-        pageInfo,
-        layoutService.isSnapshot
-      );
+      expect(mockedExtractLeft).toHaveBeenCalledWith([], dataPage.qLeft, dataPage.qArea, pageInfo, layoutService);
       expect(nextData.grid).toEqual(nextLeft);
       expect(nextData.dimensionInfoIndexMap).toEqual([0]);
       expect(nextData.columnCount).toEqual(1);
@@ -92,7 +81,7 @@ describe("left dimension data", () => {
           qTop: 3,
         },
       } as unknown as EngineAPI.INxPivotPage;
-      const nextData = addPageToLeftDimensionData({ prevData, nextDataPage, pageInfo });
+      const nextData = addPageToLeftDimensionData({ prevData, nextDataPage, pageInfo, layoutService });
 
       expect(nextData).toBe(prevData);
     });

--- a/src/pivot-table/data/__tests__/top-dimension-data.test.ts
+++ b/src/pivot-table/data/__tests__/top-dimension-data.test.ts
@@ -58,7 +58,7 @@ describe("top dimension data", () => {
           qLeft: 3,
         },
       } as unknown as EngineAPI.INxPivotPage;
-      const nextData = addPageToTopDimensionData({ prevData, nextDataPage });
+      const nextData = addPageToTopDimensionData({ prevData, nextDataPage, layoutService });
 
       expect(nextData).not.toBe(prevData);
       expect(nextData.grid).toEqual(nextTop);
@@ -77,7 +77,7 @@ describe("top dimension data", () => {
           qLeft: 3,
         },
       } as unknown as EngineAPI.INxPivotPage;
-      const nextData = addPageToTopDimensionData({ prevData, nextDataPage });
+      const nextData = addPageToTopDimensionData({ prevData, nextDataPage, layoutService });
 
       expect(nextData).toBe(prevData);
     });

--- a/src/pivot-table/data/extract-left.ts
+++ b/src/pivot-table/data/extract-left.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 
-import type { Cell, Grid, PageInfo } from "../../types/types";
+import type { Cell, Grid, LayoutService, PageInfo } from "../../types/types";
 import createCell from "./helpers/create-cell";
 
 const extractLeftGrid = (
@@ -8,7 +8,7 @@ const extractLeftGrid = (
   qLeft: EngineAPI.INxPivotDimensionCell[],
   qArea: EngineAPI.INxDataAreaPage,
   pageInfo: PageInfo,
-  isSnapshot: boolean
+  layoutService: LayoutService
 ): Grid => {
   if (!qLeft.length) {
     return grid;
@@ -33,7 +33,16 @@ const extractLeftGrid = (
       // Start position + current page position - previous tail size,
       const pageY = Math.max(0, startPosition + rowIdx - node.qUp);
       const y = qArea.qTop + rowIdx - node.qUp;
-      const cell = createCell(node, parent, root, colIdx, y, pageY, isSnapshot);
+      const cell = createCell(
+        node,
+        parent,
+        root,
+        colIdx,
+        y,
+        pageY,
+        layoutService.isSnapshot,
+        layoutService.sortedLeftDimensionInfo[colIdx]
+      );
 
       grid[colIdx][pageY] = cell;
 

--- a/src/pivot-table/data/extract-top.ts
+++ b/src/pivot-table/data/extract-top.ts
@@ -1,13 +1,13 @@
 /* eslint-disable no-param-reassign */
 
-import type { Cell, Grid } from "../../types/types";
+import type { Cell, Grid, LayoutService } from "../../types/types";
 import createCell from "./helpers/create-cell";
 
 const extractTopGrid = (
   grid: Grid,
   qTop: EngineAPI.INxPivotDimensionCell[],
   qArea: EngineAPI.INxDataAreaPage,
-  isSnapshot: boolean
+  layoutService: LayoutService
 ): Grid => {
   if (!qTop.length) {
     return grid;
@@ -28,7 +28,16 @@ const extractTopGrid = (
     nodes.forEach((node, currColIdx) => {
       colIdx += currColIdx === 0 ? 0 : 1;
       const x = qArea.qLeft + colIdx - node.qUp; // Start position + current page position - previous tail size
-      const cell = createCell(node, parent, root, x, rowIdx, rowIdx, isSnapshot);
+      const cell = createCell(
+        node,
+        parent,
+        root,
+        x,
+        rowIdx,
+        rowIdx,
+        layoutService.isSnapshot,
+        layoutService.sortedTopDimensionInfo[rowIdx]
+      );
 
       grid[rowIdx][x] = cell;
 

--- a/src/pivot-table/data/helpers/create-cell.ts
+++ b/src/pivot-table/data/helpers/create-cell.ts
@@ -1,3 +1,4 @@
+import type { PseudoDimension } from "../../../types/QIX";
 import type { Cell } from "../../../types/types";
 
 const createCell = (
@@ -7,7 +8,8 @@ const createCell = (
   x: number,
   y: number,
   pageY: number,
-  isSnapshot: boolean
+  isSnapshot: boolean,
+  dimensionInfo: EngineAPI.INxDimensionInfo | PseudoDimension
 ): Cell => ({
   ref: node,
   x,
@@ -20,6 +22,7 @@ const createCell = (
   root,
   leafCount: isSnapshot ? 0 : node.qUp + node.qDown,
   distanceToNextCell: 0,
+  isLockedByDimension: typeof dimensionInfo === "object" && dimensionInfo.qLocked,
   incrementLeafCount() {
     this.leafCount += 1;
     if (parent) {

--- a/src/pivot-table/data/left-dimension-data.ts
+++ b/src/pivot-table/data/left-dimension-data.ts
@@ -8,17 +8,19 @@ export interface AddPageToLeftDimensionDataProps {
   nextDataPage: EngineAPI.INxPivotPage;
   pageInfo: PageInfo;
   isNewPage?: boolean;
+  layoutService: LayoutService;
 }
 
 export const addPageToLeftDimensionData = ({
   prevData,
   nextDataPage,
   pageInfo,
+  layoutService,
 }: AddPageToLeftDimensionDataProps): LeftDimensionData => {
   const { qLeft, qArea } = nextDataPage;
   if (!qLeft.length) return prevData;
 
-  const grid = extractLeftGrid(prevData.grid, qLeft, qArea, pageInfo, false);
+  const grid = extractLeftGrid(prevData.grid, qLeft, qArea, pageInfo, layoutService);
   assignDistanceToNextCell(grid, "pageY", prevData.layoutSize, pageInfo);
 
   return {
@@ -36,7 +38,7 @@ export const createLeftDimensionData = (
   const { qHyperCube } = layoutService.layout;
   const { qArea, qLeft } = dataPage;
   const { qEffectiveInterColumnSortOrder } = qHyperCube;
-  const grid = extractLeftGrid([], qLeft, qArea, pageInfo, layoutService.isSnapshot);
+  const grid = extractLeftGrid([], qLeft, qArea, pageInfo, layoutService);
   assignDistanceToNextCell(grid, "pageY", layoutService.size, pageInfo);
   const dimensionInfoIndexMap = grid.map(createDimInfoToIndexMapCallback(0, qEffectiveInterColumnSortOrder));
 

--- a/src/pivot-table/data/top-dimension-data.ts
+++ b/src/pivot-table/data/top-dimension-data.ts
@@ -6,16 +6,18 @@ import createDimInfoToIndexMapCallback from "./helpers/dimension-info-to-index-m
 export interface AddPageToTopDimensionDataProps {
   prevData: TopDimensionData;
   nextDataPage: EngineAPI.INxPivotPage;
+  layoutService: LayoutService;
 }
 
 export const addPageToTopDimensionData = ({
   prevData,
   nextDataPage,
+  layoutService,
 }: AddPageToTopDimensionDataProps): TopDimensionData => {
   const { qTop, qArea } = nextDataPage;
   if (!qTop.length) return prevData;
 
-  const grid = extractTopGrid(prevData.grid, qTop, qArea, false);
+  const grid = extractTopGrid(prevData.grid, qTop, qArea, layoutService);
   assignDistanceToNextCell(grid, "pageX", prevData.layoutSize);
 
   return {
@@ -32,7 +34,7 @@ export const createTopDimensionData = (
   const { qHyperCube } = layoutService.layout;
   const { qArea, qTop } = dataPage;
   const { qEffectiveInterColumnSortOrder, qNoOfLeftDims } = qHyperCube;
-  const grid = extractTopGrid([], qTop, qArea, layoutService.isSnapshot);
+  const grid = extractTopGrid([], qTop, qArea, layoutService);
   assignDistanceToNextCell(grid, "pageX", layoutService.size);
   const dimensionInfoIndexMap = grid.map(
     createDimInfoToIndexMapCallback(qNoOfLeftDims, qEffectiveInterColumnSortOrder)

--- a/src/pivot-table/hooks/__tests__/use-data.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-data.test.ts
@@ -148,11 +148,13 @@ describe("useData", () => {
     expect(mockedAddPageToTopDimensionData).toHaveBeenCalledWith({
       prevData: topDimensionData,
       nextDataPage: nextPage,
+      layoutService,
     });
     expect(mockedAddPageToLeftDimensionData).toHaveBeenCalledWith({
       prevData: leftDimensionData,
       nextDataPage: nextPage,
       pageInfo,
+      layoutService,
     });
     expect(mockedAddPageToMeasureData).toHaveBeenCalledWith({
       prevData: measureData,

--- a/src/pivot-table/hooks/use-data.ts
+++ b/src/pivot-table/hooks/use-data.ts
@@ -34,7 +34,7 @@ const useData = (qPivotDataPages: EngineAPI.INxPivotPage[], layoutService: Layou
       qPivotDataPages
         .slice(1)
         .reduce(
-          (prevData, nextDataPage) => addPageToTopDimensionData({ prevData, nextDataPage }),
+          (prevData, nextDataPage) => addPageToTopDimensionData({ prevData, nextDataPage, layoutService }),
           createTopDimensionData(qPivotDataPages[0], layoutService)
         ),
     [layoutService, qPivotDataPages]
@@ -45,7 +45,7 @@ const useData = (qPivotDataPages: EngineAPI.INxPivotPage[], layoutService: Layou
       qPivotDataPages
         .slice(1)
         .reduce(
-          (prevData, nextDataPage) => addPageToLeftDimensionData({ prevData, nextDataPage, pageInfo }),
+          (prevData, nextDataPage) => addPageToLeftDimensionData({ prevData, nextDataPage, pageInfo, layoutService }),
           createLeftDimensionData(qPivotDataPages[0], layoutService, pageInfo)
         ),
     [layoutService, qPivotDataPages, pageInfo]
@@ -72,8 +72,10 @@ const useData = (qPivotDataPages: EngineAPI.INxPivotPage[], layoutService: Layou
   useOnPropsChange(() => {
     if (!nextPage) return;
     setMeasureData((prevData) => addPageToMeasureData({ prevData, nextDataPage: nextPage, pageInfo }));
-    setTopDimensionData((prevData) => addPageToTopDimensionData({ prevData, nextDataPage: nextPage }));
-    setLeftDimensionData((prevData) => addPageToLeftDimensionData({ prevData, nextDataPage: nextPage, pageInfo }));
+    setTopDimensionData((prevData) => addPageToTopDimensionData({ prevData, nextDataPage: nextPage, layoutService }));
+    setLeftDimensionData((prevData) =>
+      addPageToLeftDimensionData({ prevData, nextDataPage: nextPage, pageInfo, layoutService })
+    );
     // we dont need dependency of pageInfo
     // this causes a rerender to add unrelevant data into grids
     // the reson for why we dont need it as dependancy is because

--- a/src/services/__tests__/layout-service.test.ts
+++ b/src/services/__tests__/layout-service.test.ts
@@ -5,7 +5,13 @@ import createLayoutService from "../layout-service";
 
 const getMeasureInfo = () => ({} as EngineAPI.INxMeasureInfo);
 
-const getDimensionInfo = (qLocked: boolean) => ({ qLocked } as EngineAPI.INxDimensionInfo);
+const getDimensionInfo = ({ qLocked, isVisible }: { qLocked?: boolean; isVisible?: boolean }) =>
+  ({
+    qLocked: !qLocked,
+    qCardinalities: {
+      qHypercubeCardinal: isVisible ? 1 : 0,
+    },
+  } as unknown as EngineAPI.INxDimensionInfo);
 
 describe("createLayoutService", () => {
   let layout: PivotLayout;
@@ -18,7 +24,10 @@ describe("createLayoutService", () => {
         qNoOfLeftDims: 1,
         qEffectiveInterColumnSortOrder: [0, 1, -1],
         qMeasureInfo: [getMeasureInfo()],
-        qDimensionInfo: [{ qLocked: false }, { qLocked: false }],
+        qDimensionInfo: [
+          getDimensionInfo({ qLocked: false, isVisible: true }),
+          getDimensionInfo({ qLocked: false, isVisible: true }),
+        ],
         qSize: {
           qcx: 100,
           qcy: 200,
@@ -73,46 +82,45 @@ describe("createLayoutService", () => {
     });
   });
 
-  describe("isDimensionLocked", () => {
-    test("should return true when left dimension is locked", () => {
-      layout.qHyperCube.qDimensionInfo = [getDimensionInfo(true), getDimensionInfo(false)];
-      const service = create();
-      expect(service.isDimensionLocked("L", 0, 0)).toEqual(true);
-    });
+  describe("sortedLeftDimensionInfo", () => {
+    test("should only include visibile dimensions and pseudo dimension", () => {
+      layout.qHyperCube.qEffectiveInterColumnSortOrder = [1, -1, 0, 2];
+      layout.qHyperCube.qNoOfLeftDims = 4;
+      layout.qHyperCube.qDimensionInfo = [
+        getDimensionInfo({ isVisible: true }),
+        getDimensionInfo({ isVisible: true }),
+        getDimensionInfo({ isVisible: false }),
+      ];
 
-    test("should return false when left dimension is not locked", () => {
-      layout.qHyperCube.qDimensionInfo = [getDimensionInfo(false), getDimensionInfo(true)];
       const service = create();
-      expect(service.isDimensionLocked("L", 0, 0)).toEqual(false);
-    });
 
-    test("should return false when dimension index does not exist for tyoe L", () => {
-      layout.qHyperCube.qDimensionInfo = [];
-      const service = create();
-      expect(service.isDimensionLocked("L", 0, 0)).toEqual(false);
+      expect(service.sortedTopDimensionInfo).toEqual([]);
+      expect(service.sortedLeftDimensionInfo).toEqual([
+        layout.qHyperCube.qDimensionInfo[layout.qHyperCube.qEffectiveInterColumnSortOrder[0]],
+        -1,
+        layout.qHyperCube.qDimensionInfo[layout.qHyperCube.qEffectiveInterColumnSortOrder[2]],
+      ]);
     });
+  });
 
-    test("should return true when top dimension is locked", () => {
-      layout.qHyperCube.qDimensionInfo = [getDimensionInfo(false), getDimensionInfo(true)];
-      const service = create();
-      expect(service.isDimensionLocked("T", 0, 0)).toEqual(true);
-    });
+  describe("sortedTopDimensionInfo", () => {
+    test("should only include visibile dimensions and pseudo dimension", () => {
+      layout.qHyperCube.qEffectiveInterColumnSortOrder = [1, -1, 0, 2];
+      layout.qHyperCube.qNoOfLeftDims = 0;
+      layout.qHyperCube.qDimensionInfo = [
+        getDimensionInfo({ isVisible: true }),
+        getDimensionInfo({ isVisible: true }),
+        getDimensionInfo({ isVisible: false }),
+      ];
 
-    test("should return false when top dimension is not locked", () => {
-      layout.qHyperCube.qDimensionInfo = [getDimensionInfo(true), getDimensionInfo(false)];
       const service = create();
-      expect(service.isDimensionLocked("T", 0, 0)).toEqual(false);
-    });
 
-    test("should return false when dimension index does not exist for type T", () => {
-      layout.qHyperCube.qDimensionInfo = [];
-      const service = create();
-      expect(service.isDimensionLocked("T", 0, 0)).toEqual(false);
-    });
-
-    test("should return false when cell type is not supported", () => {
-      const service = create();
-      expect(service.isDimensionLocked("D", 0, 0)).toEqual(false);
+      expect(service.sortedLeftDimensionInfo).toEqual([]);
+      expect(service.sortedTopDimensionInfo).toEqual([
+        layout.qHyperCube.qDimensionInfo[layout.qHyperCube.qEffectiveInterColumnSortOrder[0]],
+        -1,
+        layout.qHyperCube.qDimensionInfo[layout.qHyperCube.qEffectiveInterColumnSortOrder[2]],
+      ]);
     });
   });
 

--- a/src/services/utils/get-sorted-dimension-info.ts
+++ b/src/services/utils/get-sorted-dimension-info.ts
@@ -1,0 +1,26 @@
+import { PSEUDO_DIMENSION_INDEX } from "../../constants";
+import type { ExtendedDimensionInfo, PivotLayout, PseudoDimension } from "../../types/QIX";
+
+const filterPseudoAndVisibleDimensions = (qDim: ExtendedDimensionInfo | -1) =>
+  qDim === PSEUDO_DIMENSION_INDEX || qDim.qCardinalities.qHypercubeCardinal > 0;
+
+const getSortedDimensionInfo = (layout: PivotLayout) => {
+  const { qHyperCube } = layout;
+  const { qNoOfLeftDims, qEffectiveInterColumnSortOrder, qDimensionInfo } = qHyperCube;
+
+  const sortedDimensionInfo = qEffectiveInterColumnSortOrder.map((index) => {
+    if (index === PSEUDO_DIMENSION_INDEX) return PSEUDO_DIMENSION_INDEX;
+
+    return qDimensionInfo[index];
+  }) as (ExtendedDimensionInfo | PseudoDimension)[];
+
+  const sortedLeftDimensionInfo = sortedDimensionInfo.slice(0, qNoOfLeftDims).filter(filterPseudoAndVisibleDimensions);
+  const sortedTopDimensionInfo = sortedDimensionInfo.slice(qNoOfLeftDims).filter(filterPseudoAndVisibleDimensions);
+
+  return {
+    sortedLeftDimensionInfo,
+    sortedTopDimensionInfo,
+  };
+};
+
+export default getSortedDimensionInfo;

--- a/src/types/QIX.ts
+++ b/src/types/QIX.ts
@@ -19,6 +19,8 @@ export enum NxSelectionCellType {
   NX_CELL_LEFT = "L",
 }
 
+export type PseudoDimension = -1;
+
 type Size = {
   w: number;
   h: number;
@@ -128,6 +130,9 @@ export interface SnapshotLayout extends EngineAPI.IGenericObjectLayout {
 export interface ExtendedDimensionInfo extends EngineAPI.INxDimensionInfo {
   cId?: string;
   qLibraryId?: string;
+  qCardinalities: {
+    qHypercubeCardinal: number;
+  };
 }
 
 export type Model = EngineAPI.IGenericObject | EngineAPI.IGenericBookmark | undefined;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,5 @@
 import type { stardust } from "@nebula.js/stardust";
-import type { PivotLayout } from "./QIX";
+import type { ExtendedDimensionInfo, PivotLayout } from "./QIX";
 
 export type ExpandOrCollapser = (rowIndex: number, columnIndex: number) => void;
 
@@ -67,6 +67,7 @@ export interface Cell {
   leafCount: number;
   distanceToNextCell: number;
   incrementLeafCount: () => void;
+  isLockedByDimension: boolean;
 }
 
 export interface PivotDataSize {
@@ -140,13 +141,14 @@ export interface ViewService {
 
 export interface LayoutService {
   layout: PivotLayout;
-  isDimensionLocked: (qType: EngineAPI.NxSelectionCellType, qRow: number, qCol: number) => boolean;
   getMeasureInfoIndexFromCellIndex: (index: number) => number;
   getNullValueText: () => string;
   size: Point;
   isSnapshot: boolean;
   hasLimitedData: boolean;
   hasLeftDimensions: boolean;
+  sortedLeftDimensionInfo: (ExtendedDimensionInfo | -1)[];
+  sortedTopDimensionInfo: (ExtendedDimensionInfo | -1)[];
 }
 
 export interface DataService {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,5 @@
 import type { stardust } from "@nebula.js/stardust";
-import type { ExtendedDimensionInfo, PivotLayout } from "./QIX";
+import type { ExtendedDimensionInfo, PivotLayout, PseudoDimension } from "./QIX";
 
 export type ExpandOrCollapser = (rowIndex: number, columnIndex: number) => void;
 
@@ -147,8 +147,8 @@ export interface LayoutService {
   isSnapshot: boolean;
   hasLimitedData: boolean;
   hasLeftDimensions: boolean;
-  sortedLeftDimensionInfo: (ExtendedDimensionInfo | -1)[];
-  sortedTopDimensionInfo: (ExtendedDimensionInfo | -1)[];
+  sortedLeftDimensionInfo: (ExtendedDimensionInfo | PseudoDimension)[];
+  sortedTopDimensionInfo: (ExtendedDimensionInfo | PseudoDimension)[];
 }
 
 export interface DataService {


### PR DESCRIPTION
Fixes an issue where the background styling for a locked dimension was not rendered when the pseudo dimension was not at either the last row or column.

Also included:
* A minor performance improvement as the logic for checking if a cell is locked by the dimension is no longer run at every render. Instead only when new layout is received.
* `background` and `backgroundImage` style properties did not work well together in the DimensionCell component. Now only `background` is used.

TODO for another PR:
* Improve the support for custom background colors. Currently the background for a locked dimension does not take the background set by theme or styling panel into account.
* Remove `dimensionInfoIndexMap` as it should no longer be needed.

Before:
![Skärmavbild 2023-08-09 kl  12 32 27](https://github.com/qlik-oss/sn-pivot-table/assets/16608020/e77e57d9-343d-4592-8d61-806aaf8c5f9c)


After:
![Skärmavbild 2023-08-09 kl  12 28 03](https://github.com/qlik-oss/sn-pivot-table/assets/16608020/aa97b7e6-24ef-4d4a-8230-4bbab04668f4)
