### PR TITLE
fix: grid out of sync

### DIFF
--- a/src/pivot-table/components/PivotTable.tsx
+++ b/src/pivot-table/components/PivotTable.tsx
@@ -73,8 +73,6 @@ export const StickyPivotTable = ({
   });
 
   const {
-    getScrollLeft,
-    getScrollTop,
     onHorizontalScrollHandler,
     onVerticalScrollHandler,
     verticalScrollableContainerRef,
@@ -170,7 +168,6 @@ export const StickyPivotTable = ({
                     leftGridRef={leftGridRef}
                     {...leftWrapper.leftGrid}
                     columnWidths={leftGridColumnWidths}
-                    getScrollTop={getScrollTop}
                     layoutService={layoutService}
                     leftDimensionData={leftDimensionData}
                     showLastBorder={{ right: false, bottom: allRowsVisible }}
@@ -197,7 +194,6 @@ export const StickyPivotTable = ({
                   topGridRef={topGridRef}
                   rowHightCallback={headerCellRowHightCallback}
                   {...rightWrapper.topGrid}
-                  getScrollLeft={getScrollLeft}
                   layoutService={layoutService}
                   topDimensionData={topDimensionData}
                   showLastBorder={{ right: showLastRightBorder, bottom: false }}

--- a/src/pivot-table/components/grids/LeftGrid.tsx
+++ b/src/pivot-table/components/grids/LeftGrid.tsx
@@ -1,5 +1,5 @@
 import { useOnPropsChange } from "@qlik/nebula-table-utils/lib/hooks";
-import React, { memo, useLayoutEffect } from "react";
+import React, { memo } from "react";
 import { VariableSizeList } from "react-window";
 import type {
   DataModel,
@@ -24,7 +24,6 @@ interface LeftGridProps {
   width: number;
   columnWidths: number[];
   height: number;
-  getScrollTop: () => number;
   layoutService: LayoutService;
   leftDimensionData: LeftDimensionData;
   showLastBorder: ShowLastBorder;
@@ -61,7 +60,6 @@ const LeftGrid = ({
   width,
   columnWidths,
   height,
-  getScrollTop,
   layoutService,
   leftDimensionData,
   showLastBorder,
@@ -80,11 +78,7 @@ const LeftGrid = ({
     }
   }, [dataModel, width, height, leftDimensionData, leftGridRef, contentCellHeight]);
 
-  useLayoutEffect(() => {
-    if (leftGridRef.current) {
-      leftGridRef.current.forEach((list) => list?.scrollTo(getScrollTop()));
-    }
-  }, [getScrollTop, layoutService, leftGridRef]);
+  // useScrollToOnExpand({ listRef: leftGridRef, layoutService, getLastKnownScrollPosition: getScrollTop });
 
   const totalHeight = pageInfo.rowsOnCurrentPage * contentCellHeight;
 

--- a/src/pivot-table/components/grids/LeftGrid.tsx
+++ b/src/pivot-table/components/grids/LeftGrid.tsx
@@ -78,8 +78,6 @@ const LeftGrid = ({
     }
   }, [dataModel, width, height, leftDimensionData, leftGridRef, contentCellHeight]);
 
-  // useScrollToOnExpand({ listRef: leftGridRef, layoutService, getLastKnownScrollPosition: getScrollTop });
-
   const totalHeight = pageInfo.rowsOnCurrentPage * contentCellHeight;
 
   if (leftDimensionData.columnCount === 0) {

--- a/src/pivot-table/components/grids/TopGrid.tsx
+++ b/src/pivot-table/components/grids/TopGrid.tsx
@@ -1,5 +1,5 @@
 import { useOnPropsChange } from "@qlik/nebula-table-utils/lib/hooks";
-import React, { memo, useLayoutEffect } from "react";
+import React, { memo } from "react";
 import { VariableSizeList } from "react-window";
 import type {
   DataModel,
@@ -23,7 +23,6 @@ interface TopGridProps {
   rowHightCallback: () => number;
   width: number;
   height: number;
-  getScrollLeft: () => number;
   layoutService: LayoutService;
   topDimensionData: TopDimensionData;
   showLastBorder: ShowLastBorder;
@@ -52,7 +51,6 @@ const TopGrid = ({
   rowHightCallback,
   width,
   height,
-  getScrollLeft,
   layoutService,
   topDimensionData,
   showLastBorder,
@@ -73,12 +71,6 @@ const TopGrid = ({
       topGridRef.current.forEach((list) => list?.resetAfterIndex(0, false));
     }
   }, [dataModel, width, height, topDimensionData, topGridRef, headerCellHeight]);
-
-  useLayoutEffect(() => {
-    if (topGridRef.current) {
-      topGridRef.current.forEach((list) => list?.scrollTo(getScrollLeft()));
-    }
-  }, [layoutService, getScrollLeft, topGridRef]);
 
   const totalWidth = layoutService.size.x * getRightGridColumnWidth();
 
@@ -121,6 +113,21 @@ const TopGrid = ({
             }}
             itemKey={getItemKey}
             estimatedItemSize={estimatedItemSize}
+            onScroll={({
+              scrollDirection,
+
+              scrollOffset,
+
+              scrollUpdateWasRequested,
+            }) =>
+              console.log("%c onScroll", "color: orangered", {
+                scrollDirection,
+
+                scrollOffset,
+
+                scrollUpdateWasRequested,
+              })
+            }
           >
             {MemoizedDimensionValue}
           </VariableSizeList>

--- a/src/pivot-table/components/grids/TopGrid.tsx
+++ b/src/pivot-table/components/grids/TopGrid.tsx
@@ -113,21 +113,6 @@ const TopGrid = ({
             }}
             itemKey={getItemKey}
             estimatedItemSize={estimatedItemSize}
-            onScroll={({
-              scrollDirection,
-
-              scrollOffset,
-
-              scrollUpdateWasRequested,
-            }) =>
-              console.log("%c onScroll", "color: orangered", {
-                scrollDirection,
-
-                scrollOffset,
-
-                scrollUpdateWasRequested,
-              })
-            }
           >
             {MemoizedDimensionValue}
           </VariableSizeList>

--- a/src/pivot-table/hooks/__tests__/use-scroll.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-scroll.test.ts
@@ -127,6 +127,23 @@ describe("useScroll", () => {
     );
   });
 
+  test("should not scroll to last known scroll position when a cell has not been expanded or collapsed", async () => {
+    layoutService.layout.qHyperCube.qLastExpandedPos = undefined;
+    verticalScrollableContainerRefMock.scrollTop = 123;
+    leftGridHorizontalScrollableContainerRefMock.scrollLeft = 321;
+
+    renderUseScroll();
+
+    await waitFor(() =>
+      expect(mockedTopGridRef.scrollTo).not.toHaveBeenCalledWith(
+        leftGridHorizontalScrollableContainerRefMock.scrollLeft,
+      ),
+    );
+    await waitFor(() =>
+      expect(mockedLeftGridRef.scrollTo).not.toHaveBeenCalledWith(verticalScrollableContainerRefMock.scrollTop),
+    );
+  });
+
   describe("onScrollHandlers", () => {
     let fakeTarget: HTMLElement;
 

--- a/src/pivot-table/hooks/__tests__/use-scroll.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-scroll.test.ts
@@ -14,6 +14,7 @@ describe("useScroll", () => {
   let dataGridRef: VariableSizeGrid;
   let leftGridHorizontalScrollableContainerRefMock: HTMLDivElement;
   let dataGridHorizontalScrollableContainerRefMock: HTMLDivElement;
+  let verticalScrollableContainerRefMock: HTMLDivElement;
 
   const renderUseScroll = () =>
     renderHook(
@@ -24,7 +25,7 @@ describe("useScroll", () => {
           mockedRefs: {
             leftGridHorizontalScrollableContainerRef: leftGridHorizontalScrollableContainerRefMock,
             dataGridHorizontalScrollableContainerRef: dataGridHorizontalScrollableContainerRefMock,
-            verticalScrollableContainerRef: {} as HTMLDivElement,
+            verticalScrollableContainerRef: verticalScrollableContainerRefMock,
             topGridRef: [mockedTopGridRef],
             leftGridRef: [mockedLeftGridRef],
             dataGridRef,
@@ -48,6 +49,7 @@ describe("useScroll", () => {
     } as LayoutService;
     leftGridHorizontalScrollableContainerRefMock = {} as HTMLDivElement;
     dataGridHorizontalScrollableContainerRefMock = {} as HTMLDivElement;
+    verticalScrollableContainerRefMock = {} as HTMLDivElement;
 
     pageInfo = { page: 0 } as PageInfo;
 
@@ -108,6 +110,21 @@ describe("useScroll", () => {
     await waitFor(() => expect(leftGridHorizontalScrollableContainerRef.current?.scrollLeft).toBe(0));
     await waitFor(() => expect(dataGridHorizontalScrollableContainerRef.current?.scrollLeft).toBe(0));
     await waitFor(() => expect(verticalScrollableContainerRef.current?.scrollTop).toBe(0));
+  });
+
+  test("should scroll to last known scroll position when a cell is expanded or collapsed", async () => {
+    layoutService.layout.qHyperCube.qLastExpandedPos = { qx: 0, qy: 0 };
+    verticalScrollableContainerRefMock.scrollTop = 123;
+    leftGridHorizontalScrollableContainerRefMock.scrollLeft = 321;
+
+    renderUseScroll();
+
+    await waitFor(() =>
+      expect(mockedTopGridRef.scrollTo).toHaveBeenCalledWith(leftGridHorizontalScrollableContainerRefMock.scrollLeft),
+    );
+    await waitFor(() =>
+      expect(mockedLeftGridRef.scrollTo).toHaveBeenCalledWith(verticalScrollableContainerRefMock.scrollTop),
+    );
   });
 
   describe("onScrollHandlers", () => {

--- a/src/pivot-table/hooks/__tests__/use-scroll.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-scroll.test.ts
@@ -122,7 +122,7 @@ describe("useScroll", () => {
       const scrollLeft = 123;
       const {
         result: {
-          current: { onHorizontalScrollHandler, getScrollLeft },
+          current: { onHorizontalScrollHandler },
         },
       } = renderUseScroll();
 
@@ -133,14 +133,13 @@ describe("useScroll", () => {
 
       expect(mockedTopGridRef.scrollTo).toHaveBeenCalledWith(scrollLeft);
       expect(dataGridRef.scrollTo).toHaveBeenCalledWith({ scrollLeft });
-      expect(getScrollLeft()).toEqual(scrollLeft);
     });
 
     test("when called `onVerticalScrollHandler()` should update grids with new scroll position", () => {
       const scrollTop = 321;
       const {
         result: {
-          current: { onVerticalScrollHandler, getScrollTop },
+          current: { onVerticalScrollHandler },
         },
       } = renderUseScroll();
 
@@ -151,7 +150,6 @@ describe("useScroll", () => {
 
       expect(mockedLeftGridRef.scrollTo).toHaveBeenCalledWith(scrollTop);
       expect(dataGridRef.scrollTo).toHaveBeenCalledWith({ scrollTop });
-      expect(getScrollTop()).toEqual(scrollTop);
     });
   });
 

--- a/src/pivot-table/hooks/use-scroll.ts
+++ b/src/pivot-table/hooks/use-scroll.ts
@@ -26,13 +26,8 @@ const useScroll = ({ layoutService, pageInfo, mockedRefs }: Props) => {
   const topGridRef = useRef<VariableSizeList[]>(mockedRefs?.topGridRef ?? []);
   const leftGridRef = useRef<VariableSizeList[]>(mockedRefs?.leftGridRef ?? []);
   const dataGridRef = useRef<VariableSizeGrid>(mockedRefs?.dataGridRef ?? null);
-  const currentScrollLeft = useRef<number>(0);
-  const currentScrollTop = useRef<number>(0);
   const [verticalScrollbarWidth, setVerticalScrollbarWidth] = useState<number>(0);
   const [horizontalScrollbarHeight, setHorizontalScrollbarHeight] = useState<number>(0);
-
-  const getScrollLeft = useCallback(() => currentScrollLeft.current, [currentScrollLeft]);
-  const getScrollTop = useCallback(() => currentScrollTop.current, [currentScrollTop]);
 
   // If the layout change reset the scroll position, except if the layout
   // change because a node was expanded or collapsed
@@ -103,55 +98,34 @@ const useScroll = ({ layoutService, pageInfo, mockedRefs }: Props) => {
     // Call scrollTo here so that when a cell is expanded or collapsed, scroll to the last known position.
     // Otherwise it will be out-of-sync with the data grid.
     if (layoutService.layout.qHyperCube.qLastExpandedPos) {
-      console.log("%c compare", "color: orangered", {
-        getScrollLeft: getScrollLeft(),
-        containerLeft: dataGridHorizontalScrollableContainerRef.current?.scrollLeft,
-      });
-      leftGridRef.current?.forEach((list) => list?.scrollTo(getScrollTop()));
-      topGridRef.current?.forEach((list) => list?.scrollTo(getScrollLeft()));
+      const scrollLeft = dataGridHorizontalScrollableContainerRef.current?.scrollLeft ?? 0;
+      const scrollTop = verticalScrollableContainerRef.current?.scrollTop ?? 0;
+
+      leftGridRef.current?.forEach((list) => list?.scrollTo(scrollTop));
+      topGridRef.current?.forEach((list) => list?.scrollTo(scrollLeft));
     }
-  }, [layoutService, getScrollTop, getScrollLeft]);
+  }, [layoutService]);
 
   const onHorizontalScrollHandler = (evt: React.SyntheticEvent) => {
     if (!(evt.target instanceof HTMLDivElement)) return;
 
     if (evt.target.dataset["key"] === `scrollable-container--${ScrollableContainerOrigin.DATA_GRID}`) {
-      if (topGridRef.current) {
-        topGridRef.current.forEach((list) => list?.scrollTo(evt.currentTarget.scrollLeft));
-      }
+      topGridRef.current?.forEach((list) => list?.scrollTo(evt.currentTarget.scrollLeft));
 
-      if (dataGridRef.current) {
-        dataGridRef.current.scrollTo({
-          scrollLeft: evt.currentTarget.scrollLeft,
-        });
-      }
-
-      if (currentScrollLeft.current !== undefined) {
-        // Set scrollLeft here so that when a top grid is expanded with a new row, scroll that row to scrollLeft position.
-        // Otherwise it will be out-of-sync with the other rows.
-        currentScrollLeft.current = evt.currentTarget.scrollLeft;
-      }
+      dataGridRef.current?.scrollTo({
+        scrollLeft: evt.currentTarget.scrollLeft,
+      });
     }
   };
 
   const onVerticalScrollHandler = (evt: React.SyntheticEvent) => {
     if (!(evt.target instanceof HTMLDivElement)) return;
 
-    if (leftGridRef.current) {
-      leftGridRef.current.filter(Boolean).forEach((list) => list.scrollTo(evt.currentTarget.scrollTop));
-    }
+    leftGridRef.current?.filter(Boolean).forEach((list) => list.scrollTo(evt.currentTarget.scrollTop));
 
-    if (dataGridRef.current) {
-      dataGridRef.current.scrollTo({
-        scrollTop: evt.currentTarget.scrollTop,
-      });
-    }
-
-    if (currentScrollTop.current !== undefined) {
-      // Set scrollTop here so that when a left grid is expanded with a new column, scroll that row to scrollTop position.
-      // Otherwise it will be out-of-sync with the other columns.
-      currentScrollTop.current = evt.currentTarget.scrollTop;
-    }
+    dataGridRef.current?.scrollTo({
+      scrollTop: evt.currentTarget.scrollTop,
+    });
   };
 
   return {

--- a/src/pivot-table/hooks/use-scroll.ts
+++ b/src/pivot-table/hooks/use-scroll.ts
@@ -99,6 +99,19 @@ const useScroll = ({ layoutService, pageInfo, mockedRefs }: Props) => {
     horizontalScrollbarHeightSetter();
   }, [horizontalScrollbarHeightSetter]);
 
+  useLayoutEffect(() => {
+    // Call scrollTo here so that when a cell is expanded or collapsed, scroll to the last known position.
+    // Otherwise it will be out-of-sync with the data grid.
+    if (layoutService.layout.qHyperCube.qLastExpandedPos) {
+      console.log("%c compare", "color: orangered", {
+        getScrollLeft: getScrollLeft(),
+        containerLeft: dataGridHorizontalScrollableContainerRef.current?.scrollLeft,
+      });
+      leftGridRef.current?.forEach((list) => list?.scrollTo(getScrollTop()));
+      topGridRef.current?.forEach((list) => list?.scrollTo(getScrollLeft()));
+    }
+  }, [layoutService, getScrollTop, getScrollLeft]);
+
   const onHorizontalScrollHandler = (evt: React.SyntheticEvent) => {
     if (!(evt.target instanceof HTMLDivElement)) return;
 
@@ -142,8 +155,6 @@ const useScroll = ({ layoutService, pageInfo, mockedRefs }: Props) => {
   };
 
   return {
-    getScrollLeft,
-    getScrollTop,
     onHorizontalScrollHandler,
     onVerticalScrollHandler,
     verticalScrollableContainerRef,

--- a/src/pivot-table/hooks/use-scroll.ts
+++ b/src/pivot-table/hooks/use-scroll.ts
@@ -47,6 +47,18 @@ const useScroll = ({ layoutService, pageInfo, mockedRefs }: Props) => {
     }
   }, [layoutService]);
 
+  // Call scrollTo here so that when a cell is expanded or collapsed, scroll to the last known position.
+  // Otherwise it will be out-of-sync with the data grid.
+  useLayoutEffect(() => {
+    if (layoutService.layout.qHyperCube.qLastExpandedPos) {
+      const scrollLeft = leftGridHorizontalScrollableContainerRef.current?.scrollLeft ?? 0;
+      const scrollTop = verticalScrollableContainerRef.current?.scrollTop ?? 0;
+
+      leftGridRef.current?.forEach((list) => list?.scrollTo(scrollTop));
+      topGridRef.current?.forEach((list) => list?.scrollTo(scrollLeft));
+    }
+  }, [layoutService]);
+
   // Reset scroll position when page has changed
   useLayoutEffect(() => {
     if (leftGridHorizontalScrollableContainerRef.current) {
@@ -93,18 +105,6 @@ const useScroll = ({ layoutService, pageInfo, mockedRefs }: Props) => {
 
     horizontalScrollbarHeightSetter();
   }, [horizontalScrollbarHeightSetter]);
-
-  useLayoutEffect(() => {
-    // Call scrollTo here so that when a cell is expanded or collapsed, scroll to the last known position.
-    // Otherwise it will be out-of-sync with the data grid.
-    if (layoutService.layout.qHyperCube.qLastExpandedPos) {
-      const scrollLeft = leftGridHorizontalScrollableContainerRef.current?.scrollLeft ?? 0;
-      const scrollTop = verticalScrollableContainerRef.current?.scrollTop ?? 0;
-
-      leftGridRef.current?.forEach((list) => list?.scrollTo(scrollTop));
-      topGridRef.current?.forEach((list) => list?.scrollTo(scrollLeft));
-    }
-  }, [layoutService]);
 
   const onHorizontalScrollHandler = (evt: React.SyntheticEvent) => {
     if (!(evt.target instanceof HTMLDivElement)) return;

--- a/src/pivot-table/hooks/use-scroll.ts
+++ b/src/pivot-table/hooks/use-scroll.ts
@@ -98,7 +98,7 @@ const useScroll = ({ layoutService, pageInfo, mockedRefs }: Props) => {
     // Call scrollTo here so that when a cell is expanded or collapsed, scroll to the last known position.
     // Otherwise it will be out-of-sync with the data grid.
     if (layoutService.layout.qHyperCube.qLastExpandedPos) {
-      const scrollLeft = dataGridHorizontalScrollableContainerRef.current?.scrollLeft ?? 0;
+      const scrollLeft = leftGridHorizontalScrollableContainerRef.current?.scrollLeft ?? 0;
       const scrollTop = verticalScrollableContainerRef.current?.scrollTop ?? 0;
 
       leftGridRef.current?.forEach((list) => list?.scrollTo(scrollTop));


### PR DESCRIPTION
There should be 3 rules of scroll behavior when we get a change in the data:
1. Layout changed and it's because a cell have been expanded or collapse. The LeftGrid and TopGrid should scroll to the last known scroll position.
2. Layout changed and it's not because of a expanded or collapsed cell. The scroll position should be reset to 0.
3. Page changed. The scroll position should be reset to 0.

`1.` was done in the `LeftGrid` and `TopGrid` components, but was done regardless if a cell had been expanded or collapsed. I've moved that logic to the `useScroll` hook and fixed the condition. With that done some code could be removed.