### PR TITLE
fix: columns in left grid out of sync

### DIFF
--- a/src/hooks/__tests__/use-pagination.test.ts
+++ b/src/hooks/__tests__/use-pagination.test.ts
@@ -43,6 +43,7 @@ describe("usePagination", () => {
       shouldShowPagination: true,
       totalPages: Math.ceil(qcy / Math.min(qcy, MAX_ROW_COUNT)),
       totalRowCount: qcy,
+      rowsOnCurrentPage: MAX_ROW_COUNT,
     });
   });
 
@@ -62,6 +63,9 @@ describe("usePagination", () => {
     // check the the currPage to be the last page (considering that page count is based 0)
     await waitFor(() => {
       expect(result.current.pageInfo.currentPage).toBe(totalPages - 1);
+    });
+    await waitFor(() => {
+      expect(result.current.pageInfo.rowsOnCurrentPage).toBe(10_000);
     });
   });
 });

--- a/src/hooks/use-pagination.ts
+++ b/src/hooks/use-pagination.ts
@@ -16,11 +16,11 @@ interface UsePagination {
 const getRowsOnCurrentPage = ({ rowsPerPage, totalRowCount, currentPage }: PageInfo) =>
   Math.min(rowsPerPage, totalRowCount - currentPage * rowsPerPage);
 
-const getPageMeta = (qcy: number) => {
+const getPageMeta = (qcy: number, currentPage: number) => {
   const rowsPerPage = Math.min(qcy, MAX_ROW_COUNT);
   const totalPages = Math.ceil(qcy / rowsPerPage);
   const totalRowCount = qcy;
-  const rowsOnCurrentPage = getRowsOnCurrentPage({ rowsPerPage, totalRowCount, currentPage: 0 } as PageInfo);
+  const rowsOnCurrentPage = getRowsOnCurrentPage({ rowsPerPage, totalRowCount, currentPage } as PageInfo);
 
   return { rowsPerPage, totalPages, totalRowCount, rowsOnCurrentPage };
 };
@@ -36,21 +36,15 @@ const usePagination: UsePagination = (layoutService) => {
   const [pageInfo, setPageInfo] = useState<PageInfo>({
     currentPage: 0,
     shouldShowPagination: qSize.qcy > size.y,
-    ...getPageMeta(qSize.qcy),
+    ...getPageMeta(qSize.qcy, 0),
   });
 
   useEffect(() => {
-    setPageInfo((prev) => {
-      const newPageMeta = getPageMeta(layoutService.layout.qHyperCube.qSize.qcy);
-      const rowsOnCurrentPage = getRowsOnCurrentPage({ ...prev, ...newPageMeta });
-
-      return {
-        ...prev,
-        ...newPageMeta,
-        rowsOnCurrentPage,
-        shouldShowPagination: layoutService.layout.qHyperCube.qSize.qcy > layoutService.size.y,
-      };
-    });
+    setPageInfo((prev) => ({
+      ...prev,
+      ...getPageMeta(layoutService.layout.qHyperCube.qSize.qcy, prev.currentPage),
+      shouldShowPagination: layoutService.layout.qHyperCube.qSize.qcy > layoutService.size.y,
+    }));
   }, [layoutService.layout.qHyperCube.qSize.qcy, layoutService.size.y, setPageInfo]);
 
   useEffect(() => {

--- a/src/pivot-table/components/PivotTable.tsx
+++ b/src/pivot-table/components/PivotTable.tsx
@@ -120,12 +120,7 @@ export const StickyPivotTable = ({
   const getScrollLeft = useCallback(() => currentScrollLeft.current, [currentScrollLeft]);
   const getScrollTop = useCallback(() => currentScrollTop.current, [currentScrollTop]);
 
-  const dataRowCount = Math.min(
-    layoutService.layout.qHyperCube.qSize.qcy - pageInfo.currentPage * pageInfo.rowsPerPage,
-    pageInfo.rowsPerPage,
-  );
-
-  const totalDataHeight = dataRowCount * contentCellHeight + GRID_BORDER;
+  const totalDataHeight = pageInfo.rowsOnCurrentPage * contentCellHeight + GRID_BORDER;
   const containerHeight = totalDataHeight + headerCellHeight * topDimensionData.rowCount;
   const headerGridHeight = headerCellHeight * headersData.size.y;
   // Top grid should always have height to support cases when there is no top data but it need to occupy space to currecly render headers
@@ -181,6 +176,7 @@ export const StickyPivotTable = ({
             leftDimensionData={leftDimensionData}
             showLastRowBorderBottom={showLastRowBorderBottom}
             visibleLeftDimensionInfo={visibleLeftDimensionInfo}
+            pageInfo={pageInfo}
           />
 
           <DataGrid

--- a/src/pivot-table/components/__tests__/Pagination.test.tsx
+++ b/src/pivot-table/components/__tests__/Pagination.test.tsx
@@ -18,6 +18,7 @@ describe("<Pagination />", () => {
       totalPages: 10,
       totalRowCount: 45,
       shouldShowPagination: true,
+      rowsOnCurrentPage: 5,
     };
   });
 

--- a/src/pivot-table/components/grids/LeftGrid.tsx
+++ b/src/pivot-table/components/grids/LeftGrid.tsx
@@ -1,7 +1,7 @@
 import { useOnPropsChange } from "@qlik/nebula-table-utils/lib/hooks";
 import React, { memo, useLayoutEffect } from "react";
 import { VariableSizeList } from "react-window";
-import type { DataModel, LayoutService, LeftDimensionData, VisibleDimensionInfo } from "../../../types/types";
+import type { DataModel, LayoutService, LeftDimensionData, PageInfo, VisibleDimensionInfo } from "../../../types/types";
 import { useStyleContext } from "../../contexts/StyleProvider";
 import MemoizedListCellFactory from "../cells/ListCellFactory";
 import getItemKey from "../helpers/get-item-key";
@@ -22,6 +22,7 @@ interface LeftGridProps {
   leftDimensionData: LeftDimensionData;
   showLastRowBorderBottom: boolean;
   visibleLeftDimensionInfo: VisibleDimensionInfo[];
+  pageInfo: PageInfo;
 }
 
 const containerStyle: React.CSSProperties = {
@@ -56,6 +57,7 @@ const LeftGrid = ({
   leftDimensionData,
   showLastRowBorderBottom,
   visibleLeftDimensionInfo,
+  pageInfo,
 }: LeftGridProps): JSX.Element | null => {
   const { qSize } = layoutService.layout.qHyperCube;
   const {
@@ -75,7 +77,7 @@ const LeftGrid = ({
     }
   }, [getScrollTop, layoutService, leftGridRef]);
 
-  const totalHeight = layoutService.size.y * contentCellHeight;
+  const totalHeight = pageInfo.rowsOnCurrentPage * contentCellHeight;
 
   if (leftDimensionData.columnCount === 0) {
     return null;
@@ -89,7 +91,7 @@ const LeftGrid = ({
         const { itemCount, estimatedItemSize, listValues } = getListMeta(
           list,
           totalHeight,
-          layoutService.size.y,
+          pageInfo.rowsOnCurrentPage,
           isLastColumn,
         );
 

--- a/src/pivot-table/data/left-dimension-data.ts
+++ b/src/pivot-table/data/left-dimension-data.ts
@@ -12,9 +12,6 @@ export interface AddPageToLeftDimensionDataProps {
   visibleLeftDimensionInfo: VisibleDimensionInfo[];
 }
 
-const getRowsOnPage = ({ rowsPerPage, totalRowCount, currentPage }: PageInfo) =>
-  Math.min(rowsPerPage, totalRowCount - currentPage * rowsPerPage);
-
 export const addPageToLeftDimensionData = ({
   prevData,
   nextDataPage,
@@ -26,8 +23,7 @@ export const addPageToLeftDimensionData = ({
   if (!qLeft.length) return prevData;
 
   const grid = extractLeftGrid(prevData.grid, qLeft, qArea, pageInfo, layoutService, visibleLeftDimensionInfo);
-  const rowsOnPage = getRowsOnPage(pageInfo);
-  assignDistanceToNextCell(grid, rowsOnPage);
+  assignDistanceToNextCell(grid, pageInfo.rowsOnCurrentPage);
   const totalDividerIndex = getTotalDividerIndex(grid);
 
   return {
@@ -46,8 +42,7 @@ export const createLeftDimensionData = (
 ): LeftDimensionData => {
   const { qArea, qLeft } = dataPage;
   const grid = extractLeftGrid([], qLeft, qArea, pageInfo, layoutService, visibleLeftDimensionInfo);
-  const rowsOnPage = getRowsOnPage(pageInfo);
-  assignDistanceToNextCell(grid, rowsOnPage);
+  assignDistanceToNextCell(grid, pageInfo.rowsOnCurrentPage);
   const totalDividerIndex = getTotalDividerIndex(grid);
 
   return {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -192,6 +192,7 @@ export interface PageInfo {
   totalPages: number;
   rowsPerPage: number;
   totalRowCount: number;
+  rowsOnCurrentPage: number;
 }
 
 interface FontStyling {


### PR DESCRIPTION
Uses the actual number of rows in a page instead of the maximum possible when computing some values. I ended up putting the value for that on `PageInfo` as a way to make it easily shared across components/hooks.

Issue that have been fixed:
![Skärmavbild 2023-09-13 kl  11 31 02](https://github.com/qlik-oss/sn-pivot-table/assets/16608020/7cf8ed09-6ed4-4690-bce6-81a687fd2962)
