### PR TITLE
fix: last col cannot be expanded

### DIFF
--- a/src/pivot-table/components/cells/DimensionValue/Container.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/Container.tsx
@@ -64,7 +64,7 @@ const Container = ({
         }),
         cursor: getCursor(canBeSelected),
         background: getBackground({ styleService, isCellSelected, cell, isCellLocked }),
-        zIndex: layoutService.size.x - cell.x,
+        zIndex: isLeftColumn ? undefined : layoutService.size.x - cell.x,
         justifyContent: isLeftColumn ? undefined : "center",
         display: "flex",
       }}


### PR DESCRIPTION
Last col is now expandable

https://github.com/qlik-oss/sn-pivot-table/assets/29652890/0f0b3303-cdca-42fd-9cbf-c2b88ce2c3e6