### PR TITLE
fix: font family dropdown

### DIFF
--- a/src/ext/property-panel/__tests__/data.test.ts
+++ b/src/ext/property-panel/__tests__/data.test.ts
@@ -12,6 +12,7 @@ describe("data", () => {
     data = createData({
       translator,
       anything: { sense: { isUnsupportedFeature: () => false } },
+      flags: { isEnabled: () => true },
     });
   });
 
@@ -83,6 +84,7 @@ describe("data", () => {
         data = createData({
           translator,
           anything: { sense: { isUnsupportedFeature: (f) => f === "totals" } },
+          flags: { isEnabled: () => true },
         });
         expect(data.items.dimensions.items.totalMode.show).toBe(false);
         expect(data.items.dimensions.items.totalsLabel.show(itemData, null, args)).toBe(false);

--- a/src/ext/property-panel/index.ts
+++ b/src/ext/property-panel/index.ts
@@ -11,7 +11,7 @@ interface PropertyPanelDefinition {
 }
 
 export default function create(env: Galaxy): PropertyPanelDefinition {
-  const { translator } = env;
+  const { translator, flags } = env;
 
   return {
     type: "items",
@@ -20,7 +20,7 @@ export default function create(env: Galaxy): PropertyPanelDefinition {
       data: createData(env),
       sorting,
       addons,
-      settings: settings(translator),
+      settings: settings(translator, flags),
     },
   };
 }

--- a/src/ext/property-panel/settings/index.ts
+++ b/src/ext/property-panel/settings/index.ts
@@ -1,4 +1,5 @@
 import type { stardust } from "@nebula.js/stardust";
+import type { Flags } from "../../../types/types";
 import getStylingPanelConfig from "./styling-panel";
 
 interface ExtendedVisualizationHyperCubeDef extends EngineAPI.IVisualizationHyperCubeDef {
@@ -52,14 +53,14 @@ export const getRowStylesConfig = () => ({
   },
 });
 
-const settings = (translator: stardust.Translator) => ({
+const settings = (translator: stardust.Translator, flags: Flags) => ({
   uses: "settings",
   items: {
     presentation: {
       type: "items",
       translation: "properties.presentation",
       grouped: true,
-      items: [getStylingPanelConfig(translator), getRowStylesConfig()],
+      items: [getStylingPanelConfig(translator, flags), getRowStylesConfig()],
     },
   },
 });

--- a/src/ext/property-panel/settings/styling-panel/index.ts
+++ b/src/ext/property-panel/settings/styling-panel/index.ts
@@ -1,10 +1,11 @@
 import type { stardust } from "@nebula.js/stardust";
 import { Colors } from "../../../../pivot-table/components/shared-styles";
+import type { Flags } from "../../../../types/types";
 import gridSection from "./grid";
 import largePanelSection from "./large-panal-section";
 import smallPanelSection from "./small-panel-section";
 
-const getStylingPanelConfig = (translator: stardust.Translator) => ({
+const getStylingPanelConfig = (translator: stardust.Translator, flags: Flags) => ({
   type: "items",
   items: [
     {
@@ -16,14 +17,16 @@ const getStylingPanelConfig = (translator: stardust.Translator) => ({
       useGeneral: true,
       defaultValue: [],
       items: {
-        headerSection: largePanelSection({ section: "header", defaultFontStyle: ["bold"], translator }),
+        headerSection: largePanelSection({ section: "header", defaultFontStyle: ["bold"], translator, flags }),
         dimensionValueSection: largePanelSection({
           section: "dimensionValues",
           translator,
+          flags,
         }),
         measureValueSection: largePanelSection({
           section: "measureValues",
           translator,
+          flags,
         }),
         measureLabelSection: smallPanelSection({ section: "measureLabels" }),
         totalValuesSection: smallPanelSection({ section: "totalValues", defaultFontStyle: ["bold"] }),

--- a/src/ext/property-panel/settings/styling-panel/large-panal-section.ts
+++ b/src/ext/property-panel/settings/styling-panel/large-panal-section.ts
@@ -1,5 +1,6 @@
 import type { stardust } from "@nebula.js/stardust";
 import { Colors } from "../../../../pivot-table/components/shared-styles";
+import type { Flags } from "../../../../types/types";
 import createColorPickerItem from "./utils/create-color-picker-item";
 import createFontFamilyItem from "./utils/create-font-family-item";
 import createFontSizeItem from "./utils/create-font-size-item";
@@ -11,9 +12,10 @@ interface Props {
   section: LargeSection;
   defaultFontStyle?: string[];
   translator: stardust.Translator;
+  flags: Flags;
 }
 
-const largePanelSection = ({ section, defaultFontStyle, translator }: Props) => ({
+const largePanelSection = ({ section, defaultFontStyle, translator, flags }: Props) => ({
   component: "panel-section",
   translation: `properties.pivot.${section}`,
   items: {
@@ -27,6 +29,7 @@ const largePanelSection = ({ section, defaultFontStyle, translator }: Props) => 
           themeAccessor: (currentTheme) =>
             getThemeValue(currentTheme, section, "fontFamily") ?? currentTheme.fontFamily,
           translator,
+          flags,
         }),
         fontWrapperItem: {
           component: "inline-wrapper",

--- a/src/ext/property-panel/settings/styling-panel/utils/__tests__/create-font-family-items.test.ts
+++ b/src/ext/property-panel/settings/styling-panel/utils/__tests__/create-font-family-items.test.ts
@@ -1,7 +1,11 @@
 import type { stardust } from "@nebula.js/stardust";
+import * as qlikChartModules from "qlik-chart-modules";
 import { DEFAULT_FONT_FAMILY } from "../../../../../../pivot-table/constants";
 import type { Args, CurrentTheme } from "../../../../../../types/QIX";
-import createFontFamilyItem, { DEFAULT_FONT_FAMILIES, type ThemeAccessor } from "../create-font-family-item";
+import type { Flags } from "../../../../../../types/types";
+import createFontFamilyItem, { type ThemeAccessor } from "../create-font-family-item";
+
+jest.mock("qlik-chart-modules");
 
 describe("createFontFamilyItem", () => {
   const translator = { get: (str: string) => str } as stardust.Translator;
@@ -9,6 +13,8 @@ describe("createFontFamilyItem", () => {
   let themeAccessor: ThemeAccessor;
   const fontFamily = "Test family";
   const themeAccessorFontFamily = "Theme family";
+  const defaultSharedFont = "Default shared font";
+  const flags: Flags = { isEnabled: () => true };
   let fontFamilies: string[] | undefined = ["Test families"];
 
   beforeEach(() => {
@@ -22,6 +28,12 @@ describe("createFontFamilyItem", () => {
           }) as CurrentTheme,
       },
     };
+
+    jest.spyOn(qlikChartModules, "getAvailableFonts").mockImplementation(() => [defaultSharedFont]);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   test("should include font family from default fonts", () => {
@@ -29,6 +41,7 @@ describe("createFontFamilyItem", () => {
       ref: "someRef",
       themeAccessor,
       translator,
+      flags,
     });
 
     expect(def.ref).toEqual("someRef");
@@ -45,18 +58,21 @@ describe("createFontFamilyItem", () => {
         label: "Test families",
         groupHeader: false,
         disabled: false,
+        styles: { fontFamily: "Test families" },
       },
       {
         value: "Test family",
         label: "Test family",
         groupHeader: false,
         disabled: false,
+        styles: { fontFamily: "Test family" },
       },
       {
         value: "Theme family",
         label: "Theme family",
         groupHeader: false,
         disabled: false,
+        styles: { fontFamily: "Theme family" },
       },
       {
         value: "DefaultHeader",
@@ -65,130 +81,11 @@ describe("createFontFamilyItem", () => {
         groupHeader: true,
       },
       {
-        value: "American Typewriter, serif",
-        label: "American Typewriter, serif",
+        value: defaultSharedFont,
+        label: defaultSharedFont,
         groupHeader: false,
         disabled: false,
-      },
-      {
-        value: "Andalé Mono, monospace",
-        label: "Andalé Mono, monospace",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Arial Black, sans-serif",
-        label: "Arial Black, sans-serif",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Arial, sans-serif",
-        label: "Arial, sans-serif",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Bradley Hand, cursive",
-        label: "Bradley Hand, cursive",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Brush Script MT, cursive",
-        label: "Brush Script MT, cursive",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Comic Sans MS, cursive",
-        label: "Comic Sans MS, cursive",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Courier, monospace",
-        label: "Courier, monospace",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Didot, serif",
-        label: "Didot, serif",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Georgia, serif",
-        label: "Georgia, serif",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Impact, sans-serif",
-        label: "Impact, sans-serif",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Lucida Console, monospace",
-        label: "Lucida Console, monospace",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Luminari, fantasy",
-        label: "Luminari, fantasy",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Monaco, monospace",
-        label: "Monaco, monospace",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "QlikView Sans, sans-serif",
-        label: "QlikView Sans, sans-serif",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Source Sans Pro, Arial, sans-serif",
-        label: "Source Sans Pro, Arial, sans-serif",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Source Sans Pro, sans-serif",
-        label: "Source Sans Pro, sans-serif",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Tahoma, sans-serif",
-        label: "Tahoma, sans-serif",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Times New Roman, serif",
-        label: "Times New Roman, serif",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Trebuchet MS, sans-serif",
-        label: "Trebuchet MS, sans-serif",
-        groupHeader: false,
-        disabled: false,
-      },
-      {
-        value: "Verdana, sans-serif",
-        label: "Verdana, sans-serif",
-        groupHeader: false,
-        disabled: false,
+        styles: { fontFamily: defaultSharedFont },
       },
     ]);
   });
@@ -201,6 +98,7 @@ describe("createFontFamilyItem", () => {
       ref: "someRef",
       themeAccessor,
       translator,
+      flags,
     });
 
     expect(def.defaultValue(null, null, args)).toEqual(fontFamily);
@@ -210,6 +108,9 @@ describe("createFontFamilyItem", () => {
         label: fontFamily,
         groupHeader: false,
         disabled: false,
+        styles: {
+          fontFamily,
+        },
       },
     ]);
   });
@@ -221,6 +122,7 @@ describe("createFontFamilyItem", () => {
       ref: "someRef",
       themeAccessor,
       translator,
+      flags,
     });
 
     expect(def.options(null, null, args).filter((f) => f.value === DEFAULT_FONT_FAMILY)).toEqual([
@@ -229,17 +131,21 @@ describe("createFontFamilyItem", () => {
         label: DEFAULT_FONT_FAMILY,
         groupHeader: false,
         disabled: false,
+        styles: {
+          fontFamily: "Source Sans Pro, sans-serif",
+        },
       },
     ]);
   });
 
   test("should remove Default section if there are no unique font families", () => {
-    fontFamilies = DEFAULT_FONT_FAMILIES;
+    fontFamilies = qlikChartModules.getAvailableFonts(flags);
 
     const def = createFontFamilyItem({
       ref: "someRef",
       themeAccessor,
       translator,
+      flags,
     });
 
     const options = def.options(null, null, args);
@@ -261,6 +167,7 @@ describe("createFontFamilyItem", () => {
       ref: "someRef",
       themeAccessor,
       translator,
+      flags,
     });
 
     expect(def.defaultValue(null, null, args)).toEqual(themeAccessorFontFamily);
@@ -272,12 +179,14 @@ describe("createFontFamilyItem", () => {
         label: fontFamily,
         groupHeader: false,
         disabled: false,
+        styles: { fontFamily },
       },
       {
         value: themeAccessorFontFamily,
         label: themeAccessorFontFamily,
         groupHeader: false,
         disabled: false,
+        styles: { fontFamily: themeAccessorFontFamily },
       },
     ]);
   });

--- a/src/ext/property-panel/settings/styling-panel/utils/create-font-family-item.ts
+++ b/src/ext/property-panel/settings/styling-panel/utils/create-font-family-item.ts
@@ -1,6 +1,8 @@
 import type { stardust } from "@nebula.js/stardust";
+import { getAvailableFonts } from "qlik-chart-modules";
 import { DEFAULT_FONT_FAMILY } from "../../../../../pivot-table/constants";
 import type { Args, CurrentTheme } from "../../../../../types/QIX";
+import type { Flags } from "../../../../../types/types";
 import { toValueLabel } from "./to-value-label";
 
 export type ThemeAccessor = (currentTheme: CurrentTheme) => string;
@@ -9,34 +11,16 @@ interface Props {
   ref: string;
   themeAccessor: ThemeAccessor;
   translator: stardust.Translator;
+  flags: Flags;
 }
 
-export const DEFAULT_FONT_FAMILIES: string[] = [
-  "American Typewriter, serif",
-  "Andalé Mono, monospace",
-  "Arial Black, sans-serif",
-  "Arial, sans-serif",
-  "Bradley Hand, cursive",
-  "Brush Script MT, cursive",
-  "Comic Sans MS, cursive",
-  "Courier, monospace",
-  "Didot, serif",
-  "Georgia, serif",
-  "Impact, sans-serif",
-  "Lucida Console, monospace",
-  "Luminari, fantasy",
-  "Monaco, monospace",
-  "QlikView Sans, sans-serif",
-  DEFAULT_FONT_FAMILY,
-  "Source Sans Pro, sans-serif",
-  "Tahoma, sans-serif",
-  "Times New Roman, serif",
-  "Trebuchet MS, sans-serif",
-  "Verdana, sans-serif",
-];
-
-const getFontFamilies = (currentValue: string, currentTheme: CurrentTheme, translator: stardust.Translator) => {
-  const defaultThemeFontFamily = currentTheme.fontFamily;
+const getFontFamilies = (
+  currentValue: string,
+  currentTheme: CurrentTheme,
+  translator: stardust.Translator,
+  flags: Flags,
+) => {
+  const defaultThemeFontFamily = currentTheme.fontFamily ?? DEFAULT_FONT_FAMILY;
   const customFontFamilies = currentTheme.fontFamilies ?? [];
   const themeFontFamilies = Array.from(new Set([currentValue, defaultThemeFontFamily, ...customFontFamilies]));
 
@@ -56,21 +40,21 @@ const getFontFamilies = (currentValue: string, currentTheme: CurrentTheme, trans
       metaText: translator.get("properties.default"),
       groupHeader: true,
     },
-    ...DEFAULT_FONT_FAMILIES.filter((fontFamily) => !themeFontFamilies.includes(fontFamily)).map((fontFamily) =>
-      toValueLabel(fontFamily, true),
-    ),
+    ...getAvailableFonts(flags)
+      .filter((fontFamily) => !themeFontFamilies.includes(fontFamily))
+      .map((fontFamily) => toValueLabel(fontFamily, true)),
   ];
 
   return [...themeSection, ...(allFontsSection.length > 1 ? allFontsSection : [])];
 };
 
-const createFontFamilyItem = ({ ref, themeAccessor, translator }: Props) => ({
+const createFontFamilyItem = ({ ref, themeAccessor, translator, flags }: Props) => ({
   component: "dropdown",
   ref,
   options: (data: unknown, handler: unknown, args: Args) => {
     const currentTheme = args.theme.current();
     const currentValue = themeAccessor(currentTheme);
-    return getFontFamilies(currentValue, currentTheme, translator);
+    return getFontFamilies(currentValue, currentTheme, translator, flags);
   },
   defaultValue: (data: unknown, handler: unknown, args: Args) => themeAccessor(args.theme.current()),
 });

--- a/src/ext/property-panel/settings/styling-panel/utils/to-value-label.ts
+++ b/src/ext/property-panel/settings/styling-panel/utils/to-value-label.ts
@@ -5,4 +5,5 @@ export const toValueLabel = (value: string, isFontFamily = false) => ({
   label: isFontFamily ? makeFirstLetterUpperCase(value) : value,
   groupHeader: false,
   disabled: false,
+  styles: isFontFamily ? { fontFamily: value } : undefined,
 });

--- a/src/pivot-table/constants.ts
+++ b/src/pivot-table/constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_FONT_SIZE = "12px";
-export const DEFAULT_FONT_FAMILY = "Source Sans Pro, Arial, sans-serif";
+export const DEFAULT_FONT_FAMILY = "Source Sans Pro, sans-serif";
 export const DEFAULT_CELL_HEIGHT = 24;
 export const DEFAULT_HEADER_CELL_HEIGHT = 32;
 export const DEFAULT_LINE_CLAMP = 1;

--- a/src/types/qlik-chart-models.d.ts
+++ b/src/types/qlik-chart-models.d.ts
@@ -3,9 +3,11 @@ declare module "qlik-chart-modules" {
   type Memoize = <T>(callback: T) => T;
   type Debouncer = <T>(callback: T, timeout?: number) => T;
   type Throttler = <T>(callback: T, timeout?: number) => T;
+  type GetAvailableFonts = (flags: { isEnabled: (flag: string) => boolean }) => string[];
 
   export const setValue: SetValue;
   export const memoize: Memoize;
   export const debouncer: Debouncer;
   export const throttler: Throttler;
+  export const getAvailableFonts: GetAvailableFonts;
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -208,6 +208,8 @@ export interface DataService {
   size: PivotDataSize;
 }
 
+export type Flags = { isEnabled: (flag: string) => boolean };
+
 export interface Galaxy {
   translator: stardust.Translator;
   anything: {
@@ -215,6 +217,7 @@ export interface Galaxy {
       isUnsupportedFeature: (f: string) => boolean;
     };
   };
+  flags: Flags;
 }
 
 export interface PageInfo {


### PR DESCRIPTION
The dropdown for font family did not match the general styling drop down. This PR fixes:
- Get default fonts from the same source as the general styling drop down (`getAvailableFonts`).
- Apply the font family on the actual item on the drop down to get a preview of it.

Before:
![Skärmavbild 2023-12-05 kl  10 51 49](https://github.com/qlik-oss/sn-pivot-table/assets/16608020/61aa7e11-82fd-47e4-8bac-ef2eb2d8d7c2)

After:
![Skärmavbild 2023-12-05 kl  10 50 24](https://github.com/qlik-oss/sn-pivot-table/assets/16608020/c5d3cb65-24a4-4bc6-8b89-314692979c0e)
