### PR TITLE
fix: prevent clickable head cell for pseudo dims

### DIFF
--- a/src/pivot-table/components/cells/DimensionTitleCell.tsx
+++ b/src/pivot-table/components/cells/DimensionTitleCell.tsx
@@ -93,7 +93,6 @@ const DimensionTitleCell = ({
       style={{
         ...style,
         ...getBorderStyle(true, isLastColumn, styleService.grid.border),
-
         color,
       }}
       data-testid={testId}

--- a/src/pivot-table/components/cells/DimensionTitleCell.tsx
+++ b/src/pivot-table/components/cells/DimensionTitleCell.tsx
@@ -86,7 +86,7 @@ const DimensionTitleCell = ({
     <StyledHeaderCellWrapper
       title={cell.title}
       interactions={interactions}
-      background={isDim && open ? activeBackground : background}
+      background={open ? activeBackground : background}
       hoverBackground={hoverBackground}
       shouldShowMenuIcon={shouldShowMenuIcon}
       isDimension={isDim}

--- a/src/pivot-table/components/cells/DimensionTitleCell.tsx
+++ b/src/pivot-table/components/cells/DimensionTitleCell.tsx
@@ -86,12 +86,14 @@ const DimensionTitleCell = ({
     <StyledHeaderCellWrapper
       title={cell.title}
       interactions={interactions}
-      background={open ? activeBackground : background}
+      background={isDim && open ? activeBackground : background}
       hoverBackground={hoverBackground}
       shouldShowMenuIcon={shouldShowMenuIcon}
+      isDimension={isDim}
       style={{
         ...style,
         ...getBorderStyle(true, isLastColumn, styleService.grid.border),
+
         color,
       }}
       data-testid={testId}

--- a/src/pivot-table/components/cells/styles.tsx
+++ b/src/pivot-table/components/cells/styles.tsx
@@ -15,12 +15,14 @@ interface StyledHeaderCellWrapperProps {
   background: string;
   hoverBackground: string;
   shouldShowMenuIcon: boolean;
+  isDimension: boolean;
 }
 
 export const StyledHeaderCellWrapper = styled(Box, {
   shouldForwardProp: (prop: string) =>
-    !["interactions", "hoverBackground", "background", "shouldShowMenuIcon"].includes(prop),
-})(({ interactions, background, hoverBackground, shouldShowMenuIcon }: StyledHeaderCellWrapperProps) => ({
+    !["interactions", "hoverBackground", "background", "shouldShowMenuIcon", "isDimension"].includes(prop),
+})(({ interactions, background, hoverBackground, shouldShowMenuIcon, isDimension }: StyledHeaderCellWrapperProps) => ({
+  pointerEvents: isDimension ? "all" : "none",
   position: "relative",
   display: "grid",
   gridTemplateColumns: shouldShowMenuIcon ? `1fr ${HEADER_ICON_SIZE}px` : "1fr",


### PR DESCRIPTION
fix for this: 

https://github.com/qlik-oss/sn-pivot-table/assets/29652890/efd8db39-79cb-4f8b-b0cc-1643b80b052a

