### PR TITLE
fix: use increasing z-index for header grid cells

### DIFF
--- a/src/pivot-table/components/grids/HeaderGrid.tsx
+++ b/src/pivot-table/components/grids/HeaderGrid.tsx
@@ -57,7 +57,7 @@ const HeaderGrid = ({
                 height: rowHight,
                 gridColumn: colIndex + 1,
                 gridRow: rowIndex + 1,
-                zIndex: Number(!cell.isDim),
+                zIndex: headersData.size.x - colIndex,
               }}
               isLastRow={rowIndex === headersData.size.y - 1}
               isFirstColumn={colIndex === 0}


### PR DESCRIPTION
As for the top grid, the z-index is needed to make sure the column adjuster overlaps two cells.