### PR TITLE
fix: primary text color

### DIFF
--- a/src/pivot-table/components/shared-styles.ts
+++ b/src/pivot-table/components/shared-styles.ts
@@ -2,6 +2,7 @@ import type React from "react";
 import type { ShowLastBorder } from "../../types/types";
 import { LINE_HEIGHT_COEFFICIENT } from "../constants";
 
+// TODO Replace with colors from Sprout
 export enum Colors {
   Black3 = "rgba(0, 0, 0, 0.03)",
   Black5 = "rgba(0, 0, 0, 0.05)",

--- a/src/pivot-table/components/shared-styles.ts
+++ b/src/pivot-table/components/shared-styles.ts
@@ -3,7 +3,6 @@ import type { ShowLastBorder } from "../../types/types";
 import { LINE_HEIGHT_COEFFICIENT } from "../constants";
 
 export enum Colors {
-  PrimaryText = "#404040",
   Black3 = "rgba(0, 0, 0, 0.03)",
   Black5 = "rgba(0, 0, 0, 0.05)",
   Black15 = "rgba(0, 0, 0, 0.15)",

--- a/src/services/style-service.ts
+++ b/src/services/style-service.ts
@@ -1,5 +1,5 @@
 import type { ExtendedTheme } from "@qlik/nebula-table-utils/lib/hooks/use-extended-theme/types";
-import { getHoverColor } from "@qlik/nebula-table-utils/lib/utils";
+import { COLORING, getHoverColor } from "@qlik/nebula-table-utils/lib/utils";
 import { Colors } from "../pivot-table/components/shared-styles";
 import {
   BOLD_FONT_WEIGHT,
@@ -123,7 +123,7 @@ const createStyleService = (theme: ExtendedTheme, layoutService: LayoutService):
       color:
         resolveColor(theme, headerStyling?.[Attribute.FontColor]) ??
         getThemeStyle([Path.Header], Attribute.Color) ??
-        Colors.PrimaryText,
+        COLORING.TEXT,
       background: headerBackground,
       hoverBackground: getHoverColor(headerBackground, HEADER_MENU_COLOR_MODIFIER.hover),
       activeBackground: getHoverColor(headerBackground, HEADER_MENU_COLOR_MODIFIER.active),
@@ -143,7 +143,7 @@ const createStyleService = (theme: ExtendedTheme, layoutService: LayoutService):
       color:
         resolveColor(theme, dimensionValue?.[Attribute.FontColor]) ??
         getThemeStyle([Path.DimensionValues], Attribute.Color) ??
-        Colors.PrimaryText,
+        COLORING.TEXT,
       background:
         resolveColor(theme, dimensionValue?.[Attribute.Background]) ??
         getThemeStyle([Path.DimensionValues], Attribute.Background) ??
@@ -177,7 +177,7 @@ const createStyleService = (theme: ExtendedTheme, layoutService: LayoutService):
       color:
         resolveColor(theme, measureLabelStyling?.[Attribute.FontColor]) ??
         getThemeStyle([Path.MeasureLabels], Attribute.Color) ??
-        Colors.PrimaryText,
+        COLORING.TEXT,
       background:
         resolveColor(theme, measureLabelStyling?.[Attribute.Background]) ??
         getThemeStyle([Path.MeasureLabels], Attribute.Background) ??
@@ -190,7 +190,7 @@ const createStyleService = (theme: ExtendedTheme, layoutService: LayoutService):
       color:
         resolveColor(theme, totalValuesStyling?.[Attribute.FontColor]) ??
         getThemeStyle([Path.TotalValues], Attribute.Color) ??
-        Colors.PrimaryText,
+        COLORING.TEXT,
       background:
         resolveColor(theme, totalValuesStyling?.[Attribute.Background]) ??
         getThemeStyle([Path.TotalValues], Attribute.Background) ??
@@ -203,7 +203,7 @@ const createStyleService = (theme: ExtendedTheme, layoutService: LayoutService):
       color:
         resolveColor(theme, nullValueStyling?.[Attribute.FontColor]) ??
         getThemeStyle([Path.NullValues], Attribute.Color) ??
-        Colors.PrimaryText,
+        COLORING.TEXT,
       background:
         resolveColor(theme, nullValueStyling?.[Attribute.Background]) ??
         getThemeStyle([Path.NullValues], Attribute.Background) ??


### PR DESCRIPTION
Changes so that the default text color is resolved from the sprout color palette instead of being hard-coded in sn-pivot-table repo.

Currently the colors are the same and I would guess not really expected to change any time soon.