### PR TITLE
fix: change page while loading data

### DIFF
--- a/src/pivot-table/components/cells/__tests__/__mocks__/data-model-mock.ts
+++ b/src/pivot-table/components/cells/__tests__/__mocks__/data-model-mock.ts
@@ -1,7 +1,7 @@
 import type { DataModel } from "../../../../../types/types";
 
 const dataModelMock = (): DataModel => ({
-  fetchMoreData: () => Promise.resolve(true),
+  fetchMoreData: () => Promise.resolve(),
   collapseLeft: () => {},
   collapseTop: () => {},
   expandLeft: () => {},

--- a/src/pivot-table/hooks/__tests__/use-data-model.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-data-model.test.ts
@@ -4,20 +4,24 @@ import type { Model } from "../../../types/QIX";
 import type { PageInfo } from "../../../types/types";
 import useDataModel from "../use-data-model";
 
+const pivotPage = {};
+
 describe("useDataModel", () => {
   let model: Model;
   let nextPageHandler: (page: EngineAPI.INxPivotPage) => void;
   let pageInfo: PageInfo;
+  let getHyperCubePivotDataMock: jest.MockedFunction<() => Promise<EngineAPI.INxPivotPage[]>>;
 
   beforeEach(() => {
+    getHyperCubePivotDataMock = jest.fn() as jest.MockedFunction<() => Promise<EngineAPI.INxPivotPage[]>>;
     model = {
       collapseLeft: jest.fn(),
       collapseTop: jest.fn(),
       expandLeft: jest.fn(),
       expandTop: jest.fn(),
-      getHyperCubePivotData: jest.fn() as jest.MockedFunction<() => Promise<EngineAPI.INxPivotPage[]>>,
+      getHyperCubePivotData: getHyperCubePivotDataMock,
     } as unknown as EngineAPI.IGenericObject;
-    (model.getHyperCubePivotData as jest.Mock).mockResolvedValue([]);
+    (model.getHyperCubePivotData as jest.Mock).mockResolvedValue([pivotPage]);
     nextPageHandler = jest.fn();
     pageInfo = {
       page: 0,
@@ -70,18 +74,17 @@ describe("useDataModel", () => {
       } as unknown as EngineAPI.IGenericBookmark;
 
       const { fetchMoreData } = renderer();
-      const output = await fetchMoreData(1, 2, 10, 20);
+      await fetchMoreData(1, 2, 10, 20);
 
-      expect(output).toBeFalsy();
+      expect(getHyperCubePivotDataMock).not.toHaveBeenCalled();
+      expect(nextPageHandler).not.toHaveBeenCalled();
     });
 
     test("fetchMoreData should call getHyperCubePivotData to fetch more data", async () => {
       const { fetchMoreData } = renderer();
-      const output = await fetchMoreData(1, 2, 10, 20);
+      await fetchMoreData(1, 2, 10, 20);
 
-      expect(output).toBeTruthy();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect((model as EngineAPI.IGenericObject).getHyperCubePivotData).toHaveBeenCalledWith(Q_PATH, [
+      expect(getHyperCubePivotDataMock).toHaveBeenCalledWith(Q_PATH, [
         {
           qLeft: 1,
           qTop: 2,
@@ -89,6 +92,7 @@ describe("useDataModel", () => {
           qWidth: 10,
         },
       ]);
+      expect(nextPageHandler).toHaveBeenCalledWith(pivotPage);
     });
 
     test("fetchMoreData should consider `pageInfo` while calling getHyperCubePivotData to fetch more data", async () => {
@@ -97,11 +101,9 @@ describe("useDataModel", () => {
         page: 5,
       };
       const { fetchMoreData } = renderer();
-      const output = await fetchMoreData(1, 2, 10, 20);
+      await fetchMoreData(1, 2, 10, 20);
 
-      expect(output).toBeTruthy();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect((model as EngineAPI.IGenericObject).getHyperCubePivotData).toHaveBeenCalledWith(Q_PATH, [
+      expect(getHyperCubePivotDataMock).toHaveBeenCalledWith(Q_PATH, [
         {
           qLeft: 1,
           qTop: pageInfo.page * pageInfo.rowsPerPage + 2,
@@ -109,15 +111,14 @@ describe("useDataModel", () => {
           qWidth: 10,
         },
       ]);
+      expect(nextPageHandler).toHaveBeenCalledWith(pivotPage);
     });
 
     test("fetchMoreData should not try and fetch more data then available", async () => {
       const { fetchMoreData } = renderer();
-      const output = await fetchMoreData(40, 50, 50, 60);
+      await fetchMoreData(40, 50, 50, 60);
 
-      expect(output).toBeTruthy();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect((model as EngineAPI.IGenericObject).getHyperCubePivotData).toHaveBeenCalledWith(Q_PATH, [
+      expect(getHyperCubePivotDataMock).toHaveBeenCalledWith(Q_PATH, [
         {
           qLeft: 40,
           qTop: 50,
@@ -125,15 +126,54 @@ describe("useDataModel", () => {
           qWidth: 50,
         },
       ]);
+      expect(nextPageHandler).toHaveBeenCalledWith(pivotPage);
     });
 
     test("fetchMoreData should handle when call to getHyperCubePivotData is rejected", async () => {
-      const genericObjectModel = model as EngineAPI.IGenericObject;
-      (genericObjectModel.getHyperCubePivotData as jest.Mock).mockRejectedValue(new Error("testing"));
+      getHyperCubePivotDataMock.mockRejectedValue(new Error("testing"));
       const { fetchMoreData } = renderer();
-      const output = await fetchMoreData(1, 2, 10, 20);
+      await fetchMoreData(1, 2, 10, 20);
 
-      expect(output).toBeFalsy();
+      expect(getHyperCubePivotDataMock).toHaveBeenCalledWith(Q_PATH, [
+        {
+          qLeft: 1,
+          qTop: 2,
+          qHeight: 20,
+          qWidth: 10,
+        },
+      ]);
+      expect(nextPageHandler).not.toHaveBeenCalled();
+    });
+
+    test("fetchMoreData should handle when page is changed during fetch", async () => {
+      getHyperCubePivotDataMock.mockResolvedValueOnce(
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve([]);
+          }, 1000);
+        }),
+      );
+      const { rerender, result } = renderHook(
+        (pi: PageInfo) => useDataModel({ model, nextPageHandler, pageInfo: pi }),
+        {
+          initialProps: pageInfo,
+        },
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      result.current.fetchMoreData(1, 2, 10, 20);
+
+      rerender({ ...pageInfo, page: 1 });
+
+      expect(getHyperCubePivotDataMock).toHaveBeenCalledWith(Q_PATH, [
+        {
+          qLeft: 1,
+          qTop: 2,
+          qHeight: 20,
+          qWidth: 10,
+        },
+      ]);
+      expect(nextPageHandler).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/pivot-table/hooks/use-mutable-prop.ts
+++ b/src/pivot-table/hooks/use-mutable-prop.ts
@@ -1,0 +1,10 @@
+import { useRef } from "react";
+
+const useMutableProp = <T>(value: T) => {
+  const mutableRef = useRef<T>(value);
+  mutableRef.current = value;
+
+  return mutableRef;
+};
+
+export default useMutableProp;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -5,7 +5,7 @@ export type ExpandOrCollapser = (rowIndex: number, columnIndex: number) => void;
 
 export type FetchNextPage = (isRow: boolean, startIndex: number) => Promise<boolean>;
 
-export type FetchMoreData = (left: number, top: number, width: number, height: number) => Promise<boolean>;
+export type FetchMoreData = (left: number, top: number, width: number, height: number) => Promise<void>;
 
 export type List = Record<number, Cell>;
 


### PR DESCRIPTION
Fixes an issue where data from previous page could end up on the new page.

It could be reproduces in the following way:
1. Go to last page
2. Scroll down to bottom. Should be more than 50 rows on the page and the call to `getHyperCubePivotData` have to be slow.
3. Go to first page.

Now the data from the last page would be rendered on the first page.