### PR TITLE
fix: column width error

### DIFF
--- a/src/pivot-table/hooks/__tests__/use-data-model.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-data-model.test.ts
@@ -204,6 +204,7 @@ describe("useDataModel", () => {
         layout: {
           qHyperCube: { qDimensionInfo: [dimension, dimension], qMeasureInfo: [measure, measure], qNoOfLeftDims: 0 },
         },
+        hasPseudoDimOnLeft: false,
         getMeasureInfoIndexFromCellIndex: (index: number) => index,
       } as unknown as LayoutService;
 
@@ -224,6 +225,18 @@ describe("useDataModel", () => {
     test("should call applyPatches with qPath for dimension with pseudo as ancestor", () => {
       layoutService.layout.qHyperCube.qNoOfLeftDims = 1;
       cell.isAncestorPseudoDimension = true;
+      cell.y = 1;
+      patch.qPath = "/qHyperCubeDef/qDimensions/1/qDef/columnWidth";
+
+      const { applyColumnWidth } = renderer();
+      applyColumnWidth(newColumnWidth, cell);
+
+      expect(model?.applyPatches).toHaveBeenCalledWith([patch], true);
+    });
+
+    test("should call applyPatches with qPath for dimension when hasPseudoDimOnLeft is true", () => {
+      layoutService.layout.qHyperCube.qNoOfLeftDims = 1;
+      layoutService.hasPseudoDimOnLeft = true;
       cell.y = 1;
       patch.qPath = "/qHyperCubeDef/qDimensions/1/qDef/columnWidth";
 

--- a/src/pivot-table/hooks/use-column-width.ts
+++ b/src/pivot-table/hooks/use-column-width.ts
@@ -84,7 +84,7 @@ export default function useColumnWidth(
    * The widths of the left columns. Scales the width to fit LEFT_SIDE_MAX_WIDTH_RATIO * rect.width if wider than that
    */
   const leftGridWidthInfo = useMemo<LeftGridWidthInfo>(() => {
-    const getColumnWidth = (columnWidth: ColumnWidth, fitToContentWidth: number) => {
+    const getColumnWidth = (columnWidth: ColumnWidth | undefined, fitToContentWidth: number) => {
       switch (columnWidth?.type) {
         case ColumnWidthType.Pixels:
           return getPixelValue(columnWidth.pixels);

--- a/src/pivot-table/hooks/use-data-model.ts
+++ b/src/pivot-table/hooks/use-data-model.ts
@@ -84,6 +84,8 @@ export default function useDataModel({
 
   const applyColumnWidth = useCallback<ApplyColumnWidth>(
     (newColumnWidth: ColumnWidth, { isPseudoDimension, isAncestorPseudoDimension, isLeftColumn, x, y }: Cell) => {
+      const { qNoOfLeftDims, qMeasureInfo, qDimensionInfo } = layoutService.layout.qHyperCube;
+
       let index: number;
       if (isPseudoDimension) {
         // TODO: what todo with the left pseudo dim? set all measures?
@@ -91,12 +93,12 @@ export default function useDataModel({
       } else {
         index = isLeftColumn
           ? x - Number(isAncestorPseudoDimension)
-          : y - Number(isAncestorPseudoDimension) + layoutService.layout.qHyperCube.qNoOfLeftDims;
+          : y - Number(isAncestorPseudoDimension) + qNoOfLeftDims - Number(layoutService.hasPseudoDimOnLeft);
       }
 
       const qPath = `${Q_PATH}/${isPseudoDimension ? "qMeasures" : "qDimensions"}/${index}/qDef/columnWidth`;
-      const oldColumnWidth =
-        layoutService.layout.qHyperCube[isPseudoDimension ? "qMeasureInfo" : "qDimensionInfo"][index].columnWidth;
+      const oldColumnWidth = isPseudoDimension ? qMeasureInfo[index].columnWidth : qDimensionInfo[index].columnWidth;
+
       const patch = oldColumnWidth
         ? {
             qPath,

--- a/src/types/QIX.ts
+++ b/src/types/QIX.ts
@@ -126,11 +126,11 @@ export interface ExtendedDimensionInfo extends EngineAPI.INxDimensionInfo {
   qCardinalities: {
     qHypercubeCardinal: number;
   };
-  columnWidth: ColumnWidth;
+  columnWidth?: ColumnWidth;
 }
 
 export interface ExtendedMeasureInfo extends EngineAPI.INxMeasureInfo {
-  columnWidth: ColumnWidth;
+  columnWidth?: ColumnWidth;
 }
 
 export interface ExtendedHyperCube extends EngineAPI.IHyperCube {


### PR DESCRIPTION
Fixes an issue where an error would be thrown when re-sizing the bottom top dimension, if the left side had a pseudo dimension.

Also fixes the type definition. As `columnWidth` does not exist on sn-pivot-tables created in older versions.