### PR TITLE
fix: only render columnadjuster for headers that are left dimensions + correctly override widths on the left side

### DIFF
--- a/src/pivot-table/components/cells/ColumnAdjusterWrapper.tsx
+++ b/src/pivot-table/components/cells/ColumnAdjusterWrapper.tsx
@@ -35,7 +35,7 @@ const ColumnAdjusterWrapper = ({
 
   const updateWidth = (adjustedWidth: number) => {
     forceRerender({});
-    if (overrideLeftGridWidth && cellInfo.colIdx) {
+    if (overrideLeftGridWidth && cellInfo.colIdx !== undefined) {
       overrideLeftGridWidth(adjustedWidth, cellInfo.colIdx);
     }
   };

--- a/src/pivot-table/components/cells/ColumnAdjusterWrapper.tsx
+++ b/src/pivot-table/components/cells/ColumnAdjusterWrapper.tsx
@@ -35,7 +35,9 @@ const ColumnAdjusterWrapper = ({
 
   const updateWidth = (adjustedWidth: number) => {
     forceRerender({});
-    overrideLeftGridWidth?.(adjustedWidth, cellInfo.dimensionInfoIndex);
+    if (overrideLeftGridWidth && cellInfo.colIdx) {
+      overrideLeftGridWidth(adjustedWidth, cellInfo.colIdx);
+    }
   };
 
   const confirmWidth = (newWidthData: ColumnWidth) => dataModel?.applyColumnWidth(newWidthData, cellInfo);

--- a/src/pivot-table/data/extract-headers.ts
+++ b/src/pivot-table/data/extract-headers.ts
@@ -116,7 +116,7 @@ const extractHeaders = (
   // Update canBeResized on bottom row
   if (matrix.length > 0) {
     for (const cell of matrix[matrix.length - 1]) {
-      if (cell) {
+      if (cell?.isLeftDimension) {
         cell.canBeResized = true;
       }
     }

--- a/src/pivot-table/data/extract-headers.ts
+++ b/src/pivot-table/data/extract-headers.ts
@@ -105,11 +105,13 @@ const extractHeaders = (
   }
 
   // Update canBeResized, isActivelySorted and colIdx on bottom row
-  for (const [colIdx, cell] of matrix[matrix.length - 1].entries()) {
-    if (cell) {
-      cell.canBeResized = cell.isLeftDimension;
-      cell.isActivelySorted = colIdx === (layoutService.layout.qHyperCube.activelySortedColumn?.colIdx ?? 0);
-      cell.colIdx = cell.colIdx || colIdx;
+  if (matrix.length) {
+    for (const [colIdx, cell] of matrix[matrix.length - 1].entries()) {
+      if (cell) {
+        cell.canBeResized = cell.isLeftDimension;
+        cell.isActivelySorted = colIdx === (layoutService.layout.qHyperCube.activelySortedColumn?.colIdx ?? 0);
+        cell.colIdx = cell.colIdx || colIdx;
+      }
     }
   }
 

--- a/src/pivot-table/data/extract-headers.ts
+++ b/src/pivot-table/data/extract-headers.ts
@@ -22,18 +22,9 @@ const trimTrailingPseudo = (visibleDimensionInfos: VisibleDimensionInfo[]) => {
   return visibleDimensionInfos;
 };
 
-const createHeaderCell = (
-  layoutService: LayoutService,
-  qDimensionInfo: VisibleDimensionInfo,
-  colIdx: number,
-): HeaderCell => {
-  const {
-    layout: { qHyperCube },
-    getDimensionInfoIndex,
-  } = layoutService;
-
+const createHeaderCell = (layoutService: LayoutService, qDimensionInfo: VisibleDimensionInfo): HeaderCell => {
   const id = getKey(qDimensionInfo);
-  const dimensionInfoIndex = getDimensionInfoIndex(qDimensionInfo);
+  const dimensionInfoIndex = layoutService.getDimensionInfoIndex(qDimensionInfo);
   const isLeftDimension = layoutService.isLeftDimension(dimensionInfoIndex);
   if (qDimensionInfo === PSEUDO_DIMENSION_INDEX) {
     return {
@@ -53,21 +44,21 @@ const createHeaderCell = (
   }
   return {
     id,
-    colIdx,
+    colIdx: 0, // has to be properly set later, would be incorrect after transposing otherwise
     label: qDimensionInfo.qFallbackTitle,
     qReverseSort: qDimensionInfo.qReverseSort,
     sortDirection:
       qDimensionInfo.qSortIndicator && qDimensionInfo.qSortIndicator !== "N" ? qDimensionInfo.qSortIndicator : "A",
     qLibraryId: qDimensionInfo.qLibraryId,
     fieldId: qDimensionInfo.qGroupFieldDefs[qDimensionInfo.qGroupPos],
-    isActivelySorted: colIdx === (qHyperCube.activelySortedColumn?.colIdx ?? 0),
+    isActivelySorted: false, // has to be properly set later, would be incorrect after transposing otherwise
     isLocked: qDimensionInfo.qLocked ?? false,
     columnWidth: qDimensionInfo.columnWidth,
     qApprMaxGlyphCount: qDimensionInfo.qApprMaxGlyphCount,
     isDim: true,
     headTextAlign: "left",
     dimensionInfoIndex,
-    canBeResized: false,
+    canBeResized: false, // has to be properly set later, would be incorrect after transposing otherwise
     isLeftDimension,
   };
 };
@@ -82,11 +73,11 @@ const createMatrix = ({ layoutService, lastRow, lastCol }: CreateMatrixProps): H
   const matrix: HeadersDataMatrix = createEmptyMatrix(rowCount, colCount);
 
   lastRow.forEach((dimensionInfo, colIdx) => {
-    matrix[rowCount - 1][colIdx] = createHeaderCell(layoutService, dimensionInfo, colIdx);
+    matrix[rowCount - 1][colIdx] = createHeaderCell(layoutService, dimensionInfo);
   });
 
   prunedLastCol.forEach((dimensionInfo, rowIdx) => {
-    matrix[rowIdx][colCount - 1] = createHeaderCell(layoutService, dimensionInfo, colCount - 1);
+    matrix[rowIdx][colCount - 1] = createHeaderCell(layoutService, dimensionInfo);
   });
   return matrix;
 };
@@ -113,12 +104,12 @@ const extractHeaders = (
     );
   }
 
-  // Update canBeResized on bottom row
-  if (matrix.length > 0) {
-    for (const cell of matrix[matrix.length - 1]) {
-      if (cell?.isLeftDimension) {
-        cell.canBeResized = true;
-      }
+  // Update canBeResized, isActivelySorted and colIdx on bottom row
+  for (const [colIdx, cell] of matrix[matrix.length - 1].entries()) {
+    if (cell) {
+      cell.canBeResized = cell.isLeftDimension;
+      cell.isActivelySorted = colIdx === (layoutService.layout.qHyperCube.activelySortedColumn?.colIdx ?? 0);
+      cell.colIdx = cell.colIdx || colIdx;
     }
   }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -83,6 +83,7 @@ export interface AdjusterCellInfo {
   isLeftColumn: boolean;
   canBeResized: boolean;
   x?: number;
+  colIdx?: number;
 }
 
 export interface Cell {


### PR DESCRIPTION
- don't render the column adjuster for row headers
- set `colIdx` and use it for `overrideLeftGridWidth`. Now `colIdx` is used to set `activelySortedColumn`, which in turn determines some states in the header menu. That is still not correct and needs to be fixed in a different PR. This is still an improvement of what it was before.

I tried to test this, but to get a correct `isLeftDimension`, we need to mock more or less all of `layoutService`. We might want to do that in a smart way, but that is a different PR 