### PR TITLE
fix: proplery check for adjuster class

### DIFF
--- a/src/pivot-table/hooks/__tests__/use-selections-model.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-selections-model.test.ts
@@ -54,10 +54,10 @@ describe("useSelectionsModel", () => {
     expect(selections.removeListener).toHaveBeenCalledWith("cleared", expect.any(Function));
   });
 
-  test("should not select cell when mouse event is comming from ColumnAdjuster", async () => {
+  test("should not select cell when mouse event is coming from ColumnAdjuster", async () => {
     const cell = { selectionCellType: NxSelectionCellType.NX_CELL_TOP, x: 1, y: 0 } as Cell;
     mouseEvt.target = {
-      getAttribute: () => "sn-pivot-table-column-adjuster",
+      getAttribute: () => "sn-pivot-table-column-adjuster some-other-class",
     } as unknown as HTMLElement;
     const { result } = renderHook(() => useSelectionsModel(selections, updatePageInfo));
 

--- a/src/pivot-table/hooks/use-selections-model.ts
+++ b/src/pivot-table/hooks/use-selections-model.ts
@@ -102,7 +102,7 @@ export default function useSelectionsModel(
 
   const select = useCallback(
     (cell: Cell) => async (evt: React.MouseEvent) => {
-      if ((evt.target as HTMLElement | SVGElement)?.getAttribute("class") === "sn-pivot-table-column-adjuster") {
+      if ((evt.target as HTMLElement | SVGElement)?.getAttribute("class")?.includes("sn-pivot-table-column-adjuster")) {
         return;
       }
 


### PR DESCRIPTION
getAttribute("class") can return a string with multiple classes, so using `includes` instead. This also works when the class is `sn-pivot-table-column-adjuster-border`