### PR TITLE
fix: remove expand icon at last column only

### DIFF
--- a/src/pivot-table/hooks/use-column-width/__tests__/use-column-width.test.ts
+++ b/src/pivot-table/hooks/use-column-width/__tests__/use-column-width.test.ts
@@ -115,6 +115,21 @@ describe("useColumnWidth", () => {
       expect(leftGridColumnWidths[2]).toBe(width + TOTAL_CELL_PADDING + MENU_ICON_SIZE);
     });
 
+    test("should return left column width for auto setting with no expanded columns", () => {
+      const width = 25;
+      mockEstimateWidth(width);
+      mockMeasureText(width);
+
+      visibleLeftDimensionInfo = createDimInfos([0]);
+      visibleTopDimensionInfo = createDimInfos([1, PSEUDO_DIMENSION_INDEX]);
+      headersData = createHeadersData(layoutService, visibleTopDimensionInfo, visibleLeftDimensionInfo);
+
+      const { leftGridColumnWidths } = renderUseColumnWidth();
+
+      expect(leftGridColumnWidths.length).toBe(1);
+      expect(leftGridColumnWidths[0]).toBe(width + EXPAND_ICON_SIZE + TOTAL_CELL_PADDING);
+    });
+
     test("should return left column width for auto setting, not left dimension, 3 top dimension and pseudo last", () => {
       const width = 25;
       mockEstimateWidth(width);

--- a/src/pivot-table/hooks/use-column-width/use-column-width-left.ts
+++ b/src/pivot-table/hooks/use-column-width/use-column-width-left.ts
@@ -19,6 +19,7 @@ export default function useColumnWidthLeft({ layoutService, tableRect, headersDa
     layout: {
       qHyperCube: { qMeasureInfo, qNoOfLeftDims },
     },
+    hasPseudoDimOnLeft,
     isFullyExpanded,
   } = layoutService;
   const styleService = useStyleContext();
@@ -57,7 +58,7 @@ export default function useColumnWidthLeft({ layoutService, tableRect, headersDa
             } else {
               const { label, qApprMaxGlyphCount, columnWidth, isLocked } = header;
               const expandIconSize =
-                !isFullyExpanded && header.isLeftDimension && !header.isLastDimension ? EXPAND_ICON_SIZE : 0;
+                !isFullyExpanded && header.isLeftDimension && collIdx < qNoOfLeftDims - 1 ? EXPAND_ICON_SIZE : 0;
               const lockedIconSize = isLocked ? LOCK_ICON_SIZE : 0;
 
               let fitToContentWidth = 0;
@@ -68,7 +69,7 @@ export default function useColumnWidthLeft({ layoutService, tableRect, headersDa
                     measureTextForHeader(label) + MENU_ICON_SIZE + lockedIconSize,
                     estimateWidthForDimensionValue(qApprMaxGlyphCount as number) + expandIconSize,
                   );
-              } else if (lastRowLastColumn && !header.isLeftDimension && layoutService.hasPseudoDimOnLeft) {
+              } else if (lastRowLastColumn && !header.isLeftDimension && hasPseudoDimOnLeft) {
                 fitToContentWidth = maxMeasureCellWidth;
               } else {
                 fitToContentWidth = TOTAL_CELL_PADDING + measureTextForHeader(label) + MENU_ICON_SIZE + lockedIconSize;
@@ -99,12 +100,13 @@ export default function useColumnWidthLeft({ layoutService, tableRect, headersDa
     },
     [
       estimateWidthForDimensionValue,
+      hasPseudoDimOnLeft,
       headersData,
       isFullyExpanded,
-      layoutService,
       measureTextForHeader,
       measureTextForMeasureValue,
       qMeasureInfo,
+      qNoOfLeftDims,
       tableRect.width,
     ],
   );


### PR DESCRIPTION
Fixes an issue where the expand icon was removed from column width calculations. The column was incorrectly marked as the last column and therefore not needing the expand icon

Before:

https://github.com/qlik-oss/sn-pivot-table/assets/968450/492cee38-e694-44e3-8a27-a487a5ba6a09

After:

https://github.com/qlik-oss/sn-pivot-table/assets/968450/707c25bd-c348-4a50-9bb4-78fc41c13f9d


