### PR TITLE
chore: locked cells now keeps the original background color

### DIFF
--- a/src/pivot-table/components/cells/__tests__/DimensionCell.test.tsx
+++ b/src/pivot-table/components/cells/__tests__/DimensionCell.test.tsx
@@ -15,7 +15,7 @@ import TestWithProvider from "../../../__tests__/test-with-providers";
 import type { SelectionModel } from "../../../hooks/use-selections-model";
 import useSelectionsModel from "../../../hooks/use-selections-model";
 import DimensionCell, { testId, testIdCollapseIcon, testIdExpandIcon } from "../DimensionCell";
-import { lockedFromSelectionStyle, selectedStyle } from "../utils/get-dimension-cell-style";
+import { getLockedStyleFromSelection, selectedStyle } from "../utils/get-dimension-cell-style";
 // eslint-disable-next-line jest/no-mocks-import
 import dataModelMock from "./__mocks__/data-model-mock";
 
@@ -475,7 +475,7 @@ describe("DimensionCell", () => {
 
         expect(selectSpy).toHaveBeenCalledTimes(0);
         expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
-        expect(screen.getByTestId(testId)).toHaveStyle(lockedFromSelectionStyle as Record<string, string>);
+        expect(screen.getByTestId(testId)).toHaveStyle(getLockedStyleFromSelection() as Record<string, string>);
       });
 
       test("should not be possible to select cell when dimension is locked", async () => {
@@ -503,7 +503,7 @@ describe("DimensionCell", () => {
 
         expect(selectSpy).toHaveBeenCalledTimes(0);
         expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
-        expect(screen.getByTestId(testId)).toHaveStyle(lockedFromSelectionStyle as Record<string, string>);
+        expect(screen.getByTestId(testId)).toHaveStyle(getLockedStyleFromSelection() as Record<string, string>);
       });
     });
   });
@@ -802,7 +802,7 @@ describe("DimensionCell", () => {
 
         expect(selectSpy).toHaveBeenCalledTimes(0);
         expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
-        expect(screen.getByTestId(testId)).toHaveStyle(lockedFromSelectionStyle as Record<string, string>);
+        expect(screen.getByTestId(testId)).toHaveStyle(getLockedStyleFromSelection() as Record<string, string>);
       });
 
       test("should not be possible to select cell when dimension is locked", async () => {
@@ -830,7 +830,7 @@ describe("DimensionCell", () => {
 
         expect(selectSpy).toHaveBeenCalledTimes(0);
         expect(onClickHandlerSpy).toHaveBeenCalledTimes(0);
-        expect(screen.getByTestId(testId)).toHaveStyle(lockedFromSelectionStyle as Record<string, string>);
+        expect(screen.getByTestId(testId)).toHaveStyle(getLockedStyleFromSelection() as Record<string, string>);
       });
     });
   });

--- a/src/pivot-table/components/cells/utils/get-dimension-cell-style.ts
+++ b/src/pivot-table/components/cells/utils/get-dimension-cell-style.ts
@@ -1,6 +1,7 @@
 import type React from "react";
 import type { StyleService } from "../../../../types/types";
 import {
+  Colors,
   getBorderStyle,
   getLineClampStyle,
   getTotalCellDividerStyle,
@@ -31,22 +32,28 @@ interface GetContainerStyle {
   showTotalCellDivider: boolean;
 }
 
-export const selectedStyle: Pick<React.CSSProperties, "color" | "background"> = {
+export const selectedStyle: React.CSSProperties = {
   background: "#0aaf54",
   color: "white",
 };
 
-export const selectableCellStyle: Pick<React.CSSProperties, "cursor"> = {
+export const selectableCellStyle: React.CSSProperties = {
   cursor: "pointer",
 };
 
 // Locked background does override any background color set by the user via theming or styling panel
-export const lockedFromSelectionStyle: Pick<React.CSSProperties, "color" | "background"> = {
-  background: "repeating-linear-gradient(-45deg, #f8f8f8, #f8f8f8 2px, transparent 2px, transparent 4px)",
+export const getLockedStyleFromSelection = (originalBackgroundColor?: string): React.CSSProperties => ({
+  background: `repeating-linear-gradient(
+      -45deg, 
+      #c8c8c814, 
+      #c8c8c814 2px, 
+      transparent 2px, 
+      transparent 4px
+    ), ${originalBackgroundColor ?? Colors.Transparent}`,
   color: "#bebebe",
-};
+});
 
-const cellStyle: Pick<React.CSSProperties, "display" | "flexDirection" | "alignItems" | "gap"> = {
+const cellStyle: React.CSSProperties = {
   display: "flex",
   flexDirection: "row",
   alignItems: "center",
@@ -67,9 +74,9 @@ export const getContainerStyle = ({
   showTotalCellDivider,
 }: GetContainerStyle) => {
   const resolvedSelectedStyle = isCellSelected ? selectedStyle : {};
-  const resolvedLockedSelectionStyle = isCellLocked ? lockedFromSelectionStyle : {};
-  const resolvedSelectableCellStyle = isNonSelectableCell ? {} : selectableCellStyle;
   const { nullValue, background } = isLeftColumn ? styleService.rowContent : styleService.columnContent;
+  const resolvedLockedSelectionStyle = isCellLocked ? getLockedStyleFromSelection(background) : {};
+  const resolvedSelectableCellStyle = isNonSelectableCell ? {} : selectableCellStyle;
   const resolvedNullStyle = isNull ? nullValue : { background };
 
   return {


### PR DESCRIPTION

https://github.com/qlik-oss/sn-pivot-table/assets/29652890/7ecd4fd0-d5da-47a9-9ba9-413fb584b146

