### PR TITLE
fix: render empty cells

### DIFF
--- a/src/hooks/use-render.ts
+++ b/src/hooks/use-render.ts
@@ -43,7 +43,7 @@ const useRender = () => {
   const { pageInfo, updatePageInfo } = usePagination(layoutService);
   const viewService = useViewService(pageInfo);
   const rect = useSnapshot({ rect: useRect(), layoutService, viewService, model });
-  const [qPivotDataPages, isLoading] = useLoadDataPages({ model, layoutService, viewService, pageInfo });
+  const [qPivotDataPages, isLoading] = useLoadDataPages({ model, layoutService, viewService, pageInfo, rect });
   // It needs to be theme.name() because the reference to the theme object does not change when a theme is changed
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const styleService = useMemo(() => createStyleService(theme, layoutService), [theme.name(), layoutService]);

--- a/src/pivot-table/components/grids/DataGrid.tsx
+++ b/src/pivot-table/components/grids/DataGrid.tsx
@@ -143,6 +143,14 @@ const DataGrid = ({
     }
   }, [width, height, dataGridRef, contentCellHeight]);
 
+  /**
+   * react-window callback that is called when the range of items rendered by the VariableSizeGrid changes.
+   *
+   * It's intended to handle the following scenarions that might require additional data to be fetch:
+   * - Scrolling
+   * - Re-sizing the chart
+   * - Theme change (ex: go from large font-size to small could change the number of rendered cells)
+   */
   const onItemsRendered = useCallback(
     async ({
       overscanColumnStartIndex,

--- a/src/pivot-table/hooks/use-data-model.ts
+++ b/src/pivot-table/hooks/use-data-model.ts
@@ -10,6 +10,7 @@ import {
   type LayoutService,
   type PageInfo,
 } from "../../types/types";
+import handleMaxEnginePageSize from "../../utils/handle-max-engine-size";
 import useMutableProp from "./use-mutable-prop";
 
 export interface UseDataModelProps {
@@ -68,7 +69,7 @@ export default function useDataModel({
           qHeight: height,
         };
 
-        const [pivotPage] = await genericObjectModel.getHyperCubePivotData(Q_PATH, [nextArea]);
+        const [pivotPage] = await genericObjectModel.getHyperCubePivotData(Q_PATH, handleMaxEnginePageSize(nextArea));
 
         // Guard against page changes
         if (currentPage.current === pageInfo.page) {

--- a/src/utils/__tests__/handle-max-engine-size.test.ts
+++ b/src/utils/__tests__/handle-max-engine-size.test.ts
@@ -1,0 +1,80 @@
+import type { stardust } from "@nebula.js/stardust";
+import handleMaxEnginePageSize, { getMaxVisibleRowsAndColumns } from "../handle-max-engine-size";
+
+const resolutions = {
+  "8k": {
+    width: 4320,
+    height: 7680,
+  },
+  "4k": {
+    width: 3840,
+    height: 2160,
+  },
+  "1440p": {
+    width: 2560,
+    height: 1440,
+  },
+};
+
+describe("handleMaxEnginePageSize", () => {
+  test("should null page", () => {
+    expect(handleMaxEnginePageSize(null)).toEqual([]);
+  });
+
+  test("should handle 1440p resolution", () => {
+    const { maxNumberOfVisibleRows, maxNumberOfVisibleColumns } = getMaxVisibleRowsAndColumns(
+      resolutions["1440p"] as stardust.Rect,
+    );
+
+    expect(
+      handleMaxEnginePageSize({
+        qLeft: 1,
+        qTop: 2,
+        qWidth: maxNumberOfVisibleColumns,
+        qHeight: maxNumberOfVisibleRows,
+      }),
+    ).toEqual([{ qLeft: 1, qTop: 2, qWidth: maxNumberOfVisibleColumns, qHeight: maxNumberOfVisibleRows }]);
+  });
+
+  test("should handle 4k resolution", () => {
+    const { maxNumberOfVisibleRows, maxNumberOfVisibleColumns } = getMaxVisibleRowsAndColumns(
+      resolutions["4k"] as stardust.Rect,
+    );
+
+    expect(
+      handleMaxEnginePageSize({
+        qLeft: 1,
+        qTop: 2,
+        qWidth: maxNumberOfVisibleColumns,
+        qHeight: maxNumberOfVisibleRows,
+      }),
+    ).toEqual([
+      { qLeft: 1, qTop: 2, qWidth: 100, qHeight: 90 },
+      { qLeft: 101, qTop: 2, qWidth: 28, qHeight: 90 },
+    ]);
+  });
+
+  test("should handle 8k resolution", () => {
+    const { maxNumberOfVisibleRows, maxNumberOfVisibleColumns } = getMaxVisibleRowsAndColumns(
+      resolutions["8k"] as stardust.Rect,
+    );
+
+    expect(
+      handleMaxEnginePageSize({
+        qLeft: 1,
+        qTop: 2,
+        qWidth: maxNumberOfVisibleColumns,
+        qHeight: maxNumberOfVisibleRows,
+      }),
+    ).toEqual([
+      { qLeft: 1, qTop: 2, qWidth: 100, qHeight: 100 },
+      { qLeft: 1, qTop: 102, qWidth: 100, qHeight: 100 },
+      { qLeft: 1, qTop: 202, qWidth: 100, qHeight: 100 },
+      { qLeft: 1, qTop: 302, qWidth: 100, qHeight: 20 },
+      { qLeft: 101, qTop: 2, qWidth: 44, qHeight: 100 },
+      { qLeft: 101, qTop: 102, qWidth: 44, qHeight: 100 },
+      { qLeft: 101, qTop: 202, qWidth: 44, qHeight: 100 },
+      { qLeft: 101, qTop: 302, qWidth: 44, qHeight: 20 },
+    ]);
+  });
+});

--- a/src/utils/handle-max-engine-size.ts
+++ b/src/utils/handle-max-engine-size.ts
@@ -1,0 +1,50 @@
+import type { stardust } from "@nebula.js/stardust";
+import { ColumnWidthValues } from "@qlik/nebula-table-utils/lib/constants";
+import { DEFAULT_CELL_HEIGHT } from "../pivot-table/constants";
+
+const MAX_ENGINE_PAGE_SIZE = 10_000;
+const MAX_ENGINE_PAGE_SIZE_SIDE = Math.sqrt(MAX_ENGINE_PAGE_SIZE);
+
+export const getMaxVisibleRowsAndColumns = (rect: stardust.Rect) => {
+  const maxNumberOfVisibleRows = Math.ceil(rect.height / DEFAULT_CELL_HEIGHT);
+  const maxNumberOfVisibleColumns = Math.ceil(rect.width / ColumnWidthValues.PixelsMin);
+
+  return {
+    maxNumberOfVisibleRows,
+    maxNumberOfVisibleColumns,
+  };
+};
+
+/**
+ * When quering Engine for data, it can at most return 10 000 data values per page.
+ * This helper function take a large page and splits it into multiple smaller pages
+ * that are all <= 10 000.
+ */
+const handleMaxEnginePageSize = (page: EngineAPI.INxPage | null) => {
+  if (page === null) {
+    return [];
+  }
+
+  if (page.qWidth * page.qHeight < MAX_ENGINE_PAGE_SIZE) {
+    return [page];
+  }
+
+  const pages: EngineAPI.INxPage[] = [];
+  const columnCount = Math.ceil(page.qWidth / MAX_ENGINE_PAGE_SIZE_SIDE);
+  const rowCount = Math.ceil(page.qHeight / MAX_ENGINE_PAGE_SIZE_SIDE);
+
+  for (let colIndex = 0; colIndex < columnCount; colIndex++) {
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      pages.push({
+        qLeft: page.qLeft + colIndex * MAX_ENGINE_PAGE_SIZE_SIDE,
+        qTop: page.qTop + rowIndex * MAX_ENGINE_PAGE_SIZE_SIDE,
+        qWidth: Math.min(MAX_ENGINE_PAGE_SIZE_SIDE, page.qWidth - colIndex * MAX_ENGINE_PAGE_SIZE_SIDE),
+        qHeight: Math.min(MAX_ENGINE_PAGE_SIZE_SIDE, page.qHeight - rowIndex * MAX_ENGINE_PAGE_SIZE_SIDE),
+      });
+    }
+  }
+
+  return pages;
+};
+
+export default handleMaxEnginePageSize;


### PR DESCRIPTION
Fixes an issue where empty cells could be rendered if more than 50 rows and/or 50 columns was visible in the pivot table. The `onItemsRendered` callback would fetch addtional data on the first render of the chart. But when a update was made that triggered a new layout, empty cells would be rendered as `onItemsRendered` was no longer called.

This also fixes an issue in `onItemsRendered` where it could call Engine to request data that exceeded the max limit of 10k data values.