### PR TITLE
fix: default measure labels color

### DIFF
--- a/src/services/__tests__/style-service.test.ts
+++ b/src/services/__tests__/style-service.test.ts
@@ -249,7 +249,7 @@ describe("style-service", () => {
         fontWeight: "normal",
         fontStyle: "normal",
         textDecoration: "none",
-        color: "#404040",
+        color: "rgba(0, 0, 0, 0.55)",
         background: "transparent",
       },
       totalValues: {

--- a/src/services/style-service.ts
+++ b/src/services/style-service.ts
@@ -177,7 +177,7 @@ const createStyleService = (theme: ExtendedTheme, layoutService: LayoutService):
       color:
         resolveColor(theme, measureLabelStyling?.[Attribute.FontColor]) ??
         getThemeStyle([Path.MeasureLabels], Attribute.Color) ??
-        Colors.PrimaryText,
+        Colors.Black55,
       background:
         resolveColor(theme, measureLabelStyling?.[Attribute.Background]) ??
         getThemeStyle([Path.MeasureLabels], Attribute.Background) ??


### PR DESCRIPTION
Measure labels and measure values has per design spec the same default color.