### PR TITLE
refactor: change name from currentPage to page

### DIFF
--- a/src/hooks/__tests__/use-load-data-pages.test.ts
+++ b/src/hooks/__tests__/use-load-data-pages.test.ts
@@ -30,7 +30,7 @@ describe("useLoadDataPages", () => {
       },
     } as LayoutService;
     pageInfo = {
-      currentPage: 0,
+      page: 0,
       rowsPerPage: 100,
     } as PageInfo;
   });
@@ -81,7 +81,7 @@ describe("useLoadDataPages", () => {
     test("should return true in case of new page and while qTop is falling behind current page", () => {
       pageInfo = {
         ...pageInfo,
-        currentPage: 5,
+        page: 5,
       };
       expect(isMissingLayoutData(layoutService.layout, pageInfo)).toBe(true);
     });
@@ -239,7 +239,7 @@ describe("useLoadDataPages", () => {
         // make isMissingLayoutData() returns true by fake arguments
         pageInfo = {
           ...pageInfo,
-          currentPage: 5,
+          page: 5,
         };
 
         renderer();
@@ -248,7 +248,7 @@ describe("useLoadDataPages", () => {
           expect(getHyperCubePivotDataMock).toHaveBeenCalledWith(Q_PATH, [
             {
               qLeft: viewService.gridColumnStartIndex,
-              qTop: pageInfo.currentPage * pageInfo.rowsPerPage + 0,
+              qTop: pageInfo.page * pageInfo.rowsPerPage + 0,
               qWidth: DEFAULT_PAGE_SIZE,
               qHeight: DEFAULT_PAGE_SIZE,
             },
@@ -260,7 +260,7 @@ describe("useLoadDataPages", () => {
         // make isMissingLayoutData() returns true by fake arguments
         pageInfo = {
           ...pageInfo,
-          currentPage: 5,
+          page: 5,
         };
         viewService = {
           ...viewService,
@@ -284,7 +284,7 @@ describe("useLoadDataPages", () => {
           expect(getHyperCubePivotDataMock).toHaveBeenCalledWith(Q_PATH, [
             {
               qLeft: viewService.gridColumnStartIndex,
-              qTop: pageInfo.currentPage * pageInfo.rowsPerPage + viewService.gridRowStartIndex,
+              qTop: pageInfo.page * pageInfo.rowsPerPage + viewService.gridRowStartIndex,
               qWidth: DEFAULT_PAGE_SIZE,
               qHeight: DEFAULT_PAGE_SIZE,
             },

--- a/src/hooks/__tests__/use-pagination.test.ts
+++ b/src/hooks/__tests__/use-pagination.test.ts
@@ -38,7 +38,7 @@ describe("usePagination", () => {
     const { qcy } = layoutService.layout.qHyperCube.qSize;
 
     expect(pageInfo).toMatchObject({
-      currentPage: 0,
+      page: 0,
       rowsPerPage: MAX_ROW_COUNT,
       shouldShowPagination: true,
       totalPages: Math.ceil(qcy / Math.min(qcy, MAX_ROW_COUNT)),
@@ -54,14 +54,14 @@ describe("usePagination", () => {
 
     // update the page to last page + 100 more pages (some thing out of curr pagination boundary)
     act(() => {
-      result.current.updatePageInfo({ ...result.current.pageInfo, currentPage: totalPages + 100 });
+      result.current.updatePageInfo({ ...result.current.pageInfo, page: totalPages + 100 });
     });
 
     rerender();
 
     // check the the currPage to be the last page (considering that page count is based 0)
     await waitFor(() => {
-      expect(result.current.pageInfo.currentPage).toBe(totalPages - 1);
+      expect(result.current.pageInfo.page).toBe(totalPages - 1);
     });
   });
 });

--- a/src/hooks/use-load-data-pages.ts
+++ b/src/hooks/use-load-data-pages.ts
@@ -31,7 +31,7 @@ export const isMissingLayoutData = (layout: PivotLayout, pageInfo: PageInfo): bo
   const { qTop, qWidth, qHeight } = qPivotDataPages[0]?.qArea ?? { qTop: 0, qWidth: 0, qHeight: 0 };
 
   // in case of new page -> return true
-  if (qTop < pageInfo.currentPage * pageInfo.rowsPerPage) return true;
+  if (qTop < pageInfo.page * pageInfo.rowsPerPage) return true;
   // otherwise check if we are missing data
   return qWidth < Math.min(DEFAULT_PAGE_SIZE, qSize.qcx) || qHeight < Math.min(DEFAULT_PAGE_SIZE, qSize.qcy);
 };
@@ -56,7 +56,7 @@ const useLoadDataPages = ({ model, layoutService, viewService, pageInfo }: Props
     ) {
       const fetchArea: EngineAPI.INxPage = {
         qLeft: qLastExpandedPos ? viewService.gridColumnStartIndex : 0,
-        qTop: pageInfo.currentPage * pageInfo.rowsPerPage + (qLastExpandedPos ? viewService.gridRowStartIndex : 0),
+        qTop: pageInfo.page * pageInfo.rowsPerPage + (qLastExpandedPos ? viewService.gridRowStartIndex : 0),
         qWidth: !viewService.gridWidth ? DEFAULT_PAGE_SIZE : viewService.gridWidth,
         qHeight: !viewService.gridHeight ? DEFAULT_PAGE_SIZE : viewService.gridHeight,
       };
@@ -64,7 +64,7 @@ const useLoadDataPages = ({ model, layoutService, viewService, pageInfo }: Props
     }
 
     return qHyperCube.qPivotDataPages ?? [];
-    // By explicitly using layout, isSnapshot, pageInfo.currentPage and pageInfo.rowsPerPage in the deps list. Two re-dundent page fetches are skipped on first render
-  }, [layout, isSnapshot, model, viewService, pageInfo.currentPage, pageInfo.rowsPerPage]);
+    // By explicitly using layout, isSnapshot, pageInfo.page and pageInfo.rowsPerPage in the deps list. Two re-dundent page fetches are skipped on first render
+  }, [layout, isSnapshot, model, viewService, pageInfo.page, pageInfo.rowsPerPage]);
 };
 export default useLoadDataPages;

--- a/src/hooks/use-pagination.ts
+++ b/src/hooks/use-pagination.ts
@@ -30,7 +30,7 @@ const usePagination: UsePagination = (layoutService) => {
   } = layoutService;
 
   const [pageInfo, setPageInfo] = useState<PageInfo>({
-    currentPage: 0,
+    page: 0,
     shouldShowPagination: qSize.qcy > size.y,
     ...getPageMeta(qSize.qcy),
   });
@@ -44,12 +44,12 @@ const usePagination: UsePagination = (layoutService) => {
   }, [layoutService.layout.qHyperCube.qSize.qcy, layoutService.size.y, setPageInfo]);
 
   useEffect(() => {
-    const { currentPage, totalPages } = pageInfo;
+    const { page, totalPages } = pageInfo;
 
     // currPage is base 0 and totalPages always includes remainder rows in last page
     // so we need to consider both of them for prevent landing in missing page
-    if (currentPage + 1 > totalPages) {
-      setPageInfo({ ...pageInfo, currentPage: totalPages - 1 });
+    if (page + 1 > totalPages) {
+      setPageInfo({ ...pageInfo, page: totalPages - 1 });
     }
   }, [pageInfo]);
 

--- a/src/hooks/use-view-service.ts
+++ b/src/hooks/use-view-service.ts
@@ -3,6 +3,6 @@ import createViewService from "../services/view-service";
 import type { PageInfo, ViewService } from "../types/types";
 
 // eslint-disable-next-line react-hooks/exhaustive-deps
-const useViewService = (pageInfo: PageInfo): ViewService => useMemo(() => createViewService(), [pageInfo.currentPage]);
+const useViewService = (pageInfo: PageInfo): ViewService => useMemo(() => createViewService(), [pageInfo.page]);
 
 export default useViewService;

--- a/src/pivot-table/components/Pagination.tsx
+++ b/src/pivot-table/components/Pagination.tsx
@@ -31,25 +31,25 @@ export const testIdPageInfo = "page-info";
 export const testIdDataRange = "data-range-info";
 
 const Pagination = ({ pageInfo, updatePageInfo }: PaginationProps) => {
-  const { totalPages, rowsPerPage, currentPage, totalRowCount } = pageInfo;
+  const { totalPages, rowsPerPage, page, totalRowCount } = pageInfo;
 
-  const isFirstPage = currentPage === 0;
-  const isLastPage = currentPage === totalPages - 1;
+  const isFirstPage = page === 0;
+  const isLastPage = page === totalPages - 1;
 
   const actionButtons = [
-    { key: 1, label: "first", disabled: isFirstPage, onClick: () => updatePageInfo({ currentPage: 0 }) },
-    { key: 2, label: "prev", disabled: isFirstPage, onClick: () => updatePageInfo({ currentPage: currentPage - 1 }) },
-    { key: 3, label: "next", disabled: isLastPage, onClick: () => updatePageInfo({ currentPage: currentPage + 1 }) },
-    { key: 4, label: "last", disabled: isLastPage, onClick: () => updatePageInfo({ currentPage: totalPages - 1 }) },
+    { key: 1, label: "first", disabled: isFirstPage, onClick: () => updatePageInfo({ page: 0 }) },
+    { key: 2, label: "prev", disabled: isFirstPage, onClick: () => updatePageInfo({ page: page - 1 }) },
+    { key: 3, label: "next", disabled: isLastPage, onClick: () => updatePageInfo({ page: page + 1 }) },
+    { key: 4, label: "last", disabled: isLastPage, onClick: () => updatePageInfo({ page: totalPages - 1 }) },
   ];
 
   return (
     <div style={containerStyle}>
       <span style={infoBoxStyle} data-testid={testIdPageInfo}>
-        page: <b>{currentPage + 1}</b> of <b>{totalPages}</b>
+        page: <b>{page + 1}</b> of <b>{totalPages}</b>
       </span>
       <span style={infoBoxStyle} data-testid={testIdDataRange}>
-        {currentPage * rowsPerPage + 1} - {Math.min((currentPage + 1) * rowsPerPage, totalRowCount)} of {totalRowCount}
+        {page * rowsPerPage + 1} - {Math.min((page + 1) * rowsPerPage, totalRowCount)} of {totalRowCount}
       </span>
       <div style={buttonsStyle}>
         {actionButtons.map(({ label, ...rest }) => (

--- a/src/pivot-table/components/PivotTable.tsx
+++ b/src/pivot-table/components/PivotTable.tsx
@@ -84,7 +84,7 @@ export const StickyPivotTable = ({
       scrollableContainerRef.current.scrollLeft = 0;
       scrollableContainerRef.current.scrollTop = 0;
     }
-  }, [pageInfo.currentPage]);
+  }, [pageInfo.page]);
 
   const onScrollHandler = (event: React.SyntheticEvent) => {
     if (topGridRef.current) {
@@ -121,7 +121,7 @@ export const StickyPivotTable = ({
   const getScrollTop = useCallback(() => currentScrollTop.current, [currentScrollTop]);
 
   const dataRowCount = Math.min(
-    layoutService.layout.qHyperCube.qSize.qcy - pageInfo.currentPage * pageInfo.rowsPerPage,
+    layoutService.layout.qHyperCube.qSize.qcy - pageInfo.page * pageInfo.rowsPerPage,
     pageInfo.rowsPerPage,
   );
 

--- a/src/pivot-table/components/__tests__/Pagination.test.tsx
+++ b/src/pivot-table/components/__tests__/Pagination.test.tsx
@@ -13,7 +13,7 @@ describe("<Pagination />", () => {
   beforeEach(() => {
     updatePageInfo = jest.fn();
     pageInfo = {
-      currentPage: 0,
+      page: 0,
       rowsPerPage: 5,
       totalPages: 10,
       totalRowCount: 45,
@@ -27,10 +27,10 @@ describe("<Pagination />", () => {
     // TODO:
     // make sure of translations
     expect(screen.getByTestId(testIdPageInfo)).toHaveTextContent(
-      `page: ${pageInfo.currentPage + 1} of ${pageInfo.totalPages}`,
+      `page: ${pageInfo.page + 1} of ${pageInfo.totalPages}`,
     );
     expect(screen.getByTestId(testIdDataRange)).toHaveTextContent(
-      `${pageInfo.currentPage + 1} - ${pageInfo.rowsPerPage} of ${pageInfo.totalRowCount}`,
+      `${pageInfo.page + 1} - ${pageInfo.rowsPerPage} of ${pageInfo.totalRowCount}`,
     );
     expect(screen.queryAllByRole("button").length).toBe(4);
     ["first", "prev", "next", "last"].forEach((btn) => {
@@ -52,7 +52,7 @@ describe("<Pagination />", () => {
   test("should disable next and last buttons if we are at the end of data set", () => {
     pageInfo = {
       ...pageInfo,
-      currentPage: 9,
+      page: 9,
     };
     renderer();
 
@@ -70,7 +70,7 @@ describe("<Pagination />", () => {
 
       await userEvent.click(screen.getByTestId("next"));
       expect(updatePageInfo).toHaveBeenCalledTimes(1);
-      expect(updatePageInfo).toHaveBeenCalledWith({ currentPage: pageInfo.currentPage + 1 });
+      expect(updatePageInfo).toHaveBeenCalledWith({ page: pageInfo.page + 1 });
     });
 
     test("in case of last button clicked:", async () => {
@@ -78,31 +78,31 @@ describe("<Pagination />", () => {
 
       await userEvent.click(screen.getByTestId("last"));
       expect(updatePageInfo).toHaveBeenCalledTimes(1);
-      expect(updatePageInfo).toHaveBeenCalledWith({ currentPage: pageInfo.totalPages - 1 });
+      expect(updatePageInfo).toHaveBeenCalledWith({ page: pageInfo.totalPages - 1 });
     });
 
     test("in case of prev button clicked:", async () => {
       pageInfo = {
         ...pageInfo,
-        currentPage: 5,
+        page: 5,
       };
       renderer();
 
       await userEvent.click(screen.getByTestId("prev"));
       expect(updatePageInfo).toHaveBeenCalledTimes(1);
-      expect(updatePageInfo).toHaveBeenCalledWith({ currentPage: pageInfo.currentPage - 1 });
+      expect(updatePageInfo).toHaveBeenCalledWith({ page: pageInfo.page - 1 });
     });
 
     test("in case of first button clicked:", async () => {
       pageInfo = {
         ...pageInfo,
-        currentPage: 5,
+        page: 5,
       };
       renderer();
 
       await userEvent.click(screen.getByTestId("first"));
       expect(updatePageInfo).toHaveBeenCalledTimes(1);
-      expect(updatePageInfo).toHaveBeenCalledWith({ currentPage: 0 });
+      expect(updatePageInfo).toHaveBeenCalledWith({ page: 0 });
     });
   });
 });

--- a/src/pivot-table/components/__tests__/Wrapper.test.tsx
+++ b/src/pivot-table/components/__tests__/Wrapper.test.tsx
@@ -24,7 +24,7 @@ describe("Wrapper", () => {
       get: () => disclaimerText,
     } as unknown as ExtendedTranslator;
     pageInfo = {
-      currentPage: 0,
+      page: 0,
       rowsPerPage: 50,
       totalPages: 100,
       shouldShowPagination: false,

--- a/src/pivot-table/data/__tests__/extract-left.test.ts
+++ b/src/pivot-table/data/__tests__/extract-left.test.ts
@@ -9,7 +9,7 @@ describe("extractLeftGrid", () => {
   const qArea = { qTop: 1 } as EngineAPI.INxDataAreaPage;
   const grid = [] as Cell[][];
   const pageInfo = {
-    currentPage: 0,
+    page: 0,
     rowsPerPage: 100,
   } as PageInfo;
 

--- a/src/pivot-table/data/__tests__/left-dimension-data.test.ts
+++ b/src/pivot-table/data/__tests__/left-dimension-data.test.ts
@@ -8,7 +8,7 @@ const mockedExtractLeft = extractLeftGrid as jest.MockedFunction<typeof extractL
 
 describe("left dimension data", () => {
   const pageInfo = {
-    currentPage: 0,
+    page: 0,
     rowsPerPage: 100,
   } as PageInfo;
   const CELL = { ref: { qType: NxDimCellType.NX_DIM_CELL_NORMAL } } as Cell;

--- a/src/pivot-table/data/__tests__/measure-data.test.ts
+++ b/src/pivot-table/data/__tests__/measure-data.test.ts
@@ -3,7 +3,7 @@ import { addPageToMeasureData, createMeasureData } from "../measure-data";
 
 describe("measure data", () => {
   const pageInfo = {
-    currentPage: 0,
+    page: 0,
     rowsPerPage: 100,
   } as PageInfo;
 

--- a/src/pivot-table/data/extract-left.ts
+++ b/src/pivot-table/data/extract-left.ts
@@ -30,7 +30,7 @@ const extractLeftGrid = (
     nodes.forEach((node, idx) => {
       rowIdx += idx === 0 ? 0 : 1;
       // consider items that might be skipped based on current page
-      const startPosition = qArea.qTop - pageInfo.currentPage * pageInfo.rowsPerPage;
+      const startPosition = qArea.qTop - pageInfo.page * pageInfo.rowsPerPage;
       // Start position + current page position - previous tail size,
       const pageY = Math.max(0, startPosition + rowIdx - node.qUp);
       const y = qArea.qTop + rowIdx - node.qUp;

--- a/src/pivot-table/data/left-dimension-data.ts
+++ b/src/pivot-table/data/left-dimension-data.ts
@@ -12,8 +12,8 @@ export interface AddPageToLeftDimensionDataProps {
   visibleLeftDimensionInfo: VisibleDimensionInfo[];
 }
 
-const getRowsOnPage = ({ rowsPerPage, totalRowCount, currentPage }: PageInfo) =>
-  Math.min(rowsPerPage, totalRowCount - currentPage * rowsPerPage);
+const getRowsOnPage = ({ rowsPerPage, totalRowCount, page }: PageInfo) =>
+  Math.min(rowsPerPage, totalRowCount - page * rowsPerPage);
 
 export const addPageToLeftDimensionData = ({
   prevData,

--- a/src/pivot-table/data/measure-data.ts
+++ b/src/pivot-table/data/measure-data.ts
@@ -9,7 +9,7 @@ const createNewGrid = (
   const data = [...prevData];
   nextData.forEach((row, rowIndex) => {
     row.forEach((cell, colIndex) => {
-      const topIdx = qArea.qTop - pageInfo.currentPage * pageInfo.rowsPerPage;
+      const topIdx = qArea.qTop - pageInfo.page * pageInfo.rowsPerPage;
       if (!Array.isArray(data[topIdx + rowIndex])) {
         data[topIdx + rowIndex] = [];
       }

--- a/src/pivot-table/hooks/__tests__/use-data-model.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-data-model.test.ts
@@ -20,7 +20,7 @@ describe("useDataModel", () => {
     (model.getHyperCubePivotData as jest.Mock).mockResolvedValue([]);
     nextPageHandler = jest.fn();
     pageInfo = {
-      currentPage: 0,
+      page: 0,
       rowsPerPage: 100,
     } as PageInfo;
   });
@@ -94,7 +94,7 @@ describe("useDataModel", () => {
     test("fetchMoreData should consider `pageInfo` while calling getHyperCubePivotData to fetch more data", async () => {
       pageInfo = {
         ...pageInfo,
-        currentPage: 5,
+        page: 5,
       };
       const { fetchMoreData } = renderer();
       const output = await fetchMoreData(1, 2, 10, 20);
@@ -104,7 +104,7 @@ describe("useDataModel", () => {
       expect((model as EngineAPI.IGenericObject).getHyperCubePivotData).toHaveBeenCalledWith(Q_PATH, [
         {
           qLeft: 1,
-          qTop: pageInfo.currentPage * pageInfo.rowsPerPage + 2,
+          qTop: pageInfo.page * pageInfo.rowsPerPage + 2,
           qHeight: 20,
           qWidth: 10,
         },

--- a/src/pivot-table/hooks/__tests__/use-data.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-data.test.ts
@@ -119,7 +119,7 @@ describe("useData", () => {
     } as HeadersData;
 
     pageInfo = {
-      currentPage: 0,
+      page: 0,
       rowsPerPage: 100,
     } as PageInfo;
 

--- a/src/pivot-table/hooks/use-data-model.ts
+++ b/src/pivot-table/hooks/use-data-model.ts
@@ -52,7 +52,7 @@ export default function useDataModel({ model, nextPageHandler, pageInfo }: UseDa
       try {
         const nextArea = {
           qLeft: left,
-          qTop: pageInfo.currentPage * pageInfo.rowsPerPage + top,
+          qTop: pageInfo.page * pageInfo.rowsPerPage + top,
           qWidth: width,
           qHeight: height,
         };

--- a/src/pivot-table/hooks/use-selections-model.ts
+++ b/src/pivot-table/hooks/use-selections-model.ts
@@ -28,7 +28,7 @@ export default function useSelectionsModel(
     const clearSelections = () => setSelected([]);
     const clearSelectionAndResetPage = () => {
       setSelected([]);
-      updatePageInfo({ currentPage: 0 });
+      updatePageInfo({ page: 0 });
     };
     selections.on("deactivated", clearSelections);
     selections.on("canceled", clearSelections);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -187,7 +187,7 @@ export interface Galaxy {
 }
 
 export interface PageInfo {
-  currentPage: number;
+  page: number;
   shouldShowPagination: boolean;
   totalPages: number;
   rowsPerPage: number;


### PR DESCRIPTION
Unifies the `sn-table` and `sn-pivot-table` PageInfo type. So that it can be used by the Pagination Footer component at a later point.