### PR TITLE
fix: resize flickering

### DIFF
--- a/src/hooks/use-mutable-nebula-prop.ts
+++ b/src/hooks/use-mutable-nebula-prop.ts
@@ -1,0 +1,10 @@
+import useNebulaRef from "./use-nebula-ref";
+
+const useMutableNebulaProp = <T>(value: T) => {
+  const mutableRef = useNebulaRef(value);
+  mutableRef.current = value;
+
+  return mutableRef;
+};
+
+export default useMutableNebulaProp;

--- a/src/hooks/use-nebula-ref.ts
+++ b/src/hooks/use-nebula-ref.ts
@@ -1,0 +1,12 @@
+import { useMemo } from "@nebula.js/stardust";
+
+const nonInitializedValue = {};
+
+const useNebulaRef = <T>(value: T) => {
+  const ref = useMemo<{ current: T }>(() => ({ current: nonInitializedValue as T }), []);
+  ref.current = ref.current === nonInitializedValue ? value : ref.current;
+
+  return ref;
+};
+
+export default useNebulaRef;


### PR DESCRIPTION
Fixes an issue where the chart would be flickering when it was being resized.

Before:


https://github.com/qlik-oss/sn-pivot-table/assets/16608020/b5f88f4f-98ff-4242-98c3-807f9c953323


After:


https://github.com/qlik-oss/sn-pivot-table/assets/16608020/8e1720b0-d0a5-4b96-ad3f-50dfe201237f

