### PR TITLE
fix: text line clamp for expanded cell

### DIFF
--- a/src/pivot-table/components/cells/DimensionValue/ExpandOrCollapseIcon.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/ExpandOrCollapseIcon.tsx
@@ -24,6 +24,8 @@ interface OnClickHandlerProps {
 export const testIdExpandIcon = "expand-icon";
 export const testIdCollapseIcon = "collapse-icon";
 
+const halfIconHeight = PLUS_MINUS_ICON_SIZE / 2;
+
 const createOnClickHandler =
   ({ expandOrCollapse, cell }: OnClickHandlerProps) =>
   (e: React.SyntheticEvent) => {
@@ -44,7 +46,6 @@ const ExpandOrCollapseIcon = ({ cell, dataModel, isLeftColumn, isCellSelected }:
   const color = getColor({ cell, styleService, isCellSelected });
   const opacity = isActive ? 0.4 : 1.0;
   const halfCellHeight = styleService.contentCellHeight / 2;
-  const halfIconHeight = PLUS_MINUS_ICON_SIZE / 2;
   const Icon = cell.ref.qCanExpand ? PlusOutlineIcon : MinusOutlineIcon;
   let expandOrCollapse: ExpandOrCollapser | undefined;
 
@@ -63,7 +64,7 @@ const ExpandOrCollapseIcon = ({ cell, dataModel, isLeftColumn, isCellSelected }:
       style={{
         flexShrink: 0,
         cursor: disableOnClickHandler ? "default" : "pointer",
-        // marginTop is need on left side to put the Icon aligned at the center of the first row.
+        // marginTop is need on left side to put the align the expand/collapse icon and the text
         marginTop: isLeftColumn ? halfCellHeight - halfIconHeight - CELL_PADDING : undefined,
       }}
       onClick={disableOnClickHandler ? undefined : createOnClickHandler({ cell, expandOrCollapse })}

--- a/src/pivot-table/components/cells/DimensionValue/ExpandOrCollapseIcon.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/ExpandOrCollapseIcon.tsx
@@ -6,6 +6,7 @@ import { PLUS_MINUS_ICON_SIZE } from "../../../constants";
 import { useBaseContext } from "../../../contexts/BaseProvider";
 import { useSelectionsContext } from "../../../contexts/SelectionsProvider";
 import { useStyleContext } from "../../../contexts/StyleProvider";
+import { CELL_PADDING } from "../../shared-styles";
 import { getColor } from "./utils/get-style";
 
 type Props = {
@@ -42,6 +43,8 @@ const ExpandOrCollapseIcon = ({ cell, dataModel, isLeftColumn, isCellSelected }:
   const disableOnClickHandler = !interactions.active || isActive || !dataModel;
   const color = getColor({ cell, styleService, isCellSelected });
   const opacity = isActive ? 0.4 : 1.0;
+  const halfCellHeight = styleService.contentCellHeight / 2;
+  const halfIconHeight = PLUS_MINUS_ICON_SIZE / 2;
   const Icon = cell.ref.qCanExpand ? PlusOutlineIcon : MinusOutlineIcon;
   let expandOrCollapse: ExpandOrCollapser | undefined;
 
@@ -57,7 +60,12 @@ const ExpandOrCollapseIcon = ({ cell, dataModel, isLeftColumn, isCellSelected }:
       color={color}
       data-testid={cell.ref.qCanExpand ? testIdExpandIcon : testIdCollapseIcon}
       height={PLUS_MINUS_ICON_SIZE}
-      style={{ flexShrink: 0, cursor: disableOnClickHandler ? "default" : "pointer" }}
+      style={{
+        flexShrink: 0,
+        cursor: disableOnClickHandler ? "default" : "pointer",
+        // marginTop is need on left side to put the Icon aligned at the center of the first row.
+        marginTop: isLeftColumn ? halfCellHeight - halfIconHeight - CELL_PADDING : undefined,
+      }}
       onClick={disableOnClickHandler ? undefined : createOnClickHandler({ cell, expandOrCollapse })}
     />
   );

--- a/src/pivot-table/components/cells/DimensionValue/StickyCellContainer.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/StickyCellContainer.tsx
@@ -6,24 +6,28 @@ type Props = {
   children: ReactNode;
 };
 
-const StickyCellContainer = ({ children, isLeftColumn }: Props): JSX.Element => (
-  <div
-    style={{
-      display: "flex",
-      flexDirection: "row",
-      alignItems: "center",
-      gap: `${CELL_PADDING}px`,
-      width: "fit-content",
-      maxWidth: "100%",
-      position: "sticky",
-      left: CELL_PADDING,
-      top: CELL_PADDING,
-      right: isLeftColumn ? undefined : CELL_PADDING,
-      alignSelf: isLeftColumn ? "flex-start" : "center",
-    }}
-  >
-    {children}
-  </div>
-);
+const StickyCellContainer = ({ children, isLeftColumn }: Props): JSX.Element => {
+  const align = isLeftColumn ? "flex-start" : "center";
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        alignItems: align,
+        gap: `${CELL_PADDING}px`,
+        width: "fit-content",
+        maxWidth: "100%",
+        position: "sticky",
+        left: CELL_PADDING,
+        top: CELL_PADDING,
+        right: isLeftColumn ? undefined : CELL_PADDING,
+        alignSelf: align,
+      }}
+    >
+      {children}
+    </div>
+  );
+};
 
 export default StickyCellContainer;

--- a/src/pivot-table/components/cells/DimensionValue/Text.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/Text.tsx
@@ -1,7 +1,7 @@
 import React, { type ReactNode } from "react";
 import type { Cell, StyleService } from "../../../../types/types";
-import { DEFAULT_LINE_CLAMP } from "../../../constants";
-import { getLineClampStyle, textStyle } from "../../shared-styles";
+import { DEFAULT_LINE_CLAMP, LINE_HEIGHT_COEFFICIENT } from "../../../constants";
+import { CELL_PADDING, getLineClampStyle, textStyle } from "../../shared-styles";
 import { getColor, getFontStyle, getFontWeight, getTextDecoration } from "./utils/get-style";
 
 type Props = {
@@ -10,6 +10,12 @@ type Props = {
   cell: Cell;
   styleService: StyleService;
   children: ReactNode;
+};
+
+const getMarginTop = (styleService: StyleService) => {
+  const textHeight = parseInt(styleService.dimensionValues.fontSize, 10) * LINE_HEIGHT_COEFFICIENT;
+
+  return styleService.contentCellHeight / 2 - textHeight / 2 - CELL_PADDING;
 };
 
 const Text = ({ children, cell, styleService, isCellSelected, isLeftColumn }: Props): JSX.Element => (
@@ -27,6 +33,8 @@ const Text = ({ children, cell, styleService, isCellSelected, isLeftColumn }: Pr
       textDecoration: getTextDecoration({ cell, styleService }),
       fontFamily: styleService.dimensionValues.fontFamily,
       fontSize: styleService.dimensionValues.fontSize,
+      // marginTop is need on left side to put the align the expand/collapse icon and the text
+      marginTop: isLeftColumn ? getMarginTop(styleService) : undefined,
     }}
   >
     {children}

--- a/src/pivot-table/components/cells/DimensionValue/Text.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/Text.tsx
@@ -16,7 +16,11 @@ const Text = ({ children, cell, styleService, isCellSelected, isLeftColumn }: Pr
   <span
     style={{
       ...textStyle,
-      ...getLineClampStyle(isLeftColumn ? styleService.grid.lineClamp : DEFAULT_LINE_CLAMP),
+      ...getLineClampStyle(
+        isLeftColumn
+          ? Math.max(styleService.grid.lineClamp, cell.leafCount * styleService.grid.lineClamp)
+          : DEFAULT_LINE_CLAMP,
+      ),
       color: getColor({ cell, styleService, isCellSelected }),
       fontWeight: getFontWeight({ cell, styleService }),
       fontStyle: getFontStyle({ cell, styleService }),


### PR DESCRIPTION
Allows cell that are expanded to have text on multiple lines.

marginTop is need on left side to put the Icon aligned at the center of the first row. Previously this was handled by `alignItems: center` in `StickCellContainer.tsx`. Now it have to be manually positioned.

Before:
![Skärmavbild 2023-10-31 kl  11 52 17](https://github.com/qlik-oss/sn-pivot-table/assets/16608020/f94682fb-651a-4999-b7b5-127b2daee031)

After:
![Skärmavbild 2023-10-31 kl  11 52 01](https://github.com/qlik-oss/sn-pivot-table/assets/16608020/92f0d1e7-469b-4a26-925f-4233fb452537)
