### PR TITLE
docs: add color by expression definition

### DIFF
--- a/api-specifications/properties.json
+++ b/api-specifications/properties.json
@@ -143,6 +143,12 @@
       "entries": {
         "qDef": {
           "type": "#/definitions/InlineDimensionDef"
+        },
+        "qAttributeExpressions": {
+          "kind": "array",
+          "items": {
+            "type": "#/definitions/AttributeExpressionDef"
+          }
         }
       }
     },
@@ -157,8 +163,53 @@
       "entries": {
         "qDefs": {
           "type": "#/definitions/InlineMeasureDef"
+        },
+        "qAttributeExpressions": {
+          "kind": "array",
+          "items": {
+            "type": "#/definitions/AttributeExpressionDef"
+          }
         }
       }
+    },
+    "AttributeExpressionDef": {
+      "kind": "union",
+      "items": [
+        {
+          "type": "#/definitions/ColorByExpressionDef"
+        },
+        {
+          "type": "NxAttrExprDef"
+        }
+      ]
+    },
+    "ColorByExpressionId": {
+      "description": "Color by expression identifier",
+      "kind": "union",
+      "items": [
+        {
+          "kind": "literal",
+          "value": "\"cellBackgroundColor\""
+        },
+        {
+          "kind": "literal",
+          "value": "\"cellForegroundColor\""
+        }
+      ]
+    },
+    "ColorByExpressionDef": {
+      "kind": "object",
+      "entries": {
+        "qExpression": {
+          "type": "StringExpression"
+        },
+        "id": {
+          "type": "#/definitions/ColorByExpressionId"
+        }
+      },
+      "examples": [
+        "{ qExpression: \"=if(Sum([Sales Quantity]) > 500, green(), blue())\", id: \"cellBackgroundColor\" }"
+      ]
     },
     "InlineDimensionDef": {
       "description": "Extends `NxInlineDimensionDef`, see Engine API: `NxInlineDimensionDef`.",

--- a/scriptappy.config.js
+++ b/scriptappy.config.js
@@ -25,6 +25,9 @@ module.exports = {
         GenericObjectProperties: {
           url: "https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FGenericObjectProperties",
         },
+        NxAttrExprDef: {
+          url: "https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxAttrExprDef",
+        },
         NxDimension: {
           url: "https://qlik.dev/apis/json-rpc/qix/schemas#%23%2Fdefinitions%2Fschemas%2Fentries%2FNxDimension",
         },

--- a/src/qae/initial-properties.js
+++ b/src/qae/initial-properties.js
@@ -80,6 +80,7 @@ const properties = {
  * @type object
  * @extends NxDimension
  * @property {InlineDimensionDef} qDef
+ * @property {AttributeExpressionDef[]} qAttributeExpressions
  */
 
 /**
@@ -88,6 +89,27 @@ const properties = {
  * @type object
  * @extends NxMeasure
  * @property {InlineMeasureDef} qDefs
+ * @property {AttributeExpressionDef[]} qAttributeExpressions
+ */
+
+/**
+ * @name AttributeExpressionDef
+ * @type {ColorByExpressionDef | NxAttrExprDef}
+ */
+
+/**
+ * Color by expression identifier
+ * @name ColorByExpressionId
+ * @type {"cellBackgroundColor" | "cellForegroundColor"}
+ */
+
+/**
+ * @name ColorByExpressionDef
+ * @type object
+ * @property {StringExpression} qExpression
+ * @property {ColorByExpressionId} id
+ * @example
+ * { qExpression: "=if(Sum([Sales Quantity]) > 500, green(), blue())", id: "cellBackgroundColor" }
  */
 
 /**


### PR DESCRIPTION
Adds the defintion for color by expression to the API.

Example on how this color by expression can be defined:

```js
embeded.render({
    element: document.querySelector(".object"),
    type: "sn-pivot-table",
    fields: ["City"],
    properties: {
      qHyperCubeDef: {
        qMode: "P",
        qMeasures: [{
         qDef: {
            qLabel: "Sales Quantity",
            qDef: "=Sum([Sales Quantity])",
          },
          qAttributeExpressions: [
            {
              qExpression: "=if(Sum([Sales Quantity]) > 500, green(), blue())",
              id: "cellBackgroundColor"
            },
            {
              qExpression: "=if(Sum([Sales Quantity]) > 500, white(), yellow())",
              id: "cellForegroundColor"
            }
          ],
        }],
      },
    }
  });
```