### PR TITLE
fix: overscroll behavior

### DIFF
--- a/src/pivot-table/components/containers/ScrollableContainer.tsx
+++ b/src/pivot-table/components/containers/ScrollableContainer.tsx
@@ -20,6 +20,7 @@ const ScrollableContainer = (props: ScrollableContainerProps, ref: React.LegacyR
         overflow: interactions.active ? "auto" : "hidden",
         width: rect.width,
         height: rect.height,
+        overscrollBehaviorX: "contain",
       }}
       onScroll={onScroll}
     >


### PR DESCRIPTION
The idea here is to prevent triggering the browser going back/forward when scrolling the in the pivot table. Using `overscroll-behavior-x` to allow scrolling along the Y axis when the end of the scrollarea is reached. This could for example be on an extended sheet where it would allow scrolling down the sheet once the bottom of the pivot table is reached.

This should work for both mouse wheel and trackpad.