### PR TITLE
refactor: use headers data for column width

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,3 +7,4 @@ export const TOTALS_CELL = -1;
 export const TOTAL_MODE_ON = "TOTAL_EXPR";
 
 export const PSEUDO_DIMENSION_INDEX = -1;
+export const PSEUDO_DIMENSION_KEY = "PSEUDO-DIM";

--- a/src/pivot-table/components/PivotTable.tsx
+++ b/src/pivot-table/components/PivotTable.tsx
@@ -92,7 +92,7 @@ export const StickyPivotTable = ({
     showLastRightBorder,
     getRightGridColumnWidth,
     getHeaderCellsIconsVisibilityStatus,
-  } = useColumnWidth(layoutService, tableRect, visibleLeftDimensionInfo, visibleTopDimensionInfo);
+  } = useColumnWidth(layoutService, tableRect, headersData, visibleTopDimensionInfo);
 
   const headerCellRowHightCallback = useCallback(() => headerCellHeight, [headerCellHeight]);
   const contentCellRowHightCallback = useCallback(() => contentCellHeight, [contentCellHeight]);

--- a/src/pivot-table/components/grids/HeaderGrid.tsx
+++ b/src/pivot-table/components/grids/HeaderGrid.tsx
@@ -40,6 +40,8 @@ const HeaderGrid = ({
 
   const hasMultipleRows = headersData.size.y > 1;
 
+  const lastRow = headersData.data.at(-1) ?? [];
+
   return (
     <div
       style={{
@@ -51,8 +53,8 @@ const HeaderGrid = ({
       }}
     >
       {hasMultipleRows && <EmptyHeaderCell columnWidths={columnWidths} />}
-      {headersData.data.map((col, colIndex) => {
-        const cell = col[col.length - 1] as HeaderCell;
+      {lastRow.map((col, colIndex) => {
+        const cell = col as HeaderCell;
         const iconsVisibilityStatus = getHeaderCellsIconsVisibilityStatus(colIndex, cell.isLocked, cell.label);
 
         return (

--- a/src/pivot-table/components/helpers/get-key.ts
+++ b/src/pivot-table/components/helpers/get-key.ts
@@ -1,9 +1,9 @@
-import { PSEUDO_DIMENSION_INDEX } from "../../../constants";
+import { PSEUDO_DIMENSION_INDEX, PSEUDO_DIMENSION_KEY } from "../../../constants";
 import type { VisibleDimensionInfo } from "../../../types/types";
 
 const getKey = (qDimensionInfo: VisibleDimensionInfo): string => {
   if (qDimensionInfo === PSEUDO_DIMENSION_INDEX) {
-    return "-1";
+    return PSEUDO_DIMENSION_KEY;
   }
 
   return (

--- a/src/pivot-table/data/__tests__/extract-headers.test.ts
+++ b/src/pivot-table/data/__tests__/extract-headers.test.ts
@@ -1,4 +1,4 @@
-import { PSEUDO_DIMENSION_INDEX } from "../../../constants";
+import { PSEUDO_DIMENSION_INDEX, PSEUDO_DIMENSION_KEY } from "../../../constants";
 import type { ExtendedHyperCube } from "../../../types/QIX";
 import extractHeaders from "../extract-headers";
 import { createDimInfo } from "./test-helper";
@@ -14,7 +14,8 @@ describe("extractHeaders", () => {
 
   test("should extract headers with row count 1 and column count 1", () => {
     const sortedLeftDimensionInfo = createDimInfo(1);
-    const headers = extractHeaders(hyperCube, 1, sortedLeftDimensionInfo);
+    const sortedTopDimensionInfo = createDimInfo(1);
+    const headers = extractHeaders(hyperCube, sortedTopDimensionInfo, sortedLeftDimensionInfo);
 
     expect(headers).toHaveLength(1);
     expect(headers[0]).toHaveLength(1);
@@ -24,63 +25,68 @@ describe("extractHeaders", () => {
 
   test("should extract headers with row count 1 and column count 2", () => {
     const sortedLeftDimensionInfo = createDimInfo(2);
-    const headers = extractHeaders(hyperCube, 1, sortedLeftDimensionInfo);
+    const sortedTopDimensionInfo = createDimInfo(1);
+    const headers = extractHeaders(hyperCube, sortedTopDimensionInfo, sortedLeftDimensionInfo);
 
-    expect(headers).toHaveLength(2);
-    expect(headers[0]).toHaveLength(1);
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toHaveLength(2);
     expect(headers[0][0]?.label).toBe("dim 0");
     expect(headers[0][0]?.id).toBe("id-0");
-    expect(headers[1][0]?.label).toBe("dim 1");
-    expect(headers[1][0]?.id).toBe("id-1");
+    expect(headers[0][1]?.label).toBe("dim 1");
+    expect(headers[0][1]?.id).toBe("id-1");
   });
 
   test("should extract headers with row count 1 and column count 2 and a pseudo dimension on first column", () => {
     const sortedLeftDimensionInfo = createDimInfo(1);
     sortedLeftDimensionInfo.unshift(PSEUDO_DIMENSION_INDEX);
-    const headers = extractHeaders(hyperCube, 1, sortedLeftDimensionInfo);
+    const sortedTopDimensionInfo = createDimInfo(1);
+    const headers = extractHeaders(hyperCube, sortedTopDimensionInfo, sortedLeftDimensionInfo);
 
-    expect(headers).toHaveLength(2);
-    expect(headers[0]).toHaveLength(1);
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toHaveLength(2);
     expect(headers[0][0]?.label).toBe("");
-    expect(headers[0][0]?.id).toBe("PSEUDO-DIM");
-    expect(headers[1][0]?.label).toBe("dim 0");
-    expect(headers[1][0]?.id).toBe("id-0");
+    expect(headers[0][0]?.id).toBe(PSEUDO_DIMENSION_KEY);
+    expect(headers[0][1]?.label).toBe("dim 0");
+    expect(headers[0][1]?.id).toBe("id-0");
   });
 
   test("should extract headers with row count 1 and column count 2 and a pseudo dimension on last column", () => {
     const sortedLeftDimensionInfo = createDimInfo(1);
     sortedLeftDimensionInfo.push(PSEUDO_DIMENSION_INDEX);
-    const headers = extractHeaders(hyperCube, 1, sortedLeftDimensionInfo);
+    const sortedTopDimensionInfo = createDimInfo(1);
+    const headers = extractHeaders(hyperCube, sortedTopDimensionInfo, sortedLeftDimensionInfo);
 
-    expect(headers).toHaveLength(2);
-    expect(headers[0]).toHaveLength(1);
+    expect(headers).toHaveLength(1);
+    expect(headers[0]).toHaveLength(2);
     expect(headers[0][0]?.label).toBe("dim 0");
     expect(headers[0][0]?.id).toBe("id-0");
-    expect(headers[1][0]?.label).toBe("");
-    expect(headers[1][0]?.id).toBe("PSEUDO-DIM");
+    expect(headers[0][1]?.label).toBe("");
+    expect(headers[0][1]?.id).toBe(PSEUDO_DIMENSION_KEY);
   });
 
   test("should extract headers with row count 2 and column count 1", () => {
     const sortedLeftDimensionInfo = createDimInfo(1);
-    const headers = extractHeaders(hyperCube, 2, sortedLeftDimensionInfo);
+    const sortedTopDimensionInfo = createDimInfo(2);
+    const headers = extractHeaders(hyperCube, sortedTopDimensionInfo, sortedLeftDimensionInfo);
 
-    expect(headers).toHaveLength(1);
-    expect(headers[0]).toHaveLength(2);
+    expect(headers).toHaveLength(2);
+    expect(headers[0]).toHaveLength(1);
     expect(headers[0][0]).toBe(null);
-    expect(headers[0][1]?.label).toBe("dim 0");
-    expect(headers[0][1]?.id).toBe("id-0");
+    expect(headers[1][0]?.label).toBe("dim 0");
+    expect(headers[1][0]?.id).toBe("id-0");
   });
 
   test("should extract headers with row count 2 and column count 2", () => {
     const sortedLeftDimensionInfo = createDimInfo(2);
-    const headers = extractHeaders(hyperCube, 2, sortedLeftDimensionInfo);
+    const sortedTopDimensionInfo = createDimInfo(2);
+    const headers = extractHeaders(hyperCube, sortedTopDimensionInfo, sortedLeftDimensionInfo);
 
     expect(headers).toHaveLength(2);
     expect(headers[0]).toHaveLength(2);
     expect(headers[0][0]).toBe(null);
-    expect(headers[1][0]).toBe(null);
-    expect(headers[0][1]?.label).toBe("dim 0");
-    expect(headers[0][1]?.id).toBe("id-0");
+    expect(headers[0][1]).toBe(null);
+    expect(headers[1][0]?.label).toBe("dim 0");
+    expect(headers[1][0]?.id).toBe("id-0");
     expect(headers[1][1]?.label).toBe("dim 1");
     expect(headers[1][1]?.id).toBe("id-1");
   });

--- a/src/pivot-table/data/__tests__/headers-data.test.ts
+++ b/src/pivot-table/data/__tests__/headers-data.test.ts
@@ -25,18 +25,18 @@ describe("create headers data", () => {
     ];
     mockedExtractHeaders.mockReturnValue(headers);
 
-    const headersData = createHeadersData(hyperCube, 1, []);
+    const headersData = createHeadersData(hyperCube, [], []);
 
     expect(headersData.data).toEqual(headers);
-    expect(headersData.size.x).toBe(1);
-    expect(headersData.size.y).toBe(2);
+    expect(headersData.size.x).toBe(2);
+    expect(headersData.size.y).toBe(1);
   });
 
   test("should handle when there are no headers", () => {
     const headers = [] as HeaderCell[][];
     mockedExtractHeaders.mockReturnValue(headers);
 
-    const headersData = createHeadersData(hyperCube, 1, []);
+    const headersData = createHeadersData(hyperCube, [], []);
 
     expect(headersData.data).toEqual(headers);
     expect(headersData.size.x).toBe(0);

--- a/src/pivot-table/data/extract-headers.ts
+++ b/src/pivot-table/data/extract-headers.ts
@@ -5,17 +5,20 @@ import getKey from "../components/helpers/get-key";
 
 const extractHeaders = (
   hyperCube: ExtendedHyperCube,
-  rowCount: number,
+  visibleTopDimensionInfo: VisibleDimensionInfo[],
   visibleLeftDimensionInfo: VisibleDimensionInfo[],
 ): (null | HeaderCell)[][] => {
-  const matrix: (null | HeaderCell)[][] = Array(visibleLeftDimensionInfo.length)
+  // rowCount cannot be 0, as it will cause an issue when there is no top data but there is left data
+  const rowCount = Math.max(1, visibleTopDimensionInfo.length);
+  const matrix: (null | HeaderCell)[][] = Array(rowCount)
     .fill(null)
-    .map(() => Array.from({ length: rowCount }, () => null));
+    .map(() => Array.from({ length: visibleLeftDimensionInfo.length }, () => null));
 
   visibleLeftDimensionInfo.forEach((qDimensionInfo, colIdx) => {
+    const id = getKey(qDimensionInfo);
     if (qDimensionInfo === PSEUDO_DIMENSION_INDEX) {
-      matrix[colIdx][rowCount - 1] = {
-        id: "PSEUDO-DIM",
+      matrix[rowCount - 1][colIdx] = {
+        id,
         colIdx: -1,
         label: "",
         sortDirection: "A",
@@ -26,8 +29,7 @@ const extractHeaders = (
         headTextAlign: "left",
       };
     } else {
-      const id: string = getKey(qDimensionInfo);
-      matrix[colIdx][rowCount - 1] = {
+      matrix[rowCount - 1][colIdx] = {
         id,
         colIdx,
         label: qDimensionInfo.qFallbackTitle,
@@ -38,6 +40,8 @@ const extractHeaders = (
         fieldId: qDimensionInfo.qGroupFieldDefs[qDimensionInfo.qGroupPos],
         isActivelySorted: colIdx === (hyperCube.activelySortedColumn?.colIdx ?? 0),
         isLocked: qDimensionInfo.qLocked ?? false,
+        columnWidth: qDimensionInfo.columnWidth,
+        qApprMaxGlyphCount: qDimensionInfo.qApprMaxGlyphCount,
         isDim: true,
         headTextAlign: "left",
       };

--- a/src/pivot-table/data/headers-data.ts
+++ b/src/pivot-table/data/headers-data.ts
@@ -4,17 +4,17 @@ import extractHeaders from "./extract-headers";
 
 const createHeadersData = (
   qHyperCube: ExtendedHyperCube,
-  rowCount: number,
+  visibleTopDimensionInfo: VisibleDimensionInfo[],
   visibleLeftDimensionInfo: VisibleDimensionInfo[],
 ): HeadersData => {
   // rowCount cannot be 0, as it couse issue when there is no top data but there is left data
-  const data = extractHeaders(qHyperCube, Math.max(rowCount, 1), visibleLeftDimensionInfo);
+  const data = extractHeaders(qHyperCube, visibleTopDimensionInfo, visibleLeftDimensionInfo);
 
   return {
     data,
     size: {
-      x: data.length,
-      y: data[0]?.length || 0,
+      x: data[0]?.length || 0,
+      y: data.length,
     },
   };
 };

--- a/src/pivot-table/hooks/__tests__/use-data.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-data.test.ts
@@ -65,7 +65,11 @@ describe("useData", () => {
   >;
   // Header data mocks
   let mockedCreateHeadersData: jest.MockedFunction<
-    (hyperCube: ExtendedHyperCube, rowCount: number, sortedLeftDimensionInfo: VisibleDimensionInfo[]) => HeadersData
+    (
+      hyperCube: ExtendedHyperCube,
+      visibleTopDimensionInfo: VisibleDimensionInfo[],
+      sortedLeftDimensionInfo: VisibleDimensionInfo[],
+    ) => HeadersData
   >;
 
   let topDimensionData: TopDimensionData;

--- a/src/pivot-table/hooks/use-data.ts
+++ b/src/pivot-table/hooks/use-data.ts
@@ -145,8 +145,8 @@ const useData = (
   }, [nextPage]);
 
   const headersData = useMemo<HeadersData>(
-    () => createHeadersData(qHyperCube, topDimensionData.rowCount, visibleLeftDimensionInfo),
-    [qHyperCube, topDimensionData.rowCount, visibleLeftDimensionInfo],
+    () => createHeadersData(qHyperCube, visibleTopDimensionInfo, visibleLeftDimensionInfo),
+    [qHyperCube, visibleTopDimensionInfo, visibleLeftDimensionInfo],
   );
 
   const nextPageHandler = useCallback((page: EngineAPI.INxPivotPage) => {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,6 @@
 import type { stardust } from "@nebula.js/stardust";
 import type { HeaderData, SortDirection } from "@qlik/nebula-table-utils/lib/components/HeadCellMenu/types";
+import type { PSEUDO_DIMENSION_INDEX } from "../constants";
 import type { ColumnWidth, ExtendedDimensionInfo, PivotLayout } from "./QIX";
 
 export type ExpandOrCollapser = (rowIndex: number, columnIndex: number) => void;
@@ -15,13 +16,15 @@ export type List = Record<number, Cell>;
 export type Grid = List[];
 
 export interface HeaderCell extends HeaderData {
+  columnWidth?: ColumnWidth;
   qReverseSort?: boolean;
   isLocked: boolean;
+  qApprMaxGlyphCount?: number;
 }
 
 export type MeasureData = MeasureCell[][];
 
-export type VisibleDimensionInfo = ExtendedDimensionInfo | -1;
+export type VisibleDimensionInfo = ExtendedDimensionInfo | typeof PSEUDO_DIMENSION_INDEX;
 
 export interface Rect {
   width: number;


### PR DESCRIPTION
To prepare for horizontal headers make column width
use headers data instead of visibleLeftDimensionInfo

Refs: VIZ-2530