### PR TITLE
fix: rename and move line count

### DIFF
--- a/nebula.config.js
+++ b/nebula.config.js
@@ -50,6 +50,7 @@ module.exports = {
                 fontFamily: '"Source Sans Pro", "Arial", "sans-serif"',
                 color: "#404040",
                 background: "transparent",
+                lineClamp: 1,
                 nullValue: {
                   color: "#404040",
                   background: "rgba(0, 0, 0, 0.05)",
@@ -83,7 +84,6 @@ module.exports = {
               },
               grid: {
                 rowHeight: "compact",
-                lineCount: 1,
                 border: "rgba(0, 0, 0, 0.15)",
                 divider: "rgba(0, 0, 0, 0.6)",
               },
@@ -114,6 +114,7 @@ module.exports = {
                 fontFamily: "sans-serif",
                 color: "black",
                 background: "salmon",
+                lineClamp: 1,
                 nullValue: {
                   color: "white",
                   background: "rgba(0, 0, 0, 0.75)",
@@ -161,7 +162,6 @@ module.exports = {
               },
               grid: {
                 rowHeight: "compact",
-                lineCount: 1,
                 border: "lime",
                 divider: "white",
               },
@@ -176,9 +176,20 @@ module.exports = {
             pivotTableV2: {
               grid: {
                 rowHeight: "compact",
-                lineCount: 1,
                 border: "transparent",
                 divider: "rgba(0, 0, 0, 0.6)",
+              },
+            },
+          },
+        },
+      },
+      {
+        id: "Line clamp",
+        theme: {
+          object: {
+            pivotTableV2: {
+              content: {
+                lineClamp: 10,
               },
             },
           },

--- a/src/ext/property-panel/settings/styling-panel/content.ts
+++ b/src/ext/property-panel/settings/styling-panel/content.ts
@@ -35,6 +35,21 @@ const contentSection = (translator: stardust.Translator) => ({
           "properties.background",
           (currentTheme) => currentTheme.object?.pivotTableV2?.content?.background ?? Colors.Transparent,
         ),
+        lineClamp: {
+          component: "inline-wrapper",
+          items: {
+            rowHeight: {
+              component: "dropdown",
+              ref: "content.lineClamp",
+              translation: "ThemeStyleEditor.style.rowHeight",
+              options: [...Array(10).keys()].map((x) => ({
+                value: x + 1,
+                translation: x + 1,
+              })),
+              defaultValue: 1,
+            },
+          },
+        },
         // Null value styling
         nullValues: {
           component: "header",

--- a/src/ext/property-panel/settings/styling-panel/grid.ts
+++ b/src/ext/property-panel/settings/styling-panel/grid.ts
@@ -10,21 +10,6 @@ const gridSection = {
       ref: "components",
       key: "theme",
       items: {
-        lineCount: {
-          component: "inline-wrapper",
-          items: {
-            rowHeight: {
-              component: "dropdown",
-              ref: "grid.lineCount",
-              translation: "ThemeStyleEditor.style.rowHeight",
-              options: [...Array(10).keys()].map((x) => ({
-                value: x + 1,
-                translation: x + 1,
-              })),
-              defaultValue: 1,
-            },
-          },
-        },
         border: createColorPickerItem(
           "grid.border",
           "properties.border",

--- a/src/pivot-table/__tests__/test-with-providers.tsx
+++ b/src/pivot-table/__tests__/test-with-providers.tsx
@@ -48,6 +48,7 @@ const TestWithProvider = (props: Props) => {
         fontFamily: '"Source Sans Pro", "Arial", "sans-serif"',
         color: "contentColor",
         background: "contentBackground",
+        lineClamp: 1,
         nullValue: {
           color: "contentNullColor",
           background: "contentNullBackground",
@@ -95,12 +96,9 @@ const TestWithProvider = (props: Props) => {
       },
       grid: {
         rowHeight: "compact",
-        lineCount: 1,
         border: "rgba(0, 0, 0, 0.15)",
         divider: "rgba(0, 0, 0, 0.6)",
       },
-      lineClamp: 1,
-      headerLineClamp: 1,
       headerCellHeight: DEFAULT_CELL_HEIGHT,
       contentCellHeight: DEFAULT_CELL_HEIGHT,
     },

--- a/src/pivot-table/components/cells/PseudoDimensionCell.tsx
+++ b/src/pivot-table/components/cells/PseudoDimensionCell.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { Cell } from "../../../types/types";
+import { DEFAULT_LINE_CLAMP } from "../../constants";
 import { useStyleContext } from "../../contexts/StyleProvider";
 import {
   getBorderStyle,
@@ -57,7 +58,7 @@ const PseudoDimensionCell = ({
     rightDivider: showTotalCellDivider && !isLeftColumn,
     borderColor: styleService.grid.divider,
   });
-  const lineClamp = isLeftColumn ? styleService.lineClamp : styleService.headerLineClamp;
+  const lineClamp = isLeftColumn ? styleService.content.lineClamp : DEFAULT_LINE_CLAMP;
 
   return (
     <div

--- a/src/pivot-table/components/cells/utils/get-dimension-cell-style.ts
+++ b/src/pivot-table/components/cells/utils/get-dimension-cell-style.ts
@@ -1,5 +1,6 @@
 import type React from "react";
 import type { StyleService } from "../../../../types/types";
+import { DEFAULT_LINE_CLAMP } from "../../../constants";
 import {
   Colors,
   getBorderStyle,
@@ -44,10 +45,10 @@ export const selectableCellStyle: React.CSSProperties = {
 // Locked background does override any background color set by the user via theming or styling panel
 export const getLockedStyleFromSelection = (originalBackgroundColor?: string): React.CSSProperties => ({
   background: `repeating-linear-gradient(
-      -45deg, 
-      #c8c8c814, 
-      #c8c8c814 2px, 
-      transparent 2px, 
+      -45deg,
+      #c8c8c814,
+      #c8c8c814 2px,
+      transparent 2px,
       transparent 4px
     ), ${originalBackgroundColor ?? Colors.Transparent}`,
   color: "#bebebe",
@@ -121,6 +122,6 @@ export const getTextStyle = ({
     fontWeight: qCanExpand || qCanCollapse ? "600" : undefined,
     overflow: "hidden",
     textOverflow: "ellipsis",
-    ...getLineClampStyle(isLeftColumn ? styleService.lineClamp : styleService.headerLineClamp),
+    ...getLineClampStyle(isLeftColumn ? styleService.content.lineClamp : DEFAULT_LINE_CLAMP),
   };
 };

--- a/src/pivot-table/components/cells/utils/get-measure-cell-style.ts
+++ b/src/pivot-table/components/cells/utils/get-measure-cell-style.ts
@@ -52,7 +52,7 @@ export const getTextStyle = (styleService: StyleService, isNumeric: boolean) => 
 
   return {
     ...textStyle,
-    ...(!isNumeric && getGridTextClampStyle(styleService.lineClamp)),
+    ...(!isNumeric && getGridTextClampStyle(styleService.content.lineClamp)),
     alignSelf: "flex-start",
     fontFamily,
     fontSize,

--- a/src/pivot-table/contexts/__mocks__/StyleProvider.tsx
+++ b/src/pivot-table/contexts/__mocks__/StyleProvider.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 export const useStyleContext = () => ({
-  lineClamp: 1,
   header: {
     fontSize: "12px",
     fontFamily: '"Source Sans Pro", "Arial", "sans-serif"',
@@ -14,6 +13,7 @@ export const useStyleContext = () => ({
     fontFamily: '"Source Sans Pro", "Arial", "sans-serif"',
     color: "rgba(0, 0, 0, 0.55)",
     background: "transparent",
+    lineClamp: 1,
     nullValue: { color: "#404040", background: "rgba(0, 0, 0, 0.05)" },
     totalValue: { color: "#404040", background: "transparent" },
   },
@@ -37,7 +37,6 @@ export const useStyleContext = () => ({
   },
   grid: {
     rowHeight: "compact",
-    lineCount: 1,
     border: "rgba(0, 0, 0, 0.15)",
     divider: "rgba(0, 0, 0, 0.6)",
   },

--- a/src/services/__tests__/style-service.test.ts
+++ b/src/services/__tests__/style-service.test.ts
@@ -10,7 +10,7 @@ describe("style-service", () => {
   let fontFamily: string;
   let color: string;
   let colorFromPalette: string;
-  let linesCount: number;
+  let lineClamp: number;
   let layoutServiceMock: LayoutService;
   let themeMock: ExtendedTheme;
 
@@ -19,9 +19,10 @@ describe("style-service", () => {
     fontFamily = "Arial";
     color = "#ff0000";
     colorFromPalette = "#00ff00";
-    linesCount = 2;
+    lineClamp = 2;
     themeMock = {
-      getStyle: () => themeValue,
+      getStyle: (basePath: string, path: string, attribute: string) =>
+        attribute === "lineClamp" && themeValue !== undefined ? lineClamp : themeValue,
       getColorPickerColor: (paletteColor: PaletteColor) =>
         paletteColor.index && paletteColor.index > -1 ? colorFromPalette : color,
     } as unknown as ExtendedTheme;
@@ -96,7 +97,7 @@ describe("style-service", () => {
             },
             grid: {
               rowHeight: "compact",
-              lineCount: linesCount,
+              lineClamp,
               border: "borderColor",
               divider: "dividerColor",
             },
@@ -110,8 +111,6 @@ describe("style-service", () => {
   test("should resolve style from layout", () => {
     const styleService = createStyleService(themeMock, layoutServiceMock);
     expect(styleService).toEqual({
-      lineClamp: linesCount,
-      headerLineClamp: 1,
       header: {
         fontSize: `${fontSize}px`,
         fontFamily,
@@ -134,6 +133,7 @@ describe("style-service", () => {
         fontFamily,
         color,
         background: color,
+        lineClamp,
         nullValue: {
           color,
           background: color,
@@ -181,7 +181,6 @@ describe("style-service", () => {
       },
       grid: {
         rowHeight: "compact",
-        lineCount: linesCount,
         border: color,
         divider: color,
       },
@@ -195,8 +194,6 @@ describe("style-service", () => {
     const styleService = createStyleService(themeMock, layoutServiceMock);
 
     expect(styleService).toEqual({
-      lineClamp: 1,
-      headerLineClamp: 1,
       header: {
         fontSize: "18px",
         fontFamily: "18px",
@@ -219,6 +216,7 @@ describe("style-service", () => {
         fontFamily: "18px",
         color: "18px",
         background: "18px",
+        lineClamp,
         nullValue: { color: "18px", background: "18px" },
         totalValue: { color: "18px", background: "18px" },
       },
@@ -242,12 +240,11 @@ describe("style-service", () => {
       },
       grid: {
         rowHeight: "18px",
-        lineCount: "18px",
         border: "18px",
         divider: "18px",
       },
       headerCellHeight: 32,
-      contentCellHeight: 32,
+      contentCellHeight: 56,
     });
   });
 
@@ -257,8 +254,6 @@ describe("style-service", () => {
     const styleService = createStyleService(themeMock, layoutServiceMock);
 
     expect(styleService).toEqual({
-      lineClamp: 1,
-      headerLineClamp: 1,
       header: {
         fontSize: "12px",
         fontFamily: DEFAULT_FONT_FAMILY,
@@ -281,6 +276,7 @@ describe("style-service", () => {
         fontFamily: DEFAULT_FONT_FAMILY,
         color: "rgba(0, 0, 0, 0.55)",
         background: "transparent",
+        lineClamp: 1,
         nullValue: { color: "#404040", background: "rgba(0, 0, 0, 0.05)" },
         totalValue: { color: "#404040", background: "transparent" },
       },
@@ -304,7 +300,6 @@ describe("style-service", () => {
       },
       grid: {
         rowHeight: "compact",
-        lineCount: 1,
         border: "rgba(0, 0, 0, 0.15)",
         divider: "rgba(0, 0, 0, 0.6)",
       },

--- a/src/services/style-service.ts
+++ b/src/services/style-service.ts
@@ -48,10 +48,9 @@ enum Attribute {
   FontColor = "fontColor",
   Color = "color",
   CellHeight = "cellHeight",
-  LineClamp = "lineClamp",
   Background = "background",
   RowHeight = "rowHeight",
-  LineCount = "lineCount",
+  LineClamp = "lineClamp",
   Border = "border",
   Divider = "divider",
 }
@@ -76,11 +75,13 @@ const createStyleService = (theme: ExtendedTheme, layoutService: LayoutService):
   const gridStyling = chartStyling?.[Path.Grid];
   const getThemeStyle = (paths: string[], attribute: string) => theme.getStyle(BASE_PATH, paths.join("."), attribute);
 
-  const lineClamp = gridStyling?.lineCount ?? DEFAULT_LINE_CLAMP;
+  const lineClamp = +(
+    contentStyling?.[Attribute.LineClamp] ??
+    getThemeStyle([Path.Content], Attribute.LineClamp) ??
+    DEFAULT_LINE_CLAMP
+  );
 
   const styleService: StyleService = {
-    lineClamp,
-    headerLineClamp: DEFAULT_LINE_CLAMP,
     header: {
       fontSize:
         resolveFontSize(headerStyling?.[Attribute.FontSize]) ??
@@ -132,6 +133,7 @@ const createStyleService = (theme: ExtendedTheme, layoutService: LayoutService):
         resolveColor(theme, contentStyling?.[Attribute.Background]) ??
         getThemeStyle([Path.Content], Attribute.Background) ??
         Colors.Transparent,
+      lineClamp,
       nullValue: {
         color:
           resolveColor(theme, contentStyling?.[Path.NullValue]?.[Attribute.FontColor]) ??
@@ -251,8 +253,6 @@ const createStyleService = (theme: ExtendedTheme, layoutService: LayoutService):
     },
     grid: {
       rowHeight: gridStyling?.[Attribute.RowHeight] ?? getThemeStyle([Path.Grid], Attribute.RowHeight) ?? "compact",
-      lineCount:
-        gridStyling?.[Attribute.LineCount] ?? getThemeStyle([Path.Grid], Attribute.LineCount) ?? DEFAULT_LINE_CLAMP,
       border:
         resolveColor(theme, gridStyling?.[Attribute.Border]) ??
         getThemeStyle([Path.Grid], Attribute.Border) ??
@@ -265,8 +265,8 @@ const createStyleService = (theme: ExtendedTheme, layoutService: LayoutService):
   } as StyleService;
 
   styleService["headerCellHeight"] = Math.max(
-    fontSizeToCellHeight(styleService.header.fontSize, styleService.headerLineClamp),
-    fontSizeToCellHeight(styleService.columnContent.fontSize, styleService.headerLineClamp),
+    fontSizeToCellHeight(styleService.header.fontSize, DEFAULT_LINE_CLAMP),
+    fontSizeToCellHeight(styleService.columnContent.fontSize, DEFAULT_LINE_CLAMP),
     DEFAULT_HEADER_CELL_HEIGHT,
   );
 

--- a/src/types/QIX.ts
+++ b/src/types/QIX.ts
@@ -66,6 +66,7 @@ export interface Component {
     fontSize?: string;
     fontColor?: PaletteColor;
     background?: PaletteColor;
+    lineClamp?: number;
     nullValue?: ComponentCellStyling;
     totalValue?: ComponentCellStyling;
   };
@@ -89,7 +90,6 @@ export interface Component {
   };
   grid: {
     rowHeight?: "compact";
-    lineCount?: number;
     border?: PaletteColor;
     divider?: PaletteColor;
   };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -218,6 +218,7 @@ interface MeasureContentStyling extends FontStyling {
   background: string;
   nullValue: CellStyling;
   totalValue: CellStyling;
+  lineClamp: number;
 }
 
 interface DimensionContentStyling extends FontStyling {
@@ -229,7 +230,6 @@ interface DimensionContentStyling extends FontStyling {
 
 interface GridStyling {
   rowHeight: "compact";
-  lineCount: number;
   border: string;
   divider: string;
 }
@@ -245,8 +245,6 @@ export interface StylingOptions {
 export interface StyleService extends StylingOptions {
   headerCellHeight: number;
   contentCellHeight: number;
-  lineClamp: number;
-  headerLineClamp: number;
 }
 
 export type ActivelySortedColumn = {


### PR DESCRIPTION
As discussed with UX. Move the "line count" styling from the Grid, to the Content section.

Also renames the variable from `lineCount` to `lineClamp`.

TODO in sense themes:
- Update all themes