### PR TITLE
fix: data fetch on resize

### DIFF
--- a/src/pivot-table/hooks/use-data-model.ts
+++ b/src/pivot-table/hooks/use-data-model.ts
@@ -59,7 +59,7 @@ export default function useDataModel({
 
   const fetchPages = useCallback<FetchPages>(
     async (pages: EngineAPI.INxPage[]): Promise<void> => {
-      if (!genericObjectModel?.getHyperCubePivotData) return;
+      if (!genericObjectModel?.getHyperCubePivotData || pages.length === 0) return;
 
       try {
         const pivotPages = await genericObjectModel.getHyperCubePivotData(

--- a/src/pivot-table/hooks/use-items-rendered-handler/utils/__tests__/fetch-pages.test.ts
+++ b/src/pivot-table/hooks/use-items-rendered-handler/utils/__tests__/fetch-pages.test.ts
@@ -46,7 +46,10 @@ describe("fetchPages", () => {
     jest.resetAllMocks();
   });
 
-  test("should not fetch pages if both scroll directions are None", async () => {
+  test("should fetch pages if both scroll directions are None", async () => {
+    horizontalScrollDirection.current = ScrollDirection.None;
+    verticalScrollDirection.current = ScrollDirection.None;
+    mockedGetRowPages.mockReturnValue([{ qLeft: 0, qTop: 0, qWidth: 1, qHeight: 1 }]);
     await fetchPages(
       dataModel,
       layoutService,
@@ -57,7 +60,7 @@ describe("fetchPages", () => {
       horizontalScrollDirection,
     );
 
-    expect(dataModel.fetchPages).toHaveBeenCalledWith([]);
+    expect(dataModel.fetchPages).toHaveBeenCalledWith([{ qLeft: 0, qTop: 0, qWidth: 1, qHeight: 1 }]);
   });
 
   test("should fetch both row and column pages", async () => {

--- a/src/pivot-table/hooks/use-items-rendered-handler/utils/fetch-pages.ts
+++ b/src/pivot-table/hooks/use-items-rendered-handler/utils/fetch-pages.ts
@@ -60,6 +60,14 @@ export const fetchPages = async (
     );
   }
 
+  // A chart have been re-size which have triggered a onScroll event and reset both scroll directions
+  if (
+    verticalScrollDirection.current === ScrollDirection.None &&
+    horizontalScrollDirection.current === ScrollDirection.None
+  ) {
+    rowPages = getRowPages(pageInfo, measureData, gridColumnStartIndex, gridRowStartIndex, gridWidth, gridHeight);
+  }
+
   await dataModel.fetchPages([...rowPages, ...columnsPages]);
 };
 

--- a/src/pivot-table/hooks/use-items-rendered-handler/utils/get-column-pages.ts
+++ b/src/pivot-table/hooks/use-items-rendered-handler/utils/get-column-pages.ts
@@ -1,13 +1,14 @@
 import type { MeasureData, PageInfo } from "../../../../types/types";
 
 const isMissingColumnData = (measureData: MeasureData, qLeft: number, pageTop: number, qHeight: number) => {
-  const targetRows = measureData.slice(pageTop, pageTop + qHeight);
-
-  if (targetRows.length === 0) {
-    return true; // Rows are not cached
+  for (let top = pageTop; top < pageTop + qHeight; top++) {
+    const row = measureData[top];
+    if (row === undefined || row[qLeft] === undefined) {
+      return true;
+    }
   }
 
-  return targetRows.some((row) => row?.[qLeft] === undefined);
+  return false;
 };
 
 const canMergePages = (prevPage: EngineAPI.INxPage, page: EngineAPI.INxPage) =>
@@ -29,8 +30,8 @@ const getColumnPages = (
       const page = {
         qLeft: left,
         qTop: Math.max(0, pageTop + pageInfo.page * pageInfo.rowsPerPage),
-        qHeight,
         qWidth: 1,
+        qHeight,
       };
 
       if (prevPage !== undefined && canMergePages(prevPage, page)) {

--- a/src/pivot-table/hooks/use-items-rendered-handler/utils/get-row-pages.ts
+++ b/src/pivot-table/hooks/use-items-rendered-handler/utils/get-row-pages.ts
@@ -36,8 +36,8 @@ const getRowPages = (
       const page = {
         qLeft,
         qTop: Math.max(0, top + pageInfo.page * pageInfo.rowsPerPage),
-        qHeight: 1,
         qWidth,
+        qHeight: 1,
       };
 
       if (prevPage !== undefined && canMergePages(prevPage, page)) {


### PR DESCRIPTION
Fixes an issue where data would not be fetch when re-sizing the PVT.

Two reason this happend:
- Both vertical and horizontal scroll direction can be reset to `None` when a PVT is re-sized.
- `isMissingColumnData` logic did not work properly as extracting "rows" from an array using `slice()` does not work if the end index is larger then the size of the array. Ex: `[0, 1, 2].slice(2, 4)` => `[2]`, but for the logic to work it should have been an array like this `[2, undefined]`


https://github.com/qlik-oss/sn-pivot-table/assets/16608020/f6522e6a-3c12-40e4-ae58-22a6e792de1e

