### PR TITLE
fix: contrasting color for light background

### DIFF
--- a/src/pivot-table/data/helpers/__tests__/get-expression-color.test.ts
+++ b/src/pivot-table/data/helpers/__tests__/get-expression-color.test.ts
@@ -1,3 +1,4 @@
+import { COLORING } from "@qlik/nebula-table-utils/lib/utils";
 import type { AttrExprInfoIndex } from "../../../../types/types";
 import getExpressionColor from "../get-expression-color";
 
@@ -30,7 +31,20 @@ describe("getExpressionColor", () => {
 
     expect(expressionColor).toEqual({
       background: "rgb(0, 0, 0)",
-      color: "#FFFFFF",
+      color: COLORING.WHITE,
+    });
+  });
+
+  test("should return contrasting color when background is light and there is no expression for color", () => {
+    attrsExprInfoIndex = { cellForegroundColor: -1, cellBackgroundColor: 0 };
+    cell = {
+      qAttrExps: { qValues: [{ qText: "white" }] },
+    } as unknown as EngineAPI.INxPivotDimensionCell;
+    const expressionColor = getExpressionColor(attrsExprInfoIndex, cell);
+
+    expect(expressionColor).toEqual({
+      background: "rgb(255, 255, 255)",
+      color: COLORING.TEXT,
     });
   });
 

--- a/src/pivot-table/data/helpers/get-expression-color.ts
+++ b/src/pivot-table/data/helpers/get-expression-color.ts
@@ -2,6 +2,14 @@ import { COLORING, isDarkColor } from "@qlik/nebula-table-utils/lib/utils";
 import type { AttrExprInfoIndex } from "../../../types/types";
 import toRGB from "./to-rgb";
 
+const getContrastingColor = (color: string | null, background: string | null) => {
+  if (color || !background) {
+    return null;
+  }
+
+  return isDarkColor(background) ? COLORING.WHITE : COLORING.TEXT;
+};
+
 const getExpressionColor = (
   attrsExprInfo: AttrExprInfoIndex,
   cell: EngineAPI.INxPivotValuePoint | EngineAPI.INxPivotDimensionCell,
@@ -12,8 +20,8 @@ const getExpressionColor = (
   const expressionBackground = attrsExprValues?.qValues?.[attrsExprInfo.cellBackgroundColor]?.qText;
 
   const background = expressionBackground ? toRGB(expressionBackground) : null;
-  const contrastingColor = !expressionColor && background && isDarkColor(background) ? COLORING.WHITE : null;
   const color = expressionColor ? toRGB(expressionColor) : null;
+  const contrastingColor = getContrastingColor(color, background);
 
   return {
     color: contrastingColor ?? color,


### PR DESCRIPTION
Make the text color for a cell with "dark" AND "light" background color hard-coded to improve readability.

Note: that it only applies to cells that get the background color from an expression.