### PR TITLE
fix: empty cells after expanding or collapsing cell

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,7 +1,5 @@
 export const Q_PATH = "/qHyperCubeDef";
 
-export const DEFAULT_PAGE_SIZE = 50;
-
 export const TOTALS_CELL = -1;
 
 export const TOTAL_MODE_ON = "TOTAL_EXPR";

--- a/src/hooks/use-load-data-pages.ts
+++ b/src/hooks/use-load-data-pages.ts
@@ -135,12 +135,12 @@ export const getFetchArea = (
     const lastVisibleColumn = viewService.gridColumnStartIndex + viewService.gridWidth;
 
     if (lastVisibleRow > pageEndIndex) {
-      // Rows where removed before the collapsed cell. Last visible row no longer exists.
+      // Last visible row no longer exists.
       qTop = Math.max(0, pageEndIndex - maxNumberOfVisibleRows);
     }
 
     if (lastVisibleColumn > qSize.qcx) {
-      // Columns where removed before the collapsed cell. Last visible column no longer exists.
+      // Last visible column no longer exists.
       qLeft = Math.max(0, qSize.qcx - maxNumberOfVisibleColumns);
     }
   }

--- a/src/hooks/use-load-data-pages.ts
+++ b/src/hooks/use-load-data-pages.ts
@@ -62,10 +62,12 @@ export const getFetchArea = (
   maxNumberOfVisibleRows: number,
   maxNumberOfVisibleColumns: number,
 ) => {
-  const pageStartIndex = pageInfo.page * pageInfo.rowsPerPage;
+  const pageRowStartIndex = pageInfo.page * pageInfo.rowsPerPage;
   // Do not fetch data beyond this value. Either because there is no more data in the layout or the current page ends.
-  const pageEndIndex = Math.min(pageStartIndex + pageInfo.rowsPerPage, qSize.qcy);
-  if (qSize.qcy < pageStartIndex) {
+  const pageRowEndIndex = Math.min(pageRowStartIndex + pageInfo.rowsPerPage, qSize.qcy);
+  const columnEndIndex = Math.min(MAX_COLUMN_COUNT, qSize.qcx);
+
+  if (qSize.qcy < pageRowStartIndex) {
     /**
      * Do not fetch data that does not exist. This can happen because "PageInfo" is resolved from the layout.
      * Which means it will not be updated until the next render cycle.
@@ -74,7 +76,7 @@ export const getFetchArea = (
   }
 
   let qLeft = 0;
-  let qTop = pageStartIndex;
+  let qTop = pageRowStartIndex;
 
   if (triggerdByExpandOrCollapse) {
     /**
@@ -129,27 +131,27 @@ export const getFetchArea = (
      */
 
     qLeft = viewService.gridColumnStartIndex;
-    qTop = pageStartIndex + viewService.gridRowStartIndex;
+    qTop = pageRowStartIndex + viewService.gridRowStartIndex;
 
     const lastVisibleRow = qTop + viewService.gridHeight;
     const lastVisibleColumn = viewService.gridColumnStartIndex + viewService.gridWidth;
 
-    if (lastVisibleRow > pageEndIndex) {
+    if (lastVisibleRow > pageRowEndIndex) {
       // Last visible row no longer exists.
-      qTop = Math.max(0, pageEndIndex - maxNumberOfVisibleRows);
+      qTop = Math.max(0, pageRowEndIndex - maxNumberOfVisibleRows);
     }
 
-    if (lastVisibleColumn > qSize.qcx) {
+    if (lastVisibleColumn > columnEndIndex) {
       // Last visible column no longer exists.
-      qLeft = Math.max(0, qSize.qcx - maxNumberOfVisibleColumns);
+      qLeft = Math.max(0, columnEndIndex - maxNumberOfVisibleColumns);
     }
   }
 
   return {
     qLeft,
     qTop,
-    qWidth: Math.min(MAX_COLUMN_COUNT - qLeft, qSize.qcx - qLeft, maxNumberOfVisibleColumns),
-    qHeight: Math.min(pageEndIndex - qTop, maxNumberOfVisibleRows),
+    qWidth: Math.min(columnEndIndex - qLeft, maxNumberOfVisibleColumns),
+    qHeight: Math.min(pageRowEndIndex - qTop, maxNumberOfVisibleRows),
   };
 };
 

--- a/src/pivot-table/hooks/__tests__/use-scroll.test.tsx
+++ b/src/pivot-table/hooks/__tests__/use-scroll.test.tsx
@@ -118,7 +118,7 @@ describe("useScroll", () => {
   });
 
   test("should scroll to last known scroll position when a cell is expanded or collapsed", async () => {
-    layoutService.layout.qHyperCube.qLastExpandedPos = { qx: 0, qy: 0 };
+    layoutService.triggerdByExpandOrCollapse = true;
     verticalScrollableContainerRefMock.scrollTop = 123;
     dataGridHorizontalScrollableContainerRefMock.scrollLeft = 321;
 
@@ -129,7 +129,7 @@ describe("useScroll", () => {
   });
 
   test("should not scroll to last known scroll position when a cell has not been expanded or collapsed", async () => {
-    layoutService.layout.qHyperCube.qLastExpandedPos = undefined;
+    layoutService.triggerdByExpandOrCollapse = false;
     verticalScrollableContainerRefMock.scrollTop = 123;
     dataGridHorizontalScrollableContainerRefMock.scrollLeft = 321;
 

--- a/src/pivot-table/hooks/use-data-model.ts
+++ b/src/pivot-table/hooks/use-data-model.ts
@@ -9,6 +9,7 @@ import {
   type FetchPages,
   type LayoutService,
   type PageInfo,
+  type ViewService,
 } from "../../types/types";
 import handleMaxEnginePageSize from "../../utils/handle-max-engine-size";
 import useMutableProp from "./use-mutable-prop";
@@ -18,6 +19,7 @@ export interface UseDataModelProps {
   nextPageHandler: (pages: EngineAPI.INxPivotPage[]) => void;
   pageInfo: PageInfo;
   layoutService: LayoutService;
+  viewService: ViewService;
 }
 
 export default function useDataModel({
@@ -25,6 +27,7 @@ export default function useDataModel({
   nextPageHandler,
   pageInfo,
   layoutService,
+  viewService,
 }: UseDataModelProps): DataModel {
   const currentPage = useMutableProp(pageInfo.page);
   const genericObjectModel = model as EngineAPI.IGenericObject | undefined;
@@ -32,29 +35,49 @@ export default function useDataModel({
   const collapseLeft = useCallback<ExpandOrCollapser>(
     async (rowIndex: number, colIndex: number) => {
       await genericObjectModel?.collapseLeft?.(Q_PATH, rowIndex, colIndex, false);
+      viewService.lastExpandedOrCollapsed = {
+        grid: "left",
+        rowIndex,
+        colIndex,
+      };
     },
-    [genericObjectModel],
+    [genericObjectModel, viewService],
   );
 
   const collapseTop = useCallback<ExpandOrCollapser>(
     async (rowIndex: number, colIndex: number) => {
       await genericObjectModel?.collapseTop(Q_PATH, rowIndex, colIndex, false);
+      viewService.lastExpandedOrCollapsed = {
+        grid: "top",
+        rowIndex,
+        colIndex,
+      };
     },
-    [genericObjectModel],
+    [genericObjectModel, viewService],
   );
 
   const expandLeft = useCallback<ExpandOrCollapser>(
     async (rowIndex: number, colIndex: number) => {
       await genericObjectModel?.expandLeft(Q_PATH, rowIndex, colIndex, false);
+      viewService.lastExpandedOrCollapsed = {
+        grid: "left",
+        rowIndex,
+        colIndex,
+      };
     },
-    [genericObjectModel],
+    [genericObjectModel, viewService],
   );
 
   const expandTop = useCallback<ExpandOrCollapser>(
     async (rowIndex: number, colIndex: number) => {
       await genericObjectModel?.expandTop(Q_PATH, rowIndex, colIndex, false);
+      viewService.lastExpandedOrCollapsed = {
+        grid: "top",
+        rowIndex,
+        colIndex,
+      };
     },
-    [genericObjectModel],
+    [genericObjectModel, viewService],
   );
 
   const fetchPages = useCallback<FetchPages>(
@@ -62,6 +85,7 @@ export default function useDataModel({
       if (!genericObjectModel?.getHyperCubePivotData || pages.length === 0) return;
 
       try {
+        console.log("%c fetchPages", "color: orangered", pages);
         const pivotPages = await genericObjectModel.getHyperCubePivotData(
           Q_PATH,
           pages.reduce<EngineAPI.INxPage[]>(

--- a/src/pivot-table/hooks/use-data-model.ts
+++ b/src/pivot-table/hooks/use-data-model.ts
@@ -9,7 +9,6 @@ import {
   type FetchPages,
   type LayoutService,
   type PageInfo,
-  type ViewService,
 } from "../../types/types";
 import handleMaxEnginePageSize from "../../utils/handle-max-engine-size";
 import useMutableProp from "./use-mutable-prop";
@@ -19,7 +18,6 @@ export interface UseDataModelProps {
   nextPageHandler: (pages: EngineAPI.INxPivotPage[]) => void;
   pageInfo: PageInfo;
   layoutService: LayoutService;
-  viewService: ViewService;
 }
 
 export default function useDataModel({
@@ -27,7 +25,6 @@ export default function useDataModel({
   nextPageHandler,
   pageInfo,
   layoutService,
-  viewService,
 }: UseDataModelProps): DataModel {
   const currentPage = useMutableProp(pageInfo.page);
   const genericObjectModel = model as EngineAPI.IGenericObject | undefined;
@@ -35,49 +32,29 @@ export default function useDataModel({
   const collapseLeft = useCallback<ExpandOrCollapser>(
     async (rowIndex: number, colIndex: number) => {
       await genericObjectModel?.collapseLeft?.(Q_PATH, rowIndex, colIndex, false);
-      viewService.lastExpandedOrCollapsed = {
-        grid: "left",
-        rowIndex,
-        colIndex,
-      };
     },
-    [genericObjectModel, viewService],
+    [genericObjectModel],
   );
 
   const collapseTop = useCallback<ExpandOrCollapser>(
     async (rowIndex: number, colIndex: number) => {
       await genericObjectModel?.collapseTop(Q_PATH, rowIndex, colIndex, false);
-      viewService.lastExpandedOrCollapsed = {
-        grid: "top",
-        rowIndex,
-        colIndex,
-      };
     },
-    [genericObjectModel, viewService],
+    [genericObjectModel],
   );
 
   const expandLeft = useCallback<ExpandOrCollapser>(
     async (rowIndex: number, colIndex: number) => {
       await genericObjectModel?.expandLeft(Q_PATH, rowIndex, colIndex, false);
-      viewService.lastExpandedOrCollapsed = {
-        grid: "left",
-        rowIndex,
-        colIndex,
-      };
     },
-    [genericObjectModel, viewService],
+    [genericObjectModel],
   );
 
   const expandTop = useCallback<ExpandOrCollapser>(
     async (rowIndex: number, colIndex: number) => {
       await genericObjectModel?.expandTop(Q_PATH, rowIndex, colIndex, false);
-      viewService.lastExpandedOrCollapsed = {
-        grid: "top",
-        rowIndex,
-        colIndex,
-      };
     },
-    [genericObjectModel, viewService],
+    [genericObjectModel],
   );
 
   const fetchPages = useCallback<FetchPages>(
@@ -85,7 +62,6 @@ export default function useDataModel({
       if (!genericObjectModel?.getHyperCubePivotData || pages.length === 0) return;
 
       try {
-        console.log("%c fetchPages", "color: orangered", pages);
         const pivotPages = await genericObjectModel.getHyperCubePivotData(
           Q_PATH,
           pages.reduce<EngineAPI.INxPage[]>(

--- a/src/pivot-table/hooks/use-scroll.ts
+++ b/src/pivot-table/hooks/use-scroll.ts
@@ -58,7 +58,7 @@ const useScroll = ({ layoutService, pageInfo, tableRect, mockedRefs }: Props) =>
   // If the layout change reset the scroll position, except if the layout
   // change because a node was expanded or collapsed
   useLayoutEffect(() => {
-    if (!layoutService.layout.qHyperCube.qLastExpandedPos) {
+    if (!layoutService.triggerdByExpandOrCollapse) {
       if (leftGridHorizontalScrollableContainerRef.current) {
         leftGridHorizontalScrollableContainerRef.current.scrollLeft = 0;
       }
@@ -76,7 +76,7 @@ const useScroll = ({ layoutService, pageInfo, tableRect, mockedRefs }: Props) =>
   // Call scrollTo here so that when a cell is expanded or collapsed, scroll to the last known position.
   // Otherwise it will be out-of-sync with the data grid.
   useLayoutEffect(() => {
-    if (layoutService.layout.qHyperCube.qLastExpandedPos) {
+    if (layoutService.triggerdByExpandOrCollapse) {
       const scrollLeft = dataGridHorizontalScrollableContainerRef.current?.scrollLeft ?? 0;
       const scrollTop = verticalScrollableContainerRef.current?.scrollTop ?? 0;
 

--- a/src/services/layout-service.ts
+++ b/src/services/layout-service.ts
@@ -50,6 +50,8 @@ const createLayoutService = (
     leftDimensionInfoIndexes,
     isLeftDimension,
     isFullyExpanded: !!effectiveProperties?.qHyperCubeDef?.qAlwaysFullyExpanded,
+    // qLastExpandedPos only exist in the layout if a new layout was received because a node was expanded or collapsed
+    triggerdByExpandOrCollapse: !!layout.qHyperCube.qLastExpandedPos,
   };
 };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -178,6 +178,11 @@ export interface ViewService {
   gridRowStartIndex: number;
   gridWidth: number;
   gridHeight: number;
+  lastExpandedOrCollapsed: {
+    grid: "top" | "left";
+    rowIndex: number;
+    colIndex: number;
+  };
 }
 
 export interface LayoutService {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -178,11 +178,6 @@ export interface ViewService {
   gridRowStartIndex: number;
   gridWidth: number;
   gridHeight: number;
-  lastExpandedOrCollapsed: {
-    grid: "top" | "left";
-    rowIndex: number;
-    colIndex: number;
-  };
 }
 
 export interface LayoutService {
@@ -201,6 +196,7 @@ export interface LayoutService {
   leftDimensionInfoIndexes: number[];
   isLeftDimension: (dimensionInfoIndex: number) => boolean;
   isFullyExpanded: boolean;
+  triggerdByExpandOrCollapse: boolean;
 }
 
 export interface DataService {


### PR DESCRIPTION
Fixes an issue where expanding or collapsing a cell could result in too few rows or columns being fetched and empty cells being rendered.