### PR TITLE
fix: column width for empty row

### DIFF
--- a/src/pivot-table/components/helpers/__tests__/get-item-size-handler.test.ts
+++ b/src/pivot-table/components/helpers/__tests__/get-item-size-handler.test.ts
@@ -97,7 +97,7 @@ describe("getItemSizeHandler", () => {
 
     test("should return a size when cell has no leaf nodes", () => {
       leafCount = 0;
-      distanceToNextCell = 1;
+      distanceToNextCell = 2;
       list[index] = {
         leafCount,
         distanceToNextCell,

--- a/src/pivot-table/components/helpers/__tests__/get-item-size-handler.test.ts
+++ b/src/pivot-table/components/helpers/__tests__/get-item-size-handler.test.ts
@@ -81,10 +81,10 @@ describe("getItemSizeHandler", () => {
       getRightGridColumnWidth = () => columnWidth;
     });
 
-    const getHandler = () =>
+    const getHandler = (isLastRow = false) =>
       getColumnWidthHandler({
         list,
-        isLastRow: false,
+        isLastRow,
         getRightGridColumnWidth,
       });
 
@@ -97,12 +97,32 @@ describe("getItemSizeHandler", () => {
 
     test("should return a size when cell has no leaf nodes", () => {
       leafCount = 0;
+      distanceToNextCell = 1;
+      list[index] = {
+        leafCount,
+        distanceToNextCell,
+        x,
+      } as Cell;
+
+      const handler = getHandler();
+      expect(handler(index)).toEqual(columnWidth * distanceToNextCell);
+    });
+
+    test("should return a size when cell has no leaf nodes and is last row", () => {
+      leafCount = 0;
       list[index] = {
         leafCount,
         x,
       } as Cell;
 
-      const handler = getHandler();
+      const handler = getHandler(true);
+      expect(handler(index)).toEqual(columnWidth);
+    });
+
+    test("should return a size for empty last row", () => {
+      list = [];
+
+      const handler = getHandler(true);
       expect(handler(index)).toEqual(columnWidth);
     });
 

--- a/src/pivot-table/components/helpers/get-item-size-handler.ts
+++ b/src/pivot-table/components/helpers/get-item-size-handler.ts
@@ -42,7 +42,7 @@ export const getColumnWidthHandler =
     }
 
     // all rows except bottom one
-    if (cell?.leafCount > 0) {
+    if (!isLastRow && cell !== undefined) {
       return (cell.leafCount + cell.distanceToNextCell) * getRightGridColumnWidth();
     }
 


### PR DESCRIPTION
Fixes an issue where the column width was not correctly calculated for the "leaf row" when the last row is an empty row.


Before


https://github.com/qlik-oss/sn-pivot-table/assets/16608020/b3f42ff8-17fd-4d3f-b64d-4baead79bb95


After


https://github.com/qlik-oss/sn-pivot-table/assets/16608020/fcbd9a56-5897-4349-8b5b-560a2c7f40c7

