### PR TITLE
fix: load out of range data page

### DIFF
--- a/src/hooks/__tests__/use-load-data-pages.test.ts
+++ b/src/hooks/__tests__/use-load-data-pages.test.ts
@@ -145,14 +145,29 @@ describe("useLoadDataPages", () => {
 
     test("should return null if page does not exist any more", () => {
       layoutService.layout.qHyperCube.qSize.qcy = pageInfo.page * pageInfo.rowsPerPage - 1;
+
       expect(getFetchArea(qLastExpandedPos, viewService, layoutService.layout.qHyperCube.qSize, pageInfo)).toBe(null);
     });
 
     test("should return default area when a node has not been collapsed or expanded", () => {
       qLastExpandedPos = undefined;
+
       expect(getFetchArea(qLastExpandedPos, viewService, layoutService.layout.qHyperCube.qSize, pageInfo)).toEqual({
         qLeft: 0,
         qTop: 0,
+        qWidth: DEFAULT_PAGE_SIZE,
+        qHeight: DEFAULT_PAGE_SIZE,
+      });
+    });
+
+    test("should return page based area when a node has not been collapsed or expanded", () => {
+      qLastExpandedPos = undefined;
+      pageInfo.page = 1;
+      layoutService.layout.qHyperCube.qSize.qcy = pageInfo.rowsPerPage * 2;
+
+      expect(getFetchArea(qLastExpandedPos, viewService, layoutService.layout.qHyperCube.qSize, pageInfo)).toEqual({
+        qLeft: 0,
+        qTop: pageInfo.rowsPerPage,
         qWidth: DEFAULT_PAGE_SIZE,
         qHeight: DEFAULT_PAGE_SIZE,
       });

--- a/src/hooks/use-load-data-pages.ts
+++ b/src/hooks/use-load-data-pages.ts
@@ -59,7 +59,7 @@ export const getFetchArea = (
   }
 
   let qLeft = 0;
-  let qTop = 0;
+  let qTop = pageStartTop;
 
   // qLastExpandedPos only exist in the layout if a new layout was received because a node was expanded or collapsed
   if (qLastExpandedPos) {

--- a/src/hooks/use-load-data-pages.ts
+++ b/src/hooks/use-load-data-pages.ts
@@ -1,5 +1,6 @@
 import { useFetch } from "@qlik/nebula-table-utils/lib/hooks";
 import { DEFAULT_PAGE_SIZE, Q_PATH } from "../constants";
+import { MAX_COLUMN_COUNT } from "../pivot-table/constants";
 import type { Model, PivotLayout } from "../types/QIX";
 import type { LayoutService, PageInfo, ViewService } from "../types/types";
 
@@ -10,18 +11,12 @@ interface Props {
   pageInfo: PageInfo;
 }
 
-export const shouldFetchAdditionalData = (
-  qLastExpandedPos: EngineAPI.INxCellPosition | undefined,
-  viewService: ViewService,
-) => {
+export const shouldFetchAdditionalData = (qLastExpandedPos: EngineAPI.INxCellPosition | undefined) => {
   if (!qLastExpandedPos) {
     return false;
   }
 
-  return (
-    viewService.gridColumnStartIndex + viewService.gridWidth >= DEFAULT_PAGE_SIZE ||
-    viewService.gridRowStartIndex + viewService.gridHeight >= DEFAULT_PAGE_SIZE
-  );
+  return qLastExpandedPos.qx >= DEFAULT_PAGE_SIZE || qLastExpandedPos.qy >= DEFAULT_PAGE_SIZE;
 };
 
 export const isMissingLayoutData = (layout: PivotLayout, pageInfo: PageInfo): boolean => {
@@ -34,6 +29,60 @@ export const isMissingLayoutData = (layout: PivotLayout, pageInfo: PageInfo): bo
   if (qTop < pageInfo.page * pageInfo.rowsPerPage) return true;
   // otherwise check if we are missing data
   return qWidth < Math.min(DEFAULT_PAGE_SIZE, qSize.qcx) || qHeight < Math.min(DEFAULT_PAGE_SIZE, qSize.qcy);
+};
+
+/**
+ * Note: the state of the viewService is always from the last time the chart was rendered. So it is not
+ * guaranteed to work with a new layout, as its properties my no longer be valid.
+ */
+export const getFetchArea = (
+  qLastExpandedPos: EngineAPI.INxCellPosition | undefined,
+  viewService: ViewService,
+  qSize: EngineAPI.ISize,
+  pageInfo: PageInfo,
+) => {
+  const pageStartTop = pageInfo.page * pageInfo.rowsPerPage;
+  const pageEndTop = pageStartTop + pageInfo.rowsPerPage;
+
+  if (qSize.qcy < pageStartTop) {
+    /**
+     * Do not fetch data that does not exist. This can happen because "PageInfo" is resolved from the layout.
+     * Which means it will not be updated until the next render cycle.
+     */
+    return null;
+  }
+
+  // TODO Make sure to index vs size are correct, i.e. to -1 or not
+
+  // TODO do qLastExpandedPos neeed to know if it was from Left or Top grid?
+
+  let qLeft = 0;
+  let qTop = 0;
+
+  // qLastExpandedPos only exist in the layout if a new layout was received because a node was expanded or collapsed
+  if (qLastExpandedPos) {
+    // gridColumnStartIndex might not exist anymore in the new expanded/collapsed layout
+    if (viewService.gridColumnStartIndex > qLastExpandedPos.qx) {
+      qLeft = Math.max(0, qLastExpandedPos.qx - DEFAULT_PAGE_SIZE);
+    } else {
+      qLeft = viewService.gridColumnStartIndex;
+    }
+
+    // pageStartTop + viewService.gridRowStartIndex might not exist anymore in the new expanded/collapsed layout
+    const inViewTop = pageStartTop + viewService.gridRowStartIndex;
+    if (inViewTop > qLastExpandedPos.qy) {
+      qTop = Math.max(0, qLastExpandedPos.qy - DEFAULT_PAGE_SIZE);
+    } else {
+      qTop = inViewTop;
+    }
+  }
+
+  return {
+    qLeft,
+    qTop,
+    qWidth: Math.min(MAX_COLUMN_COUNT - qLeft, qSize.qcx - qLeft, DEFAULT_PAGE_SIZE),
+    qHeight: Math.min(pageEndTop - qTop, qSize.qcy - qTop, DEFAULT_PAGE_SIZE),
+  };
 };
 
 const useLoadDataPages = ({ model, layoutService, viewService, pageInfo }: Props) => {
@@ -52,19 +101,21 @@ const useLoadDataPages = ({ model, layoutService, viewService, pageInfo }: Props
     if (
       model !== undefined &&
       "getHyperCubePivotData" in model &&
-      (shouldFetchAdditionalData(qLastExpandedPos, viewService) || isMissingLayoutData(layout, pageInfo))
+      (shouldFetchAdditionalData(qLastExpandedPos) || isMissingLayoutData(layout, pageInfo))
     ) {
-      const fetchArea: EngineAPI.INxPage = {
-        qLeft: qLastExpandedPos ? viewService.gridColumnStartIndex : 0,
-        qTop: pageInfo.page * pageInfo.rowsPerPage + (qLastExpandedPos ? viewService.gridRowStartIndex : 0),
-        qWidth: !viewService.gridWidth ? DEFAULT_PAGE_SIZE : viewService.gridWidth,
-        qHeight: !viewService.gridHeight ? DEFAULT_PAGE_SIZE : viewService.gridHeight,
-      };
-      return model.getHyperCubePivotData(Q_PATH, [fetchArea]);
+      const fetchArea = getFetchArea(qLastExpandedPos, viewService, layout.qHyperCube.qSize, pageInfo);
+      console.log("%c fetchArea", "color: orangered", {
+        fetchArea,
+        viewService: { ...viewService },
+        pageInfo,
+        qLastExpandedPos,
+      });
+      return fetchArea ? model.getHyperCubePivotData(Q_PATH, [fetchArea]) : [];
     }
 
     return qHyperCube.qPivotDataPages ?? [];
     // By explicitly using layout, isSnapshot, pageInfo.page and pageInfo.rowsPerPage in the deps list. Two re-dundent page fetches are skipped on first render
   }, [layout, isSnapshot, model, viewService, pageInfo.page, pageInfo.rowsPerPage]);
 };
+
 export default useLoadDataPages;

--- a/src/hooks/use-load-data-pages.ts
+++ b/src/hooks/use-load-data-pages.ts
@@ -1,6 +1,6 @@
 import { useFetch } from "@qlik/nebula-table-utils/lib/hooks";
 import { DEFAULT_PAGE_SIZE, Q_PATH } from "../constants";
-import { MAX_COLUMN_COUNT, MAX_ROW_COUNT } from "../pivot-table/constants";
+import { MAX_COLUMN_COUNT } from "../pivot-table/constants";
 import type { Model, PivotLayout } from "../types/QIX";
 import type { LayoutService, PageInfo, ViewService } from "../types/types";
 
@@ -39,7 +39,7 @@ export const isMissingLayoutData = (layout: PivotLayout, pageInfo: PageInfo): bo
 
 /**
  * Note: the state of the viewService is always from the last time the chart was rendered. So it is not
- * guaranteed to work with a new layout, as its properties my no longer be valid.
+ * guaranteed to work with a new layout, as its properties may no longer be valid.
  */
 export const getFetchArea = (
   qLastExpandedPos: EngineAPI.INxCellPosition | undefined,
@@ -48,8 +48,7 @@ export const getFetchArea = (
   pageInfo: PageInfo,
 ) => {
   const pageStartTop = pageInfo.page * pageInfo.rowsPerPage;
-  // Use MAX_ROW_COUNT because when on first page and expand a node, pageInfo.rowsPerPage might be less than 50
-  const pageEndTop = pageStartTop + MAX_ROW_COUNT;
+  const pageEndTop = pageStartTop + pageInfo.rowsPerPage;
 
   if (qSize.qcy < pageStartTop) {
     /**

--- a/src/hooks/use-pagination.ts
+++ b/src/hooks/use-pagination.ts
@@ -17,7 +17,7 @@ const getRowsOnCurrentPage = ({ rowsPerPage, totalRowCount, page }: PageInfo) =>
   Math.min(rowsPerPage, totalRowCount - page * rowsPerPage);
 
 const getPageMeta = (qcy: number, page: number) => {
-  const rowsPerPage = Math.min(qcy, MAX_ROW_COUNT);
+  const rowsPerPage = MAX_ROW_COUNT;
   const totalPages = Math.ceil(qcy / rowsPerPage);
   const totalRowCount = qcy;
   const rowsOnCurrentPage = getRowsOnCurrentPage({ rowsPerPage, totalRowCount, page } as PageInfo);


### PR DESCRIPTION
Fixes an issue where the chart could crash when a node was collapsed the total number of columns/rows was greatly reduced.

Also fixes so that `useLoadPagePages` does not try to fetch data for the "next" page.


Before:

https://github.com/qlik-oss/sn-pivot-table/assets/16608020/4d6531ad-64c7-4264-9421-40574674ee78

After:

https://github.com/qlik-oss/sn-pivot-table/assets/16608020/b71c2ebc-c8fc-4c93-9cd1-273d8276da6b

