### PR TITLE
refactor: simpler logic for border width

### DIFF
--- a/src/pivot-table/components/__tests__/shared-styles.test.ts
+++ b/src/pivot-table/components/__tests__/shared-styles.test.ts
@@ -1,54 +1,36 @@
-import {
-  borderBottomRightStyle,
-  borderBottomStyle,
-  borderRightStyle,
-  cellStyle,
-  getBorderStyle,
-} from "../shared-styles";
-
-const borderColor = "red";
+import { borderStyle, cellStyle, getBorderStyle } from "../shared-styles";
 
 describe("Shared styles", () => {
   describe("getBorderStyle", () => {
+    const borderColor = "red";
+    const baseStyle = { ...cellStyle, ...borderStyle, borderColor, borderWidth: 0 };
+    const noBorder = { ...baseStyle, borderRightWidth: 0, borderBottomWidth: 0 };
+    const borderRight = { ...baseStyle, borderRightWidth: 1, borderBottomWidth: 0 };
+    const borderBottom = { ...baseStyle, borderRightWidth: 0, borderBottomWidth: 1 };
+    const borderRightBottom = { ...baseStyle, borderRightWidth: 1, borderBottomWidth: 1 };
+
     test("should resolve style for last row and last column while `showLastRowBorderBottom` is true", () => {
-      expect(getBorderStyle(true, true, borderColor, true)).toEqual({
-        ...borderBottomStyle,
-        borderBottomColor: borderColor,
-      });
+      expect(getBorderStyle(true, true, borderColor, true)).toEqual(borderBottom);
     });
 
     test("should resolve style for last row and last column", () => {
-      expect(getBorderStyle(true, true, borderColor, false)).toBe(cellStyle);
+      expect(getBorderStyle(true, true, borderColor, false)).toEqual(noBorder);
     });
 
     test("should resolve style for last row while `showLastRowBorderBottom` is true", () => {
-      expect(getBorderStyle(true, false, borderColor, true)).toEqual({
-        ...borderBottomRightStyle,
-        borderBottomColor: borderColor,
-        borderRightColor: borderColor,
-      });
+      expect(getBorderStyle(true, false, borderColor, true)).toEqual(borderRightBottom);
     });
 
     test("should resolve style for last row", () => {
-      expect(getBorderStyle(true, false, borderColor, false)).toEqual({
-        ...borderRightStyle,
-        borderRightColor: borderColor,
-      });
+      expect(getBorderStyle(true, false, borderColor, false)).toEqual(borderRight);
     });
 
     test("should resolve style for last column", () => {
-      expect(getBorderStyle(false, true, borderColor, false)).toEqual({
-        ...borderBottomStyle,
-        borderBottomColor: borderColor,
-      });
+      expect(getBorderStyle(false, true, borderColor, false)).toEqual(borderBottom);
     });
 
     test("should resolve style cell that is not last row or column", () => {
-      expect(getBorderStyle(false, false, borderColor, false)).toEqual({
-        ...borderBottomRightStyle,
-        borderBottomColor: borderColor,
-        borderRightColor: borderColor,
-      });
+      expect(getBorderStyle(false, false, borderColor, false)).toEqual(borderRightBottom);
     });
   });
 });

--- a/src/pivot-table/components/grids/DataGrid.tsx
+++ b/src/pivot-table/components/grids/DataGrid.tsx
@@ -19,7 +19,7 @@ import {
   useShouldShowTotalCellRightDivider,
 } from "../../hooks/use-is-total-cell";
 import MemoizedDataCell from "../cells/DataCell";
-import { gridBorderStyle } from "../shared-styles";
+import { borderStyle } from "../shared-styles";
 
 interface DataGridProps {
   dataModel: DataModel;
@@ -46,7 +46,7 @@ type FetchModeData = (
 ) => Promise<void>;
 
 const gridStyle: React.CSSProperties = {
-  ...gridBorderStyle,
+  ...borderStyle,
   overflow: "hidden",
   boxSizing: "content-box",
 };

--- a/src/pivot-table/components/grids/LeftGrid.tsx
+++ b/src/pivot-table/components/grids/LeftGrid.tsx
@@ -10,7 +10,7 @@ import { getRowHeightHandler } from "../helpers/get-item-size-handler";
 import getKey from "../helpers/get-key";
 import getListMeta from "../helpers/get-list-meta";
 import setListRef from "../helpers/set-list-ref";
-import { gridBorderStyle } from "../shared-styles";
+import { borderStyle } from "../shared-styles";
 
 interface LeftGridProps {
   dataModel: DataModel;
@@ -30,7 +30,7 @@ const containerStyle: React.CSSProperties = {
   display: "flex",
   height: "fit-content",
   borderWidth: "1px 0px 0px 0px",
-  ...gridBorderStyle,
+  ...borderStyle,
 };
 
 const listStyle: React.CSSProperties = {

--- a/src/pivot-table/components/grids/TopGrid.tsx
+++ b/src/pivot-table/components/grids/TopGrid.tsx
@@ -10,7 +10,7 @@ import { getColumnWidthHandler } from "../helpers/get-item-size-handler";
 import getKey from "../helpers/get-key";
 import getListMeta from "../helpers/get-list-meta";
 import setListRef from "../helpers/set-list-ref";
-import { gridBorderStyle } from "../shared-styles";
+import { borderStyle } from "../shared-styles";
 
 interface TopGridProps {
   dataModel: DataModel;
@@ -33,12 +33,12 @@ const listStyle: React.CSSProperties = {
 };
 
 const containerStyle: React.CSSProperties = {
-  ...gridBorderStyle,
+  ...borderStyle,
   borderWidth: "0px 0px 0px 1px",
 };
 
 const containerStyleWithoutBorders: React.CSSProperties = {
-  ...gridBorderStyle,
+  ...borderStyle,
   borderWidth: "0px",
 };
 

--- a/src/pivot-table/components/shared-styles.ts
+++ b/src/pivot-table/components/shared-styles.ts
@@ -20,42 +20,11 @@ export const cellStyle: Pick<React.CSSProperties, "boxSizing" | "padding"> = {
   padding: 4,
 };
 
-export const borderBottomRightStyle: React.CSSProperties = {
-  ...cellStyle,
-  ...borderStyle,
-  borderLeftWidth: 0,
-  borderBottomWidth: 1,
-  borderRightWidth: 1,
-  borderTopWidth: 0,
-};
-
-export const borderBottomStyle: React.CSSProperties = {
-  ...cellStyle,
-  ...borderStyle,
-  borderLeftWidth: 0,
-  borderBottomWidth: 1,
-  borderRightWidth: 0,
-  borderTopWidth: 0,
-};
-
-export const borderRightStyle: React.CSSProperties = {
-  ...cellStyle,
-  ...borderStyle,
-  borderLeftWidth: 0,
-  borderBottomWidth: 0,
-  borderRightWidth: 1,
-  borderTopWidth: 0,
-};
-
 export const textStyle: React.CSSProperties = {
   lineHeight: `calc(${LINE_HEIGHT_COEFFICIENT})`,
   textOverflow: "ellipsis",
   overflow: "hidden",
   whiteSpace: "nowrap",
-};
-
-export const gridBorderStyle: React.CSSProperties = {
-  borderStyle: "solid",
 };
 
 export const getLineClampStyle = (clampCount: number): React.CSSProperties => ({
@@ -80,27 +49,10 @@ export const getBorderStyle = (
   borderColor: string,
   showLastRowBorderBottom: boolean,
 ) => {
-  if (isLastRow && isLastColumn && showLastRowBorderBottom) {
-    return { ...borderBottomStyle, borderBottomColor: borderColor };
-  }
+  const borderRightWidth = !isLastColumn ? 1 : 0;
+  const borderBottomWidth = !isLastRow || showLastRowBorderBottom ? 1 : 0;
 
-  if (isLastRow && isLastColumn) {
-    return cellStyle;
-  }
-
-  if (isLastRow && showLastRowBorderBottom) {
-    return { ...borderBottomRightStyle, borderBottomColor: borderColor, borderRightColor: borderColor };
-  }
-
-  if (isLastRow) {
-    return { ...borderRightStyle, borderRightColor: borderColor };
-  }
-
-  if (isLastColumn) {
-    return { ...borderBottomStyle, borderBottomColor: borderColor };
-  }
-
-  return { ...borderBottomRightStyle, borderBottomColor: borderColor, borderRightColor: borderColor };
+  return { ...cellStyle, ...borderStyle, borderColor, borderWidth: 0, borderRightWidth, borderBottomWidth };
 };
 
 export const getTotalCellDividerStyle = ({


### PR DESCRIPTION
Since there will be `showLastColumnBorderRight` arg to the border func added with the column width, it started to become a lot of if statements. Turns out you could simplify it quite a lot 