### PR TITLE
feat: hover on expand icon

### DIFF
--- a/src/pivot-table/components/cells/DimensionValue/ExpandOrCollapseIcon.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/ExpandOrCollapseIcon.tsx
@@ -1,12 +1,14 @@
+import { styled } from "@mui/material/styles";
 import MinusOutlineIcon from "@qlik-trial/sprout/icons/react/MinusOutline";
 import PlusOutlineIcon from "@qlik-trial/sprout/icons/react/PlusOutline";
+import { getHoverColor } from "@qlik/nebula-table-utils/lib/utils";
 import React from "react";
 import type { Cell, DataModel, ExpandOrCollapser } from "../../../../types/types";
 import { PLUS_MINUS_ICON_SIZE } from "../../../constants";
 import { useBaseContext } from "../../../contexts/BaseProvider";
 import { useSelectionsContext } from "../../../contexts/SelectionsProvider";
 import { useStyleContext } from "../../../contexts/StyleProvider";
-import { getColor } from "./utils/get-style";
+import { getBackground, getColor } from "./utils/get-style";
 
 type Props = {
   isLeftColumn: boolean;
@@ -22,6 +24,18 @@ interface OnClickHandlerProps {
 
 export const testIdExpandIcon = "expand-icon";
 export const testIdCollapseIcon = "collapse-icon";
+const lockedColorModifiers = { brighter: 1, darker: 1, opacity: 0.1 };
+
+const HighlightOnHover = styled("div", {
+  shouldForwardProp: (prop: string) => prop !== "background",
+})(({ background }: { background?: string }) => ({
+  width: PLUS_MINUS_ICON_SIZE,
+  height: PLUS_MINUS_ICON_SIZE,
+  borderRadius: "50%",
+  "&&:hover": {
+    background: background ? getHoverColor(background, lockedColorModifiers) : undefined,
+  },
+}));
 
 const createOnClickHandler =
   ({ expandOrCollapse, cell }: OnClickHandlerProps) =>
@@ -34,15 +48,19 @@ const ExpandOrCollapseIcon = ({ cell, dataModel, isLeftColumn, isCellSelected }:
   const styleService = useStyleContext();
   const { interactions } = useBaseContext();
   const { isActive } = useSelectionsContext();
+  const { isLocked } = useSelectionsContext();
 
   if (!cell.ref.qCanExpand && !cell.ref.qCanCollapse) {
     return null;
   }
 
+  const isCellLocked = isLocked(cell) || cell.isLockedByDimension;
   const disableOnClickHandler = !interactions.active || isActive || !dataModel;
   const color = getColor({ cell, styleService, isCellSelected });
   const opacity = isActive ? 0.4 : 1.0;
   const Icon = cell.ref.qCanExpand ? PlusOutlineIcon : MinusOutlineIcon;
+  const background = getBackground({ styleService, isCellSelected, cell, isCellLocked: false });
+
   let expandOrCollapse: ExpandOrCollapser | undefined;
 
   if (cell.ref.qCanExpand) {
@@ -52,14 +70,19 @@ const ExpandOrCollapseIcon = ({ cell, dataModel, isLeftColumn, isCellSelected }:
   }
 
   return (
-    <Icon
-      opacity={opacity}
-      color={color}
-      data-testid={cell.ref.qCanExpand ? testIdExpandIcon : testIdCollapseIcon}
-      height={PLUS_MINUS_ICON_SIZE}
-      style={{ flexShrink: 0, cursor: disableOnClickHandler ? "default" : "pointer" }}
-      onClick={disableOnClickHandler ? undefined : createOnClickHandler({ cell, expandOrCollapse })}
-    />
+    <HighlightOnHover background={isCellLocked ? undefined : background}>
+      <Icon
+        opacity={opacity}
+        color={color}
+        data-testid={cell.ref.qCanExpand ? testIdExpandIcon : testIdCollapseIcon}
+        height={PLUS_MINUS_ICON_SIZE}
+        style={{
+          flexShrink: 0,
+          cursor: disableOnClickHandler ? "default" : "pointer",
+        }}
+        onClick={disableOnClickHandler ? undefined : createOnClickHandler({ cell, expandOrCollapse })}
+      />
+    </HighlightOnHover>
   );
 };
 


### PR DESCRIPTION
EXPERIMENTAL

Trying to make it easier to hit the expand/collapse icon. Currently the icon is highlighted by changing background on hover. But that does not really make all that much easier to hit.