### PR TITLE
chore: limit the peer deps to minor and patch range

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,7 +1,7 @@
 {
   "module": "esm/index.js",
   "peerDependencies": {
-    "@nebula.js/stardust": ">=4.4.0",
+    "@nebula.js/stardust": "^4.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -125,8 +125,8 @@
     "typescript": "5.2.2"
   },
   "peerDependencies": {
-    "@nebula.js/stardust": ">=4.4.0",
-    "@qlik-trial/sprout": ">=2.51.0"
+    "@nebula.js/stardust": "^4.4.0",
+    "@qlik-trial/sprout": "^3.4.0"
   },
   "packageManager": "yarn@1.22.19",
   "engines": {


### PR DESCRIPTION
Not sure why different major versions was allowed. Unless someone knows a good reason for it suggest we limit it to minor range.