### PR TITLE
chore: nebula build typescript warnings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@
 module.exports = {
   collectCoverage: true,
   coverageDirectory: "coverage",
-  setupFilesAfterEnv: ["<rootDir>/jest/setup.js"],
+  setupFilesAfterEnv: ["<rootDir>/jest/setup.ts"],
   testEnvironment: "jsdom",
   testMatch: ["**/src/**/__tests__/*.test.ts?(x)"],
   transformIgnorePatterns: ["<rootDir>/node_modules/(?!(@qlik-trial/sprout|@qlik-oss/nebula-table-utils)/)"],

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -1,5 +1,0 @@
-import "@testing-library/jest-dom";
-
-global.document.fonts = {
-  load: async () => Promise.resolve(true),
-};

--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -1,0 +1,11 @@
+import "@testing-library/jest-dom";
+
+type MockDocument = {
+  fonts: {
+    load: () => Promise<FontFace[]>;
+  };
+};
+
+(global.document as unknown as MockDocument).fonts = {
+  load: async () => Promise.resolve([]),
+};

--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -6,6 +6,7 @@ type MockDocument = {
   };
 };
 
+// Custom type otherwise you would get a typescript error as fonts is a read-only property.
 (global.document as unknown as MockDocument).fonts = {
   load: async () => Promise.resolve([]),
 };


### PR DESCRIPTION
When building using nebula using the `build` or `serve` command. A bunch of warnings where logged for missing types from `@testing-library/jest-dom`. This PR attempts to fix that. I'm not entirely sure why the recently started to appear.

Some of the warnings logged:
```
(typescript plugin) src/pivot-table/components/cells/__tests__/DimensionTitleCell.test.tsx (19:34) @rollup/plugin-typescript TS2339: Property 'toBeInTheDocument' does not exist on type 'JestMatchers<HTMLElement>'.
(typescript plugin) src/pivot-table/components/cells/__tests__/DimensionTitleCell.test.tsx (20:38) @rollup/plugin-typescript TS2339: Property 'toHaveStyle' does not exist on type 'JestMatchers<HTMLElement>'.
(typescript plugin) src/pivot-table/components/cells/__tests__/EmptyCell.test.tsx (19:15) @rollup/plugin-typescript TS2339: Property 'toBeInTheDocument' does not exist on type 'JestMatchers<HTMLElement>'.
(typescript plugin) src/pivot-table/components/cells/__tests__/EmptyCell.test.tsx (20:15) @rollup/plugin-typescript TS2339: Property 'toHaveStyle' does not exist on type 'JestMatchers<HTMLElement>'.
(typescript plugin) src/pivot-table/components/cells/__tests__/PseudoDimensionCell.test.tsx (32:36) @rollup/plugin-typescript TS2339: Property 'toBeInTheDocument' does not exist on type 'JestMatchers<HTMLElement>'.
(typescript plugin) src/pivot-table/components/cells/__tests__/PseudoDimensionCell.test.tsx (33:38) @rollup/plugin-typescript TS2339: Property 'toHaveStyle' does not exist on type 'JestMatchers<HTMLElement>'.
(typescript plugin) src/pivot-table/components/cells/__tests__/PseudoDimensionCell.test.tsx (50:36) @rollup/plugin-typescript TS2339: Property 'toBeInTheDocument' does not exist on type 'JestMatchers<HTMLElement>'.
(typescript plugin) src/pivot-table/components/cells/__tests__/PseudoDimensionCell.test.tsx (51:38) @rollup/plugin-typescript TS2339: Property 'toHaveStyle' does not exist on type 'JestMatchers<HTMLElement>'.
(typescript plugin) src/pivot-table/components/cells/__tests__/PseudoDimensionCell.test.tsx (52:42) @rollup/plugin-typescript TS2339: Property 'toHaveStyle' does not exist on type 'Matchers<void, HTMLElement>'.
(typescript plugin) src/pivot-table/components/cells/__tests__/TotalsCell.test.tsx (20:44) @rollup/plugin-typescript TS2339: Property 'toBeInTheDocument' does not exist on type 'JestMatchers<HTMLElement>'.
(typescript plugin) src/pivot-table/components/cells/__tests__/TotalsCell.test.tsx (21:38) @rollup/plugin-typescript TS2339: Property 'toHaveStyle' does not exist on type 'JestMatchers<HTMLElement>'.
```

