### PR TITLE
fix: plus minus icon size

### DIFF
--- a/src/pivot-table/components/cells/styles.tsx
+++ b/src/pivot-table/components/cells/styles.tsx
@@ -3,13 +3,7 @@ import { styled } from "@mui/material/styles";
 import type { stardust } from "@nebula.js/stardust";
 import type { CellStyling } from "../../../types/types";
 import { HEADER_ICON_SIZE } from "../../constants";
-import { CELL_PADDING, textStyle } from "../shared-styles";
-
-const baseFlex: React.CSSProperties = {
-  display: "flex",
-  justifyContent: "center",
-  alignItems: "center",
-};
+import { CELL_PADDING, baseFlex, textStyle } from "../shared-styles";
 
 interface StyledHeaderCellWrapperProps {
   interactions: stardust.Interactions;

--- a/src/pivot-table/components/icons/Minus.tsx
+++ b/src/pivot-table/components/icons/Minus.tsx
@@ -1,5 +1,6 @@
 import MinusOutlineIcon from "@qlik-trial/sprout/icons/react/MinusOutline";
 import React from "react";
+import { PLUS_MINUS_ICON_SIZE } from "../../constants";
 import { headerPlusMinusIconWrapperStyle } from "./styles";
 
 interface IconProps {
@@ -11,7 +12,13 @@ interface IconProps {
 
 const MinusIcon = ({ color, opacity, testid, onClick }: IconProps): JSX.Element => (
   <div style={headerPlusMinusIconWrapperStyle}>
-    <MinusOutlineIcon opacity={opacity} color={color} data-testid={testid} onClick={onClick} height="13px" />
+    <MinusOutlineIcon
+      opacity={opacity}
+      color={color}
+      data-testid={testid}
+      onClick={onClick}
+      height={PLUS_MINUS_ICON_SIZE}
+    />
   </div>
 );
 

--- a/src/pivot-table/components/icons/Minus.tsx
+++ b/src/pivot-table/components/icons/Minus.tsx
@@ -1,7 +1,6 @@
 import MinusOutlineIcon from "@qlik-trial/sprout/icons/react/MinusOutline";
 import React from "react";
 import { PLUS_MINUS_ICON_SIZE } from "../../constants";
-import { headerPlusMinusIconWrapperStyle } from "./styles";
 
 interface IconProps {
   onClick: ((e: React.SyntheticEvent<Element, Event>) => void) | undefined;
@@ -11,15 +10,14 @@ interface IconProps {
 }
 
 const MinusIcon = ({ color, opacity, testid, onClick }: IconProps): JSX.Element => (
-  <div style={headerPlusMinusIconWrapperStyle}>
-    <MinusOutlineIcon
-      opacity={opacity}
-      color={color}
-      data-testid={testid}
-      onClick={onClick}
-      height={PLUS_MINUS_ICON_SIZE}
-    />
-  </div>
+  <MinusOutlineIcon
+    opacity={opacity}
+    color={color}
+    data-testid={testid}
+    onClick={onClick}
+    height={PLUS_MINUS_ICON_SIZE}
+    style={{ flexShrink: 0 }}
+  />
 );
 
 export default MinusIcon;

--- a/src/pivot-table/components/icons/Minus.tsx
+++ b/src/pivot-table/components/icons/Minus.tsx
@@ -1,5 +1,6 @@
 import MinusOutlineIcon from "@qlik-trial/sprout/icons/react/MinusOutline";
 import React from "react";
+import { headerPlusMinusIconWrapperStyle } from "./styles";
 
 interface IconProps {
   onClick: ((e: React.SyntheticEvent<Element, Event>) => void) | undefined;
@@ -9,7 +10,9 @@ interface IconProps {
 }
 
 const MinusIcon = ({ color, opacity, testid, onClick }: IconProps): JSX.Element => (
-  <MinusOutlineIcon opacity={opacity} color={color} data-testid={testid} onClick={onClick} height="13px" />
+  <div style={headerPlusMinusIconWrapperStyle}>
+    <MinusOutlineIcon opacity={opacity} color={color} data-testid={testid} onClick={onClick} height="13px" />
+  </div>
 );
 
 export default MinusIcon;

--- a/src/pivot-table/components/icons/Plus.tsx
+++ b/src/pivot-table/components/icons/Plus.tsx
@@ -1,5 +1,6 @@
 import PlusOutlineIcon from "@qlik-trial/sprout/icons/react/PlusOutline";
 import React from "react";
+import { PLUS_MINUS_ICON_SIZE } from "../../constants";
 import { headerPlusMinusIconWrapperStyle } from "./styles";
 
 interface IconProps {
@@ -11,7 +12,13 @@ interface IconProps {
 
 const PlusIcon = ({ color, opacity, testid, onClick }: IconProps): JSX.Element => (
   <div style={headerPlusMinusIconWrapperStyle}>
-    <PlusOutlineIcon opacity={opacity} color={color} data-testid={testid} onClick={onClick} height="13px" />
+    <PlusOutlineIcon
+      opacity={opacity}
+      color={color}
+      data-testid={testid}
+      onClick={onClick}
+      height={PLUS_MINUS_ICON_SIZE}
+    />
   </div>
 );
 

--- a/src/pivot-table/components/icons/Plus.tsx
+++ b/src/pivot-table/components/icons/Plus.tsx
@@ -1,5 +1,6 @@
 import PlusOutlineIcon from "@qlik-trial/sprout/icons/react/PlusOutline";
 import React from "react";
+import { headerPlusMinusIconWrapperStyle } from "./styles";
 
 interface IconProps {
   onClick: ((e: React.SyntheticEvent<Element, Event>) => void) | undefined;
@@ -9,7 +10,9 @@ interface IconProps {
 }
 
 const PlusIcon = ({ color, opacity, testid, onClick }: IconProps): JSX.Element => (
-  <PlusOutlineIcon opacity={opacity} color={color} data-testid={testid} onClick={onClick} height="13px" />
+  <div style={headerPlusMinusIconWrapperStyle}>
+    <PlusOutlineIcon opacity={opacity} color={color} data-testid={testid} onClick={onClick} height="13px" />
+  </div>
 );
 
 export default PlusIcon;

--- a/src/pivot-table/components/icons/Plus.tsx
+++ b/src/pivot-table/components/icons/Plus.tsx
@@ -1,7 +1,6 @@
 import PlusOutlineIcon from "@qlik-trial/sprout/icons/react/PlusOutline";
 import React from "react";
 import { PLUS_MINUS_ICON_SIZE } from "../../constants";
-import { headerPlusMinusIconWrapperStyle } from "./styles";
 
 interface IconProps {
   onClick: ((e: React.SyntheticEvent<Element, Event>) => void) | undefined;
@@ -11,15 +10,14 @@ interface IconProps {
 }
 
 const PlusIcon = ({ color, opacity, testid, onClick }: IconProps): JSX.Element => (
-  <div style={headerPlusMinusIconWrapperStyle}>
-    <PlusOutlineIcon
-      opacity={opacity}
-      color={color}
-      data-testid={testid}
-      onClick={onClick}
-      height={PLUS_MINUS_ICON_SIZE}
-    />
-  </div>
+  <PlusOutlineIcon
+    opacity={opacity}
+    color={color}
+    data-testid={testid}
+    onClick={onClick}
+    height={PLUS_MINUS_ICON_SIZE}
+    style={{ flexShrink: 0 }}
+  />
 );
 
 export default PlusIcon;

--- a/src/pivot-table/components/icons/styles.ts
+++ b/src/pivot-table/components/icons/styles.ts
@@ -1,0 +1,7 @@
+import { HEADER_ICON_SIZE } from "../../constants";
+import { baseFlex } from "../shared-styles";
+
+export const headerPlusMinusIconWrapperStyle = {
+  width: HEADER_ICON_SIZE,
+  ...baseFlex,
+};

--- a/src/pivot-table/components/icons/styles.ts
+++ b/src/pivot-table/components/icons/styles.ts
@@ -1,7 +1,6 @@
-import { HEADER_ICON_SIZE } from "../../constants";
 import { baseFlex } from "../shared-styles";
 
 export const headerPlusMinusIconWrapperStyle = {
-  width: HEADER_ICON_SIZE,
+  width: 13,
   ...baseFlex,
 };

--- a/src/pivot-table/components/icons/styles.ts
+++ b/src/pivot-table/components/icons/styles.ts
@@ -1,6 +1,7 @@
+import { PLUS_MINUS_ICON_SIZE } from "../../constants";
 import { baseFlex } from "../shared-styles";
 
 export const headerPlusMinusIconWrapperStyle = {
-  width: 13,
+  width: PLUS_MINUS_ICON_SIZE,
   ...baseFlex,
 };

--- a/src/pivot-table/components/icons/styles.ts
+++ b/src/pivot-table/components/icons/styles.ts
@@ -1,7 +1,0 @@
-import { PLUS_MINUS_ICON_SIZE } from "../../constants";
-import { baseFlex } from "../shared-styles";
-
-export const headerPlusMinusIconWrapperStyle = {
-  width: PLUS_MINUS_ICON_SIZE,
-  ...baseFlex,
-};

--- a/src/pivot-table/components/shared-styles.ts
+++ b/src/pivot-table/components/shared-styles.ts
@@ -14,10 +14,14 @@ export enum Colors {
 
 export const CELL_PADDING = 4;
 
-export const topContainerCellStyle: React.CSSProperties = {
+export const baseFlex: React.CSSProperties = {
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
+};
+
+export const topContainerCellStyle: React.CSSProperties = {
+  ...baseFlex,
 };
 
 export const leftContainerCellStyle: React.CSSProperties = {

--- a/src/pivot-table/constants.ts
+++ b/src/pivot-table/constants.ts
@@ -12,3 +12,4 @@ export const CELL_PADDING_HEIGHT = 8;
 export const DISCLAIMER_HEIGHT = 22;
 export const GRID_BORDER = 1;
 export const HEADER_ICON_SIZE = 12;
+export const PLUS_MINUS_ICON_SIZE = 13;


### PR DESCRIPTION
Plus/minus icon shrinking in the size when text requires bigger space. This PR fixes it.

Before: 
<img width="1189" alt="Screenshot 2023-10-23 at 14 50 43" src="https://github.com/qlik-oss/sn-pivot-table/assets/29652890/4d9089ec-fa8c-43fa-ad05-63116557cc3b">


After:
<img width="1169" alt="Screenshot 2023-10-23 at 14 50 06" src="https://github.com/qlik-oss/sn-pivot-table/assets/29652890/d544156b-f098-4303-a528-d8de519ebc5a">
