### PR TITLE
feat: use effective properties

### DIFF
--- a/src/hooks/__tests__/use-effective-properties.test.ts
+++ b/src/hooks/__tests__/use-effective-properties.test.ts
@@ -1,0 +1,51 @@
+import * as nebula from "@nebula.js/stardust";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { Model, PivotLayout, SnapshotData } from "../../types/QIX";
+import useEffectiveProperties from "../use-effective-properties";
+
+jest.mock("@nebula.js/stardust");
+
+describe("useEffectiveProperties", () => {
+  let model: Model;
+  let layout: PivotLayout;
+  let effectiveProperties: EngineAPI.IGenericObjectProperties;
+
+  beforeEach(() => {
+    const usePromiseMock = (factory: () => Promise<unknown>) => [factory()] as unknown as [unknown, Error];
+    jest.spyOn(nebula, "usePromise").mockImplementation(usePromiseMock);
+
+    effectiveProperties = {
+      qShowTotalsAbove: true,
+    } as unknown as EngineAPI.IGenericObjectProperties;
+    layout = {} as PivotLayout;
+
+    model = {
+      getEffectiveProperties: () => Promise.resolve(effectiveProperties),
+    } as Model;
+  });
+
+  test("should load and return effective properties", async () => {
+    effectiveProperties = {} as EngineAPI.IGenericObjectProperties;
+    const { result } = renderHook(() => useEffectiveProperties(model, layout));
+
+    await waitFor(async () => {
+      const [pendingProps] = result.current;
+      const props = await (pendingProps as unknown as Promise<EngineAPI.IGenericObjectProperties>);
+
+      expect(props).toBe(effectiveProperties);
+    });
+  });
+
+  test("should not load effective properties for a snapshot", async () => {
+    effectiveProperties = {} as EngineAPI.IGenericObjectProperties;
+    layout.snapshotData = {} as SnapshotData;
+    const { result } = renderHook(() => useEffectiveProperties(model, layout));
+
+    await waitFor(async () => {
+      const [pendingProps] = result.current;
+      const props = await (pendingProps as unknown as Promise<EngineAPI.IGenericObjectProperties>);
+
+      expect(props).toEqual({});
+    });
+  });
+});

--- a/src/hooks/__tests__/use-effective-properties.test.ts
+++ b/src/hooks/__tests__/use-effective-properties.test.ts
@@ -24,7 +24,7 @@ describe("useEffectiveProperties", () => {
     } as Model;
   });
 
-  test("should load and return effective properties", async () => {
+  test("should fetch and return effective properties", async () => {
     effectiveProperties = {} as EngineAPI.IGenericObjectProperties;
     const { result } = renderHook(() => useEffectiveProperties(model, layout));
 
@@ -36,9 +36,36 @@ describe("useEffectiveProperties", () => {
     });
   });
 
-  test("should not load effective properties for a snapshot", async () => {
+  test("should not fetch effective properties for a snapshot", async () => {
     effectiveProperties = {} as EngineAPI.IGenericObjectProperties;
     layout.snapshotData = {} as SnapshotData;
+    const { result } = renderHook(() => useEffectiveProperties(model, layout));
+
+    await waitFor(async () => {
+      const [pendingProps] = result.current;
+      const props = await (pendingProps as unknown as Promise<EngineAPI.IGenericObjectProperties>);
+
+      expect(props).toEqual({});
+    });
+  });
+
+  test("should not fetch effective properties when model is undefined", async () => {
+    effectiveProperties = {} as EngineAPI.IGenericObjectProperties;
+    layout.snapshotData = {} as SnapshotData;
+    const { result } = renderHook(() => useEffectiveProperties(undefined, layout));
+
+    await waitFor(async () => {
+      const [pendingProps] = result.current;
+      const props = await (pendingProps as unknown as Promise<EngineAPI.IGenericObjectProperties>);
+
+      expect(props).toEqual({});
+    });
+  });
+
+  test("should not fetch effective properties when model does not have getEffectiveProperties method", async () => {
+    effectiveProperties = {} as EngineAPI.IGenericObjectProperties;
+    layout.snapshotData = {} as SnapshotData;
+    model = {} as EngineAPI.IGenericBookmark;
     const { result } = renderHook(() => useEffectiveProperties(model, layout));
 
     await waitFor(async () => {

--- a/src/hooks/use-effective-properties.ts
+++ b/src/hooks/use-effective-properties.ts
@@ -1,0 +1,14 @@
+import { usePromise } from "@nebula.js/stardust";
+import type { Model, PivotLayout } from "../types/QIX";
+
+const useEffectiveProperties = (model: Model, layout: PivotLayout) =>
+  usePromise<EngineAPI.IGenericObjectProperties | undefined>(async () => {
+    if (layout.snapshotData) {
+      // Is snapshot
+      return {} as EngineAPI.IGenericObjectProperties;
+    }
+
+    return (model as EngineAPI.IGenericObject).getEffectiveProperties();
+  }, [model, layout]);
+
+export default useEffectiveProperties;

--- a/src/hooks/use-effective-properties.ts
+++ b/src/hooks/use-effective-properties.ts
@@ -3,12 +3,12 @@ import type { Model, PivotLayout } from "../types/QIX";
 
 const useEffectiveProperties = (model: Model, layout: PivotLayout) =>
   usePromise<EngineAPI.IGenericObjectProperties | undefined>(async () => {
-    if (layout.snapshotData) {
+    if (model === undefined || layout.snapshotData || !("getEffectiveProperties" in model)) {
       // Is snapshot
       return {} as EngineAPI.IGenericObjectProperties;
     }
 
-    return (model as EngineAPI.IGenericObject).getEffectiveProperties();
+    return model.getEffectiveProperties();
   }, [model, layout]);
 
 export default useEffectiveProperties;

--- a/src/hooks/use-layout-service.ts
+++ b/src/hooks/use-layout-service.ts
@@ -3,6 +3,9 @@ import createLayoutService from "../services/layout-service";
 import type { PivotLayout } from "../types/QIX";
 import type { LayoutService } from "../types/types";
 
-const useLayoutService = (layout: PivotLayout): LayoutService => useMemo(() => createLayoutService(layout), [layout]);
+const useLayoutService = (
+  layout: PivotLayout,
+  effectiveProperties: EngineAPI.IGenericObjectProperties | undefined
+): LayoutService => useMemo(() => createLayoutService(layout, effectiveProperties), [layout, effectiveProperties]);
 
 export default useLayoutService;

--- a/src/hooks/use-load-data-pages.ts
+++ b/src/hooks/use-load-data-pages.ts
@@ -71,7 +71,7 @@ const useLoadDataPages: UseLoadDataPages = ({ model, layoutService, viewService,
     }
 
     ref.isLoading = false;
-  }, [layoutService.layout, model, viewService, snapshotData, pageInfo]);
+  }, [layoutService, model, viewService, snapshotData, pageInfo]);
 
   return {
     qPivotDataPages,

--- a/src/hooks/use-render.ts
+++ b/src/hooks/use-render.ts
@@ -13,6 +13,7 @@ import render from "../pivot-table/Root";
 import createStyleService from "../services/style-service";
 import type { Model, PivotLayout } from "../types/QIX";
 import type { ExtendedSelections, ExtendedTheme } from "../types/types";
+import useEffectiveProperties from "./use-effective-properties";
 import useLayoutService from "./use-layout-service";
 import useLoadDataPages from "./use-load-data-pages";
 import usePagination from "./use-pagination";
@@ -28,7 +29,8 @@ const useRender = () => {
   const layout = useStaleLayout() as PivotLayout;
   const model = useModel() as Model;
   const constraints = useConstraints();
-  const layoutService = useLayoutService(layout);
+  const [effectiveProperties] = useEffectiveProperties(model, layout);
+  const layoutService = useLayoutService(layout, effectiveProperties);
   const selections = useSelections() as ExtendedSelections;
   const theme = useTheme() as ExtendedTheme;
   const { translator, language } = useTranslations();
@@ -64,6 +66,7 @@ const useRender = () => {
       layoutService &&
       styleService &&
       !!qPivotDataPages &&
+      effectiveProperties &&
       isFontLoaded;
 
     if (!isReadyToRender) return;
@@ -99,6 +102,7 @@ const useRender = () => {
     language,
     pageInfo,
     updatePageInfo,
+    effectiveProperties,
   ]);
 };
 

--- a/src/services/__tests__/layout-service.test.ts
+++ b/src/services/__tests__/layout-service.test.ts
@@ -16,6 +16,7 @@ const getDimensionInfo = ({ qLocked, isVisible }: { qLocked?: boolean; isVisible
 describe("createLayoutService", () => {
   let layout: PivotLayout;
   let create: () => LayoutService;
+  let effectiveProperties: EngineAPI.IGenericObjectProperties | undefined;
 
   beforeEach(() => {
     layout = {
@@ -35,7 +36,7 @@ describe("createLayoutService", () => {
       },
     } as PivotLayout;
 
-    create = () => createLayoutService(layout);
+    create = () => createLayoutService(layout, effectiveProperties);
   });
 
   describe("getNullValueText", () => {
@@ -137,6 +138,33 @@ describe("createLayoutService", () => {
       layout.qHyperCube.qNoOfLeftDims = 0;
       const service = create();
       expect(service.hasLeftDimensions).toBe(false);
+    });
+  });
+
+  describe("showTotalsAbove", () => {
+    test("should be false when property is false", () => {
+      effectiveProperties = {
+        qHyperCubeDef: { qShowTotalsAbove: false },
+      } as unknown as EngineAPI.IGenericObjectProperties;
+
+      const service = create();
+      expect(service.showTotalsAbove).toBe(false);
+    });
+
+    test("should be true when property is true", () => {
+      effectiveProperties = {
+        qHyperCubeDef: { qShowTotalsAbove: true },
+      } as unknown as EngineAPI.IGenericObjectProperties;
+
+      const service = create();
+      expect(service.showTotalsAbove).toBe(true);
+    });
+
+    test("should be false when effective properties is undefined", () => {
+      effectiveProperties = undefined;
+
+      const service = create();
+      expect(service.showTotalsAbove).toBe(false);
     });
   });
 });

--- a/src/services/layout-service.ts
+++ b/src/services/layout-service.ts
@@ -3,7 +3,10 @@ import { MAX_COLUMN_COUNT, MAX_ROW_COUNT } from "../pivot-table/constants";
 import { type PivotLayout } from "../types/QIX";
 import type { LayoutService } from "../types/types";
 
-const createLayoutService = (layout: PivotLayout): LayoutService => {
+const createLayoutService = (
+  layout: PivotLayout,
+  effectiveProperties: EngineAPI.IGenericObjectProperties | undefined
+): LayoutService => {
   const { qHyperCube, nullValueRepresentation, snapshotData } = layout;
   const { qNoOfLeftDims, qEffectiveInterColumnSortOrder, qMeasureInfo } = qHyperCube;
   const isSnapshot = !!snapshotData;
@@ -28,6 +31,8 @@ const createLayoutService = (layout: PivotLayout): LayoutService => {
     isSnapshot,
     hasLimitedData: !isSnapshot && size.x < layout.qHyperCube.qSize.qcx,
     hasLeftDimensions: layout.qHyperCube.qNoOfLeftDims !== 0,
+    // qShowTotalsAbove is not available on the layout, so it's read from effective properties instead
+    showTotalsAbove: !!effectiveProperties?.qHyperCubeDef?.qShowTotalsAbove,
   };
 };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -145,6 +145,7 @@ export interface LayoutService {
   isSnapshot: boolean;
   hasLimitedData: boolean;
   hasLeftDimensions: boolean;
+  showTotalsAbove: boolean;
 }
 
 export interface DataService {


### PR DESCRIPTION
Adding a hook to fetch effective properties so that the value `qShowTotalsAbove` can be read. It's needed for the "Total at bottom/top" feature.