### PR TITLE
fix: respect interactions select state

### DIFF
--- a/src/pivot-table/components/cells/DimensionCell.tsx
+++ b/src/pivot-table/components/cells/DimensionCell.tsx
@@ -98,7 +98,8 @@ const DimensionCell = ({
   const { select, isSelected, isActive, isLocked } = useSelectionsContext();
   const selectionCellType = isLeftColumn ? NxSelectionCellType.NX_CELL_LEFT : NxSelectionCellType.NX_CELL_TOP;
   const isCellLocked = isLocked(selectionCellType, cell.y, colIndex) || cell.isLockedByDimension;
-  const isNonSelectableCell = isCellLocked || cell.isEmpty || !interactions.active || cell.isNull;
+  const isNonSelectableCell =
+    isCellLocked || cell.isEmpty || !interactions.active || !interactions.select || cell.isNull;
   const isCellSelected = isSelected(selectionCellType, cell.y, colIndex);
   const resolvedTextStyle = getTextStyle({
     isLeftColumn,

--- a/src/pivot-table/components/cells/__tests__/DimensionCell.test.tsx
+++ b/src/pivot-table/components/cells/__tests__/DimensionCell.test.tsx
@@ -425,6 +425,34 @@ describe("DimensionCell", () => {
         expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
       });
 
+      test("should not be possible to select cell when select interaction is false", async () => {
+        const rowIdx = 0;
+        const colIdx = 1;
+        interactions.select = false;
+        cell.ref.qCanCollapse = true;
+        isSelectedSpy.mockReturnValue(true);
+
+        render(
+          <DimensionCell
+            cell={cell}
+            data={data}
+            rowIndex={rowIdx}
+            colIndex={colIdx}
+            style={style}
+            isLeftColumn
+            isLastRow={false}
+            isLastColumn={false}
+            showTotalCellDivider={false}
+          />,
+          { wrapper: ({ children }) => <TestWithProvider interactions={interactions}>{children}</TestWithProvider> },
+        );
+
+        await userEvent.click(screen.getByText(qText));
+
+        expect(selectSpy).toHaveBeenCalledTimes(0);
+        expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
+      });
+
       test("should not be possible to select cell when cell is locked due to selections in top column", async () => {
         const rowIdx = 0;
         const colIdx = 1;
@@ -700,6 +728,34 @@ describe("DimensionCell", () => {
         const rowIdx = 0;
         const colIdx = 1;
         interactions.active = false;
+        cell.ref.qCanCollapse = true;
+        isSelectedSpy.mockReturnValue(true);
+
+        render(
+          <DimensionCell
+            cell={cell}
+            data={data}
+            rowIndex={rowIdx}
+            colIndex={colIdx}
+            style={style}
+            isLeftColumn={false}
+            isLastRow={false}
+            isLastColumn={false}
+            showTotalCellDivider={false}
+          />,
+          { wrapper: ({ children }) => <TestWithProvider interactions={interactions}>{children}</TestWithProvider> },
+        );
+
+        await userEvent.click(screen.getByText(qText));
+
+        expect(selectSpy).toHaveBeenCalledTimes(0);
+        expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
+      });
+
+      test("should not be possible to select cell when select interaction is false", async () => {
+        const rowIdx = 0;
+        const colIdx = 1;
+        interactions.select = false;
         cell.ref.qCanCollapse = true;
         isSelectedSpy.mockReturnValue(true);
 


### PR DESCRIPTION
There are two interactions state, `active` and `select`, which should turn off selections. This PR fixes so that `select` now also works.