### PR TITLE
refactor: smarter args for measure text

### DIFF
--- a/src/pivot-table/hooks/__tests__/use-column-width.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-column-width.test.ts
@@ -1,7 +1,14 @@
 import { renderHook } from "@testing-library/react";
 import type { ExtendedDimensionInfo } from "../../../types/QIX";
 import NxDimCellType from "../../../types/QIX";
-import type { Cell, LayoutService, LeftDimensionData, Rect, VisibleDimensionInfo } from "../../../types/types";
+import type {
+  Cell,
+  LayoutService,
+  LeftDimensionData,
+  MeasureTextStyling,
+  Rect,
+  VisibleDimensionInfo,
+} from "../../../types/types";
 import { GRID_BORDER } from "../../constants";
 import useColumnWidth, { EXPAND_ICON_WIDTH } from "../use-column-width";
 import useMeasureText, { type MeasureTextHook } from "../use-measure-text";
@@ -11,7 +18,7 @@ jest.mock("../../contexts/StyleProvider");
 
 describe("useColumnWidth", () => {
   let rect: Rect;
-  let mockedUseMeasureText: jest.MockedFunction<(size: string, fam: string) => MeasureTextHook>;
+  let mockedUseMeasureText: jest.MockedFunction<(styling: MeasureTextStyling) => MeasureTextHook>;
   let leftDimensionData: LeftDimensionData;
   let mockedMeasureText: MeasureTextHook;
   let layoutService: LayoutService;

--- a/src/pivot-table/hooks/__tests__/use-column-width.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-column-width.test.ts
@@ -1,14 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import type { ExtendedDimensionInfo } from "../../../types/QIX";
 import NxDimCellType from "../../../types/QIX";
-import type {
-  Cell,
-  LayoutService,
-  LeftDimensionData,
-  MeasureTextStyling,
-  Rect,
-  VisibleDimensionInfo,
-} from "../../../types/types";
+import type { Cell, LayoutService, LeftDimensionData, Rect, VisibleDimensionInfo } from "../../../types/types";
 import { GRID_BORDER } from "../../constants";
 import useColumnWidth, { EXPAND_ICON_WIDTH } from "../use-column-width";
 import useMeasureText, { type MeasureTextHook } from "../use-measure-text";
@@ -18,7 +11,7 @@ jest.mock("../../contexts/StyleProvider");
 
 describe("useColumnWidth", () => {
   let rect: Rect;
-  let mockedUseMeasureText: jest.MockedFunction<(styling: MeasureTextStyling) => MeasureTextHook>;
+  let mockedUseMeasureText: jest.MockedFunction<(styling: { fontSize: string; fontFamily: string }) => MeasureTextHook>;
   let leftDimensionData: LeftDimensionData;
   let mockedMeasureText: MeasureTextHook;
   let layoutService: LayoutService;

--- a/src/pivot-table/hooks/__tests__/use-measure-text.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-measure-text.test.ts
@@ -1,10 +1,9 @@
 import { renderHook } from "@testing-library/react";
-import type { MeasureTextStyling } from "../../../types/types";
 import useMeasureText from "../use-measure-text";
 
 describe("useMeasureText", () => {
   let measureTextMock: jest.MockedFunction<(text: string) => TextMetrics>;
-  const styling = { fontSize: "13px", fontFamily: "font" } as MeasureTextStyling;
+  const styling = { fontSize: "13px", fontFamily: "font" };
 
   beforeEach(() => {
     measureTextMock = jest.fn() as jest.MockedFunction<(text: string) => TextMetrics>;

--- a/src/pivot-table/hooks/__tests__/use-measure-text.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-measure-text.test.ts
@@ -1,8 +1,10 @@
 import { renderHook } from "@testing-library/react";
+import type { MeasureTextStyling } from "../../../types/types";
 import useMeasureText from "../use-measure-text";
 
 describe("useMeasureText", () => {
   let measureTextMock: jest.MockedFunction<(text: string) => TextMetrics>;
+  const styling = { fontSize: "13px", fontFamily: "font" } as MeasureTextStyling;
 
   beforeEach(() => {
     measureTextMock = jest.fn() as jest.MockedFunction<(text: string) => TextMetrics>;
@@ -19,7 +21,7 @@ describe("useMeasureText", () => {
   describe("estimateWidth", () => {
     test("should estimate width", () => {
       measureTextMock.mockReturnValue({ width: 150 } as TextMetrics);
-      const { result } = renderHook(() => useMeasureText("13px", "font"));
+      const { result } = renderHook(() => useMeasureText(styling));
 
       expect(result.current.estimateWidth(2)).toBe(300);
     });
@@ -28,7 +30,7 @@ describe("useMeasureText", () => {
   describe("measureText", () => {
     test("should measure width", () => {
       measureTextMock.mockReturnValue({ width: 150 } as TextMetrics);
-      const { result } = renderHook(() => useMeasureText("13px", "font"));
+      const { result } = renderHook(() => useMeasureText(styling));
 
       expect(result.current.measureText("some string")).toBe(175);
     });

--- a/src/pivot-table/hooks/use-column-width.ts
+++ b/src/pivot-table/hooks/use-column-width.ts
@@ -34,13 +34,9 @@ export default function useColumnWidth(
   } = layoutService;
   const styleService = useStyleContext();
   const { estimateWidth: estimateWidthForContent, measureText: measureTextForContent } = useMeasureText(
-    styleService.content.fontSize,
-    styleService.content.fontFamily,
+    styleService.content,
   );
-  const { measureText: measureTextForHeader } = useMeasureText(
-    styleService.header.fontSize,
-    styleService.header.fontFamily,
-  );
+  const { measureText: measureTextForHeader } = useMeasureText(styleService.header);
 
   const hasPseudoDimOnLeft = useMemo(() => visibleLeftDimensionInfo.includes(-1), [visibleLeftDimensionInfo]);
 

--- a/src/pivot-table/hooks/use-measure-text.ts
+++ b/src/pivot-table/hooks/use-measure-text.ts
@@ -1,8 +1,12 @@
 import { memoize } from "qlik-chart-modules";
 import { useCallback, useMemo, useRef } from "react";
-import type { MeasureTextStyling } from "../../types/types";
 
 type MeasureText = (text: string) => TextMetrics;
+
+export interface MeasureTextStyling {
+  fontSize: string;
+  fontFamily: string;
+}
 
 export interface MeasureTextHook {
   estimateWidth: (length: number) => number;

--- a/src/pivot-table/hooks/use-measure-text.ts
+++ b/src/pivot-table/hooks/use-measure-text.ts
@@ -1,5 +1,6 @@
 import { memoize } from "qlik-chart-modules";
 import { useCallback, useMemo, useRef } from "react";
+import type { MeasureTextStyling } from "../../types/types";
 
 type MeasureText = (text: string) => TextMetrics;
 
@@ -12,7 +13,7 @@ const MAGIC_DEFAULT_CHAR = "M";
 
 const LEEWAY_WIDTH = 25; // Used to make sure there is some leeway in the measurement of a text
 
-export default function useMeasureText(fontSize: string, fontFamily: string): MeasureTextHook {
+export default function useMeasureText({ fontSize, fontFamily }: MeasureTextStyling): MeasureTextHook {
   const context = useRef<CanvasRenderingContext2D | null>(null);
 
   useMemo(() => {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -222,6 +222,8 @@ interface DimensionContentStyling extends FontStyling {
   measureLabel: CellStyling;
 }
 
+export type MeasureTextStyling = HeaderStyling | MeasureContentStyling | DimensionContentStyling;
+
 interface GridStyling {
   rowHeight: "compact";
   lineCount: number;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -222,8 +222,6 @@ interface DimensionContentStyling extends FontStyling {
   measureLabel: CellStyling;
 }
 
-export type MeasureTextStyling = HeaderStyling | MeasureContentStyling | DimensionContentStyling;
-
 interface GridStyling {
   rowHeight: "compact";
   lineCount: number;


### PR DESCRIPTION
Basically breaking out this: https://github.com/qlik-oss/sn-pivot-table/pull/287/files#diff-ec18bf142eff172651b535422a1a8fa75c79d87588adbc461acef39767dc630eR42-R43. Will be more needed as of that PR, since we take more styling into account.

Passing the whole styling object since we always use the size and fontFamliy from a specific part of the chart (rowContent, header etc). This would also simplify if we would need other styling as well, potentially bold for example