### PR TITLE
fix: prevent click event when dragging

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@playwright/test": "1.39.0",
     "@qlik-trial/sprout": "3.5.0",
     "@qlik/eslint-config": "0.4.30",
-    "@qlik/nebula-table-utils": "2.6.0",
+    "@qlik/nebula-table-utils": "2.6.1",
     "@qlik/prettier-config": "0.4.1",
     "@qlik/tsconfig": "0.2.1",
     "@rollup/plugin-typescript": "11.1.5",

--- a/src/pivot-table/components/cells/ColumnAdjusterWrapper.tsx
+++ b/src/pivot-table/components/cells/ColumnAdjusterWrapper.tsx
@@ -11,6 +11,7 @@ interface AdjusterProps {
   dataModel: DataModel | undefined;
   isLastColumn: boolean;
   overrideLeftGridWidth?: OverrideLeftGridWidth;
+  setIsAdjustingWidth: (isAdjusting: boolean) => void;
 }
 /**
  * Component that is placed on top of column border, to resize the columns.
@@ -23,6 +24,7 @@ const ColumnAdjusterWrapper = ({
   dataModel,
   isLastColumn,
   overrideLeftGridWidth,
+  setIsAdjustingWidth,
 }: AdjusterProps) => {
   const { interactions } = useBaseContext();
   const { isActive } = useSelectionsContext();
@@ -46,6 +48,7 @@ const ColumnAdjusterWrapper = ({
       keyValue={`adjuster-${cellInfo.dimensionInfoIndex}`}
       updateWidthCallback={updateWidth}
       confirmWidthCallback={confirmWidth}
+      setIsAdjustingWidth={setIsAdjustingWidth}
     />
   );
 };

--- a/src/pivot-table/components/cells/DimensionTitleCell.tsx
+++ b/src/pivot-table/components/cells/DimensionTitleCell.tsx
@@ -63,7 +63,7 @@ const DimensionTitleCell = ({
   } = styleService.header;
   const anchorRef = useRef<HTMLDivElement>(null);
   const { shouldShowLockIcon, shouldShowMenuIcon } = iconsVisibilityStatus;
-  const { open, setOpen, handleOpenMenu } = useHeadCellDim({ interactions });
+  const { open, setOpen, handleOpenMenu, setIsAdjustingWidth } = useHeadCellDim({ interactions, dataModel });
 
   const sortFromMenu = async (evt: React.MouseEvent, newSortDirection: SortDirection) => {
     evt.stopPropagation();
@@ -125,6 +125,7 @@ const DimensionTitleCell = ({
         dataModel={dataModel}
         isLastColumn={isLastColumn}
         overrideLeftGridWidth={overrideLeftGridWidth}
+        setIsAdjustingWidth={setIsAdjustingWidth}
       />
     </StyledHeaderCellWrapper>
   );

--- a/src/pivot-table/components/cells/DimensionValue/Container.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/Container.tsx
@@ -17,6 +17,7 @@ type Props = {
   cell: Cell;
   data: ListItemData;
   children: ReactNode;
+  isAdjustingWidth: boolean;
 };
 
 export const testId = "dimension-cell";
@@ -34,6 +35,7 @@ const Container = ({
   isLastColumn,
   isLeftColumn,
   isCellSelected,
+  isAdjustingWidth,
 }: Props): JSX.Element => {
   const styleService = useStyleContext();
   const { interactions } = useBaseContext();
@@ -48,7 +50,8 @@ const Container = ({
     !cell.isEmpty &&
     !cell.isNull &&
     !cell.isPseudoDimension &&
-    !cell.isTotal;
+    !cell.isTotal &&
+    !isAdjustingWidth;
   const onClickHandler = canBeSelected ? select(cell) : undefined;
 
   return (

--- a/src/pivot-table/components/cells/DimensionValue/index.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/index.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import { useOnPropsChange } from "@qlik/nebula-table-utils/lib/hooks";
+import React, { useState } from "react";
 import { areEqual } from "react-window";
 import type { ListItemData } from "../../../../types/types";
 import { useSelectionsContext } from "../../../contexts/SelectionsProvider";
@@ -22,10 +23,13 @@ const DimensionValue = ({ index, style, data }: DimensionValueProps): JSX.Elemen
   const styleService = useStyleContext();
   const { isSelected } = useSelectionsContext();
   const { dataModel, layoutService, isLeftColumn = false, showLastBorder, itemCount, isLast, totalDividerIndex } = data;
+  const [isAdjustingWidth, setIsAdjustingWidth] = useState(false);
   const cell = getCell(index, data);
   const isLastRow = isLeftColumn ? index === itemCount - 1 : isLast;
   const isLastColumn = isLeftColumn ? isLast : index === itemCount - 1;
   const showTotalCellDivider = shouldShowTotalCellDivider(cell, totalDividerIndex);
+
+  useOnPropsChange(() => setIsAdjustingWidth(false), [data]);
 
   if (cell === undefined) {
     const { background } = styleService.dimensionValues;
@@ -57,6 +61,7 @@ const DimensionValue = ({ index, style, data }: DimensionValueProps): JSX.Elemen
       showTotalCellDivider={showTotalCellDivider}
       cell={cell}
       data={data}
+      isAdjustingWidth={isAdjustingWidth}
     >
       <StickyCellContainer isLeftColumn={isLeftColumn}>
         <ExpandOrCollapseIcon
@@ -74,6 +79,7 @@ const DimensionValue = ({ index, style, data }: DimensionValueProps): JSX.Elemen
         columnWidth={style.width as number}
         dataModel={dataModel}
         isLastColumn={isLastColumn}
+        setIsAdjustingWidth={setIsAdjustingWidth}
       />
     </Container>
   );

--- a/src/pivot-table/components/cells/DimensionValue/index.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/index.tsx
@@ -1,9 +1,9 @@
-import { useOnPropsChange } from "@qlik/nebula-table-utils/lib/hooks";
-import React, { useState } from "react";
+import React from "react";
 import { areEqual } from "react-window";
 import type { ListItemData } from "../../../../types/types";
 import { useSelectionsContext } from "../../../contexts/SelectionsProvider";
 import { useStyleContext } from "../../../contexts/StyleProvider";
+import useIsAdjustingWidth from "../../../hooks/use-is-adjusting-width";
 import { shouldShowTotalCellDivider } from "../../../hooks/use-is-total-cell";
 import ColumnAdjusterWrapper from "../ColumnAdjusterWrapper";
 import EmptyCell from "../EmptyCell";
@@ -22,17 +22,13 @@ export interface DimensionValueProps {
 const DimensionValue = ({ index, style, data }: DimensionValueProps): JSX.Element => {
   const styleService = useStyleContext();
   const { isSelected } = useSelectionsContext();
-  const [isAdjustingWidth, setIsAdjustingWidth] = useState(false);
+  const { isAdjustingWidth, setIsAdjustingWidth } = useIsAdjustingWidth([data]);
 
   const { dataModel, layoutService, isLeftColumn = false, showLastBorder, itemCount, isLast, totalDividerIndex } = data;
   const cell = getCell(index, data);
   const isLastRow = isLeftColumn ? index === itemCount - 1 : isLast;
   const isLastColumn = isLeftColumn ? isLast : index === itemCount - 1;
   const showTotalCellDivider = shouldShowTotalCellDivider(cell, totalDividerIndex);
-
-  useOnPropsChange(() => {
-    setIsAdjustingWidth(false);
-  }, [data]);
 
   if (cell === undefined) {
     const { background } = styleService.dimensionValues;

--- a/src/pivot-table/components/cells/DimensionValue/index.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/index.tsx
@@ -22,14 +22,17 @@ export interface DimensionValueProps {
 const DimensionValue = ({ index, style, data }: DimensionValueProps): JSX.Element => {
   const styleService = useStyleContext();
   const { isSelected } = useSelectionsContext();
-  const { dataModel, layoutService, isLeftColumn = false, showLastBorder, itemCount, isLast, totalDividerIndex } = data;
   const [isAdjustingWidth, setIsAdjustingWidth] = useState(false);
+
+  const { dataModel, layoutService, isLeftColumn = false, showLastBorder, itemCount, isLast, totalDividerIndex } = data;
   const cell = getCell(index, data);
   const isLastRow = isLeftColumn ? index === itemCount - 1 : isLast;
   const isLastColumn = isLeftColumn ? isLast : index === itemCount - 1;
   const showTotalCellDivider = shouldShowTotalCellDivider(cell, totalDividerIndex);
 
-  useOnPropsChange(() => setIsAdjustingWidth(false), [data]);
+  useOnPropsChange(() => {
+    setIsAdjustingWidth(false);
+  }, [data]);
 
   if (cell === undefined) {
     const { background } = styleService.dimensionValues;

--- a/src/pivot-table/components/cells/__tests__/ColumnAdjusterWrapper.test.tsx
+++ b/src/pivot-table/components/cells/__tests__/ColumnAdjusterWrapper.test.tsx
@@ -19,7 +19,13 @@ describe("<ColumnAdjuster />", () => {
 
   const renderAdjuster = () =>
     render(
-      <ColumnAdjusterWrapper cellInfo={cellInfo} columnWidth={100} dataModel={{} as DataModel} isLastColumn={false} />,
+      <ColumnAdjusterWrapper
+        cellInfo={cellInfo}
+        columnWidth={100}
+        dataModel={{} as DataModel}
+        isLastColumn={false}
+        setIsAdjustingWidth={() => {}}
+      />,
       {
         wrapper: ({ children }) => (
           <TestWithProvider selections={selections} interactions={interactions}>

--- a/src/pivot-table/hooks/__tests__/use-head-cell-dim.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-head-cell-dim.test.ts
@@ -2,18 +2,21 @@ import type { stardust } from "@nebula.js/stardust";
 import { COLUMN_ADJUSTER_CLASS } from "@qlik/nebula-table-utils/lib/constants";
 import { renderHook } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
+import type { DataModel } from "../../../types/types";
 import { useHeadCellDim } from "../use-head-cell-dim";
 
 describe("UseHeadCellDim", () => {
   let interactions: stardust.Interactions;
   let evt: React.MouseEvent;
+  let dataModel: DataModel;
 
   beforeEach(() => {
     interactions = { active: true };
     evt = {} as React.MouseEvent;
+    dataModel = {} as DataModel;
   });
 
-  const renderer = () => renderHook(() => useHeadCellDim({ interactions })).result;
+  const renderer = () => renderHook(() => useHeadCellDim({ interactions, dataModel })).result;
 
   test("should return initial open state", () => {
     const result = renderer();
@@ -44,6 +47,20 @@ describe("UseHeadCellDim", () => {
   test("handleOpenMenu should not set open state to true when event is coming from column adjuster", () => {
     evt.target = { getAttribute: () => COLUMN_ADJUSTER_CLASS } as unknown as EventTarget;
     const result = renderer();
+
+    act(() => {
+      result.current.handleOpenMenu(evt);
+    });
+
+    expect(result.current.open).toBe(false);
+  });
+
+  test("handleOpenMenu should not set open state to true when isAdjustingWidth is true", async () => {
+    const result = renderer();
+
+    await act(async () => {
+      result.current.setIsAdjustingWidth(true);
+    });
 
     act(() => {
       result.current.handleOpenMenu(evt);

--- a/src/pivot-table/hooks/use-head-cell-dim.ts
+++ b/src/pivot-table/hooks/use-head-cell-dim.ts
@@ -1,8 +1,8 @@
 import type { stardust } from "@nebula.js/stardust";
-import { useOnPropsChange } from "@qlik/nebula-table-utils/lib/hooks";
 import { useState } from "react";
 import type { DataModel } from "../../types/types";
 import isEventFromColumnAdjuster from "../components/cells/utils/is-event-from-column-adjuster";
+import useIsAdjustingWidth from "./use-is-adjusting-width";
 
 interface UseHeadCellDim {
   interactions: stardust.Interactions;
@@ -11,12 +11,7 @@ interface UseHeadCellDim {
 
 export const useHeadCellDim = ({ interactions, dataModel }: UseHeadCellDim) => {
   const [open, setOpen] = useState(false);
-  const [isAdjustingWidth, setIsAdjustingWidth] = useState(false);
-
-  // dataModel is only needed here since we want to reset isAdjustingWidth whenever there is a layout change
-  useOnPropsChange(() => {
-    setIsAdjustingWidth(false);
-  }, [dataModel]);
+  const { isAdjustingWidth, setIsAdjustingWidth } = useIsAdjustingWidth([dataModel]);
 
   const handleOpenMenu = (evt: React.MouseEvent) =>
     interactions.active && !isEventFromColumnAdjuster(evt) && !isAdjustingWidth && setOpen(true);

--- a/src/pivot-table/hooks/use-head-cell-dim.ts
+++ b/src/pivot-table/hooks/use-head-cell-dim.ts
@@ -1,16 +1,26 @@
 import type { stardust } from "@nebula.js/stardust";
+import { useOnPropsChange } from "@qlik/nebula-table-utils/lib/hooks";
 import { useState } from "react";
+import type { DataModel } from "../../types/types";
 import isEventFromColumnAdjuster from "../components/cells/utils/is-event-from-column-adjuster";
 
 interface UseHeadCellDim {
   interactions: stardust.Interactions;
+  dataModel: DataModel;
 }
 
-export const useHeadCellDim = ({ interactions }: UseHeadCellDim) => {
+export const useHeadCellDim = ({ interactions, dataModel }: UseHeadCellDim) => {
   const [open, setOpen] = useState(false);
+  const [isAdjustingWidth, setIsAdjustingWidth] = useState(false);
+
+  // dataModel is only needed here since we want to reset isAdjustingWidth whenever there is a layout change
+  useOnPropsChange(() => {
+    console.log("useonprops");
+    setIsAdjustingWidth(false);
+  }, [dataModel]);
 
   const handleOpenMenu = (evt: React.MouseEvent) =>
-    interactions.active && !isEventFromColumnAdjuster(evt) && setOpen(true);
+    interactions.active && !isEventFromColumnAdjuster(evt) && !isAdjustingWidth && setOpen(true);
 
-  return { open, setOpen, handleOpenMenu };
+  return { open, setOpen, handleOpenMenu, setIsAdjustingWidth };
 };

--- a/src/pivot-table/hooks/use-head-cell-dim.ts
+++ b/src/pivot-table/hooks/use-head-cell-dim.ts
@@ -15,7 +15,6 @@ export const useHeadCellDim = ({ interactions, dataModel }: UseHeadCellDim) => {
 
   // dataModel is only needed here since we want to reset isAdjustingWidth whenever there is a layout change
   useOnPropsChange(() => {
-    console.log("useonprops");
     setIsAdjustingWidth(false);
   }, [dataModel]);
 

--- a/src/pivot-table/hooks/use-is-adjusting-width.ts
+++ b/src/pivot-table/hooks/use-is-adjusting-width.ts
@@ -1,0 +1,14 @@
+import { useOnPropsChange } from "@qlik/nebula-table-utils/lib/hooks";
+import { useState } from "react";
+
+const useIsAdjustingWidth = (deps: unknown[]) => {
+  const [isAdjustingWidth, setIsAdjustingWidth] = useState(false);
+
+  useOnPropsChange(() => {
+    setIsAdjustingWidth(false);
+  }, deps);
+
+  return { isAdjustingWidth, setIsAdjustingWidth };
+};
+
+export default useIsAdjustingWidth;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2646,10 +2646,10 @@
     eslint-plugin-vitest "0.3.9"
     svelte-eslint-parser "0.33.1"
 
-"@qlik/nebula-table-utils@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@qlik/nebula-table-utils/-/nebula-table-utils-2.6.0.tgz#99af8ad0b286339341e7f3c8ba8dcb6bf6c2dd71"
-  integrity sha512-a3b5006dawHk8qqaacoP/zhse4ZfMhohAxfkUiAm7GEITmAMLfoXj61pIKp1+fJWi2xEnxoXkinIMt1Ln/X9+g==
+"@qlik/nebula-table-utils@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@qlik/nebula-table-utils/-/nebula-table-utils-2.6.1.tgz#17dff936e7cd1d54c087b108785d86eae9e708db"
+  integrity sha512-Pn77HwCECSQaGIkXmbYaBHNb4GTxZWjcwB0qIIs+VivOJJ2ANJ/4XAJN4hFCQPnSCX19xb6w0PvEFNhJB3+trg==
 
 "@qlik/prettier-config@0.4.1":
   version "0.4.1"


### PR DESCRIPTION
In order to block click events on the dimension value cells and header cells, we need to know when the column adjuster is being dragged or not. Therefor we add a `isAdjustingWidth` state, the setter to the `ColumnAdjuster` and set it to true when you start dragging. The state is reset if there is a layout change, so you can select/open the header menu again. Note that there is still a small bug you can get. If you have the min width aldready, then start to drag over the cell and release, you will trigger the cell click handler. This is an extreme corner-case, that will be fixed if we implement drag to select. See both the fix and the remaining bug in the gif
![Kapture 2023-11-14 at 15 53 29](https://github.com/qlik-oss/sn-pivot-table/assets/9249820/b57a2183-42b5-499c-8855-206ff081936a)

[This](https://github.com/qlik-oss/nebula-table-utils/pull/76) change in utils repo needs to be released before merging this PR