### PR TITLE
fix: handle no theme border value

### DIFF
--- a/src/pivot-table/__tests__/test-with-providers.tsx
+++ b/src/pivot-table/__tests__/test-with-providers.tsx
@@ -83,6 +83,7 @@ const TestWithProvider = (props: Props) => {
     interactions = { select: true, active: true },
     embed = {} as stardust.Embed,
     theme = {
+      name: () => "theme",
       getStyle: (base, path, attr) => attr,
       background: { tableColorFromTheme: "inherit", isDark: false, isTransparent: false, color: "transparent" },
     } as ExtendedTheme,

--- a/src/pivot-table/contexts/BaseProvider.tsx
+++ b/src/pivot-table/contexts/BaseProvider.tsx
@@ -33,7 +33,8 @@ export const useBaseContext = (): IBaseProvider => useContext(BaseContext);
 const BaseProvider = ({ children, model, app, interactions, embed, theme, keyboard }: BaseProviderProps) => {
   const props = useMemo(
     () => ({ model, app, interactions, embed, theme, keyboard }),
-    [app, interactions, model, embed, theme, keyboard],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [app, interactions, model, embed, theme.name(), keyboard],
   );
 
   return <BaseContext.Provider value={props}>{children}</BaseContext.Provider>;

--- a/src/services/style-service.ts
+++ b/src/services/style-service.ts
@@ -93,7 +93,18 @@ const createStyleService = (theme: ExtendedTheme, layoutService: LayoutService):
   const totalValuesStyling = chartStyling?.[Path.TotalValues];
   const nullValueStyling = chartStyling?.[Path.NullValues];
   const gridStyling = chartStyling?.[Path.Grid];
-  const getThemeStyle = (paths: string[], attribute: string) => theme.getStyle(BASE_PATH, paths.join("."), attribute);
+  const getThemeStyle = (paths: string[], attribute: string) => {
+    const value = theme.getStyle(BASE_PATH, paths.join("."), attribute);
+
+    // If the "border" attribute cannot be resolved, theme.getStyle will return a default value
+    // which is an object. All theme values defined for "pivotTableV2" are expected to be either
+    // strings or numbers.
+    if (typeof value === "object") {
+      return undefined;
+    }
+
+    return value;
+  };
 
   const lineClamp = +(
     gridStyling?.[Attribute.LineClamp] ??


### PR DESCRIPTION
Fixes an issue where the resolved value from the `theme.getStyle()` would be an object if the active theme did not have any values set for `object.pivotTableV2.grid.border`. This would result in borders getting the wrong colors.

Before
![image](https://github.com/qlik-oss/sn-pivot-table/assets/16608020/9653bb4e-4786-4c88-8004-f89584e03f15)
