### PR TITLE
fix: react border color warning

### DIFF
--- a/src/pivot-table/components/__tests__/shared-styles.test.ts
+++ b/src/pivot-table/components/__tests__/shared-styles.test.ts
@@ -17,13 +17,11 @@ describe("Shared styles", () => {
       borderRightWidth: 1,
       borderBottomWidth: 0,
       borderRightColor: borderColor,
-      borderBottomColor: undefined,
     };
     const borderBottom = {
       ...baseStyle,
       borderRightWidth: 0,
       borderBottomWidth: 1,
-      borderRightColor: undefined,
       borderBottomColor: borderColor,
     };
     const borderRightBottom = {

--- a/src/pivot-table/components/__tests__/shared-styles.test.ts
+++ b/src/pivot-table/components/__tests__/shared-styles.test.ts
@@ -4,11 +4,35 @@ import { borderStyle, cellStyle, getBorderStyle } from "../shared-styles";
 describe("Shared styles", () => {
   describe("getBorderStyle", () => {
     const borderColor = "red";
-    const baseStyle = { ...cellStyle, ...borderStyle, borderColor, borderWidth: 0 };
+    const baseStyle = {
+      ...cellStyle,
+      ...borderStyle,
+      borderWidth: 0,
+      borderRightColor: undefined,
+      borderBottomColor: undefined,
+    };
     const noBorder = { ...baseStyle, borderRightWidth: 0, borderBottomWidth: 0 };
-    const borderRight = { ...baseStyle, borderRightWidth: 1, borderBottomWidth: 0 };
-    const borderBottom = { ...baseStyle, borderRightWidth: 0, borderBottomWidth: 1 };
-    const borderRightBottom = { ...baseStyle, borderRightWidth: 1, borderBottomWidth: 1 };
+    const borderRight = {
+      ...baseStyle,
+      borderRightWidth: 1,
+      borderBottomWidth: 0,
+      borderRightColor: borderColor,
+      borderBottomColor: undefined,
+    };
+    const borderBottom = {
+      ...baseStyle,
+      borderRightWidth: 0,
+      borderBottomWidth: 1,
+      borderRightColor: undefined,
+      borderBottomColor: borderColor,
+    };
+    const borderRightBottom = {
+      ...baseStyle,
+      borderRightWidth: 1,
+      borderBottomWidth: 1,
+      borderRightColor: borderColor,
+      borderBottomColor: borderColor,
+    };
     let showLastBorder: ShowLastBorder;
 
     beforeEach(() => {

--- a/src/pivot-table/components/shared-styles.ts
+++ b/src/pivot-table/components/shared-styles.ts
@@ -71,10 +71,22 @@ export const getBorderStyle = (
   borderColor: string,
   showLastBorder?: ShowLastBorder,
 ) => {
-  const borderRightWidth = !isLastColumn || showLastBorder?.right ? 1 : 0;
-  const borderBottomWidth = !isLastRow || showLastBorder?.bottom ? 1 : 0;
+  const showRightBorder = !isLastColumn || showLastBorder?.right;
+  const showBottomBorder = !isLastRow || showLastBorder?.bottom;
+  const borderRightWidth = showRightBorder ? 1 : 0;
+  const borderRightColor = showRightBorder ? borderColor : undefined;
+  const borderBottomWidth = showBottomBorder ? 1 : 0;
+  const borderBottomColor = showBottomBorder ? borderColor : undefined;
 
-  return { ...cellStyle, ...borderStyle, borderColor, borderWidth: 0, borderRightWidth, borderBottomWidth };
+  return {
+    ...cellStyle,
+    ...borderStyle,
+    borderRightColor,
+    borderBottomColor,
+    borderWidth: 0,
+    borderRightWidth,
+    borderBottomWidth,
+  };
 };
 
 export const getTotalCellDividerStyle = ({


### PR DESCRIPTION
Fixes a react warning that could occur when switching themes. Reproduced by switching between "Default" and "Only transparent borders" theme in Nebula dev.

> Warning: Updating a style property during rerender (borderColor) when a conflicting property is set (borderBottomColor) can lead to styling bugs. To avoid this, don't mix shorthand and non-shorthand properties for the same value; instead, replace the shorthand with separate values.