### PR TITLE
fix: set border explicitly for each side

### DIFF
--- a/src/pivot-table/components/__tests__/shared-styles.test.ts
+++ b/src/pivot-table/components/__tests__/shared-styles.test.ts
@@ -1,46 +1,40 @@
 import type { HeaderCell, ShowLastBorder } from "../../../types/types";
-import { borderStyle, getBorderStyle, getHeaderBorderStyle } from "../shared-styles";
+import { BorderStyle, getBorderStyle, getHeaderBorderStyle } from "../shared-styles";
 
 describe("Shared styles", () => {
-  const borderColor = "red";
   let showLastBorder: ShowLastBorder;
+
+  const borderColor = "red";
+  const singleBorder = `1px ${BorderStyle.Solid} ${borderColor}`;
+  const noBorders = {
+    borderRight: BorderStyle.None,
+    borderBottom: BorderStyle.None,
+    borderLeft: BorderStyle.None,
+    borderTop: BorderStyle.None,
+  };
+
+  const borderRight = {
+    ...noBorders,
+    borderRight: singleBorder,
+  };
+  const borderBottom = {
+    ...noBorders,
+    borderBottom: singleBorder,
+  };
+  const borderRightBottom = {
+    ...noBorders,
+    borderRight: singleBorder,
+    borderBottom: singleBorder,
+  };
 
   beforeEach(() => {
     showLastBorder = { right: false, bottom: false };
   });
 
-  const baseStyle = {
-    ...borderStyle,
-    borderWidth: 0,
-    borderRightColor: undefined,
-    borderBottomColor: undefined,
-  };
-
   describe("getBorderStyle", () => {
-    const noBorder = { ...baseStyle, borderRightWidth: 0, borderBottomWidth: 0 };
-    const borderRight = {
-      ...baseStyle,
-      borderRightWidth: 1,
-      borderBottomWidth: 0,
-      borderRightColor: borderColor,
-    };
-    const borderBottom = {
-      ...baseStyle,
-      borderRightWidth: 0,
-      borderBottomWidth: 1,
-      borderBottomColor: borderColor,
-    };
-    const borderRightBottom = {
-      ...baseStyle,
-      borderRightWidth: 1,
-      borderBottomWidth: 1,
-      borderRightColor: borderColor,
-      borderBottomColor: borderColor,
-    };
-
     // last row and bottom
     test("should resolve style for last row and last column", () => {
-      expect(getBorderStyle(true, true, borderColor, showLastBorder)).toEqual(noBorder);
+      expect(getBorderStyle(true, true, borderColor, showLastBorder)).toEqual(noBorders);
     });
 
     test("should resolve style for last row and last column while `showLastBorder.right` is true", () => {
@@ -87,59 +81,29 @@ describe("Shared styles", () => {
   describe("getHeaderBorderStyle", () => {
     let cell: HeaderCell;
 
+    const doubleBorder = `2px ${BorderStyle.Solid} ${borderColor}`;
+
     const borderLeft = {
-      ...baseStyle,
-      borderBottomWidth: 0,
-      borderLeftWidth: 1,
-      borderLeftColor: borderColor,
-      borderRightWidth: 0,
-      borderRightColor: undefined,
+      ...noBorders,
+      borderLeft: singleBorder,
     };
 
     const borderLeftBottom = {
-      ...baseStyle,
-      borderLeftWidth: 1,
-      borderLeftColor: borderColor,
-      borderRightWidth: 0,
-      borderRightColor: undefined,
-      borderBottomWidth: 1,
-      borderBottomColor: borderColor,
+      ...noBorders,
+      borderLeft: singleBorder,
+      borderBottom: singleBorder,
     };
 
     const borderLeftDoubleBottom = {
-      ...baseStyle,
-      borderLeftWidth: 1,
-      borderLeftColor: borderColor,
-      borderRightWidth: 0,
-      borderRightColor: undefined,
-      borderBottomWidth: 2,
-      borderBottomColor: borderColor,
-    };
-
-    const borderRight = {
-      ...baseStyle,
-      borderLeftWidth: 0,
-      borderRightWidth: 1,
-      borderRightColor: borderColor,
-      borderBottomWidth: 0,
-    };
-
-    const borderRightBottom = {
-      ...baseStyle,
-      borderLeftWidth: 0,
-      borderRightWidth: 1,
-      borderRightColor: borderColor,
-      borderBottomWidth: 1,
-      borderBottomColor: borderColor,
+      ...noBorders,
+      borderLeft: singleBorder,
+      borderBottom: doubleBorder,
     };
 
     const borderRightDoubleBottom = {
-      ...baseStyle,
-      borderLeftWidth: 0,
-      borderRightWidth: 1,
-      borderRightColor: borderColor,
-      borderBottomWidth: 2,
-      borderBottomColor: borderColor,
+      ...noBorders,
+      borderRight: singleBorder,
+      borderBottom: doubleBorder,
     };
 
     beforeEach(() => {

--- a/src/pivot-table/components/__tests__/shared-styles.test.ts
+++ b/src/pivot-table/components/__tests__/shared-styles.test.ts
@@ -5,7 +5,9 @@ describe("Shared styles", () => {
   let showLastBorder: ShowLastBorder;
 
   const borderColor = "red";
+
   const singleBorder = `1px ${BorderStyle.Solid} ${borderColor}`;
+
   const noBorders = {
     borderRight: BorderStyle.None,
     borderBottom: BorderStyle.None,

--- a/src/pivot-table/components/shared-styles.ts
+++ b/src/pivot-table/components/shared-styles.ts
@@ -12,6 +12,11 @@ export enum Colors {
   Transparent = "transparent",
 }
 
+export enum BorderStyle {
+  Solid = "solid",
+  None = "none",
+}
+
 export const CELL_PADDING = 4;
 
 export const DOUBLE_CELL_PADDING = CELL_PADDING * 2;
@@ -51,26 +56,23 @@ export const getLineClampStyle = (clampCount: number): React.CSSProperties => ({
   wordBreak: "break-all",
 });
 
+const getBorderAttributes = (width: number, color: string) =>
+  width > 0 ? `${width}px ${BorderStyle.Solid} ${color}` : BorderStyle.None;
+
 export const getBorderStyle = (
   isLastRow: boolean,
   isLastColumn: boolean,
   borderColor: string,
   showLastBorder?: ShowLastBorder,
 ): React.CSSProperties => {
-  const showRightBorder = !isLastColumn || showLastBorder?.right;
-  const showBottomBorder = !isLastRow || showLastBorder?.bottom;
-  const borderRightWidth = showRightBorder ? 1 : 0;
-  const borderRightColor = showRightBorder ? borderColor : undefined;
-  const borderBottomWidth = showBottomBorder ? 1 : 0;
-  const borderBottomColor = showBottomBorder ? borderColor : undefined;
+  const borderRightWidth = Number(!isLastColumn || showLastBorder?.right);
+  const borderBottomWidth = Number(!isLastRow || showLastBorder?.bottom);
 
   return {
-    ...borderStyle,
-    borderRightColor,
-    borderBottomColor,
-    borderWidth: 0,
-    borderRightWidth,
-    borderBottomWidth,
+    borderRight: getBorderAttributes(borderRightWidth, borderColor),
+    borderBottom: getBorderAttributes(borderBottomWidth, borderColor),
+    borderLeft: BorderStyle.None,
+    borderTop: BorderStyle.None,
   };
 };
 
@@ -86,15 +88,11 @@ export const getHeaderBorderStyle = (
 
   if (!cell.isLeftDimension) {
     if (cell.isLastDimension && !isLastRow) {
-      headerBorderStyle.borderBottomWidth = 2;
-      headerBorderStyle.borderBottomColor = borderColor;
+      headerBorderStyle.borderBottom = getBorderAttributes(2, borderColor);
     }
 
     if (!isFirstColumn) {
-      headerBorderStyle.borderLeftWidth = 1;
-      headerBorderStyle.borderLeftColor = borderColor;
-    } else {
-      headerBorderStyle.borderLeftWidth = 0;
+      headerBorderStyle.borderLeft = getBorderAttributes(1, borderColor);
     }
   }
 


### PR DESCRIPTION
Before border settings `width` and `color` was explicitly set for each side (eg. `borderLeftWidth: 1`) and then `borderStyle: solid` for all sides. Now we set `borderLeft/Right/Top/Bottom` with width, style and color. if there is no border it is just `"none"`