### PR TITLE
fix: lock bg issue

### DIFF
--- a/src/pivot-table/components/cells/utils/get-dimension-cell-style.ts
+++ b/src/pivot-table/components/cells/utils/get-dimension-cell-style.ts
@@ -63,6 +63,7 @@ export const getLockedStyleFromSelection = (originalBackgroundColor?: string): R
         ${originalBackgroundColor ?? Colors.Transparent} 0px 4px
       )`,
     color: "#bebebe",
+    backgroundClip: "padding-box",
   };
 };
 


### PR DESCRIPTION
the lock cell background is behaves differnetly in very big cell sizes (maybe over 30k px), this pr fixes it

in below examples i just stretch the cell width manually but i saw some nodes with very large children which i noticed the bug on it

Before: 

https://github.com/qlik-oss/sn-pivot-table/assets/29652890/3c57d127-5e00-4cb9-8362-176c59da651d



After: 

https://github.com/qlik-oss/sn-pivot-table/assets/29652890/340dece5-8457-4eb5-9a70-e64ce2859496

