### PR TITLE
fix: transparent color in color picker

### DIFF
--- a/src/ext/property-panel/settings/styling-panel/utils/__tests__/create-color-picker-item.test.ts
+++ b/src/ext/property-panel/settings/styling-panel/utils/__tests__/create-color-picker-item.test.ts
@@ -1,0 +1,23 @@
+import { Colors } from "../../../../../../pivot-table/components/shared-styles";
+import type { Args } from "../../../../../../types/QIX";
+import createColorPickerItem from "../create-color-picker-item";
+
+describe("createColorPickerItem", () => {
+  const args = {
+    theme: {
+      current: () => {},
+    },
+  } as Args;
+
+  test("should resolve default value from theme", () => {
+    const def = createColorPickerItem("ref", "translation", () => "red");
+
+    expect(def.defaultValue(null, null, args)).toEqual({ color: "red" });
+  });
+
+  test("should resolve default value from theme for transparent color", () => {
+    const def = createColorPickerItem("ref", "translation", () => Colors.Transparent);
+
+    expect(def.defaultValue(null, null, args)).toEqual({ color: "none" });
+  });
+});

--- a/src/ext/property-panel/settings/styling-panel/utils/create-color-picker-item.ts
+++ b/src/ext/property-panel/settings/styling-panel/utils/create-color-picker-item.ts
@@ -1,3 +1,4 @@
+import { Colors } from "../../../../../pivot-table/components/shared-styles";
 import type { Args, CurrentTheme } from "../../../../../types/QIX";
 
 const createColorPickerItem = (
@@ -11,9 +12,12 @@ const createColorPickerItem = (
   type: "object",
   component: "color-picker",
   width: "auto",
+  disableNone: false,
   defaultValue(data: unknown, handler: unknown, args: Args) {
     const currentTheme = args.theme.current();
-    return { color: themeAccessor(currentTheme) };
+    const color = themeAccessor(currentTheme);
+
+    return { color: color === Colors.Transparent.toString() ? "none" : color };
   },
 });
 


### PR DESCRIPTION
The color picker in Sense does not support `transparent` color value. To get around that we can use `none` instead, which can be shown as a selected value in the color picker.

After:

![Skärmavbild 2023-12-04 kl  14 22 35](https://github.com/qlik-oss/sn-pivot-table/assets/16608020/7d0eb02d-0dd5-40f2-813e-6e2326fe7d22)
