### PR TITLE
feat: dimension info index map

### DIFF
--- a/src/services/layout-service.ts
+++ b/src/services/layout-service.ts
@@ -8,7 +8,7 @@ const createLayoutService = (
   effectiveProperties: EngineAPI.IGenericObjectProperties | undefined,
 ): LayoutService => {
   const { qHyperCube, nullValueRepresentation, snapshotData } = layout;
-  const { qNoOfLeftDims, qEffectiveInterColumnSortOrder, qMeasureInfo } = qHyperCube;
+  const { qNoOfLeftDims, qEffectiveInterColumnSortOrder, qMeasureInfo, qDimensionInfo } = qHyperCube;
   const isSnapshot = !!snapshotData;
   const snapshotDataPage = snapshotData?.content?.qPivotDataPages?.[0]?.qArea ?? { qWidth: 0, qHeight: 0 };
   const size = {
@@ -38,6 +38,9 @@ const createLayoutService = (
     showTotalsAbove: !!effectiveProperties?.qHyperCubeDef?.qShowTotalsAbove,
     hasPseudoDimOnLeft,
     isFullyExpanded: !!effectiveProperties?.qHyperCubeDef?.qAlwaysFullyExpanded,
+    dimensionInfoIndexMap: new Map(
+      qEffectiveInterColumnSortOrder.filter((index) => index >= 0).map((index) => [qDimensionInfo[index], index]),
+    ),
   };
 };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -174,6 +174,7 @@ export interface LayoutService {
   showTotalsAbove: boolean;
   hasPseudoDimOnLeft: boolean;
   isFullyExpanded: boolean;
+  dimensionInfoIndexMap: Map<ExtendedDimensionInfo, number>;
 }
 
 export interface DataService {


### PR DESCRIPTION
A draft on how we could get the dimension info index without having to care if and where the pseudo dimension is.

Getting the index for dimension info would simple become `const dimensionInfoIndex = layoutService.dimensionInfoIndexMap.get(qDimensionInfo)`