### PR TITLE
fix: none color

### DIFF
--- a/src/services/__tests__/style-service.test.ts
+++ b/src/services/__tests__/style-service.test.ts
@@ -3,7 +3,7 @@ import { Colors } from "../../pivot-table/components/shared-styles";
 import { DEFAULT_FONT_FAMILY } from "../../pivot-table/constants";
 import type { Component, PaletteColor } from "../../types/QIX";
 import type { LayoutService, StyleService } from "../../types/types";
-import createStyleService from "../style-service";
+import createStyleService, { resolveColor } from "../style-service";
 
 describe("style-service", () => {
   let themeValue: string | undefined = "18px"; // Choosing a value that works for the cellHeight calculation
@@ -25,7 +25,7 @@ describe("style-service", () => {
       getStyle: (basePath: string, path: string, attribute: string) =>
         attribute === "lineClamp" && themeValue !== undefined ? lineClamp : themeValue,
       getColorPickerColor: (paletteColor: PaletteColor) =>
-        paletteColor.index && paletteColor.index > -1 ? colorFromPalette : color,
+        paletteColor.index !== undefined && paletteColor.index > -1 ? colorFromPalette : color,
     } as unknown as ExtendedTheme;
     layoutServiceMock = {
       layout: {
@@ -79,6 +79,17 @@ describe("style-service", () => {
         ],
       },
     } as unknown as LayoutService;
+  });
+
+  describe("resolveColor", () => {
+    test("should resolve `none` color from palette", () => {
+      themeMock = {
+        getColorPickerColor: (paletteColor: PaletteColor) =>
+          paletteColor.index !== undefined && paletteColor.index > -1 ? paletteColor.color : undefined,
+      } as unknown as ExtendedTheme;
+
+      expect(resolveColor(themeMock, { index: 0, color: "none" })).toEqual(Colors.Transparent);
+    });
   });
 
   test("should resolve style from layout", () => {

--- a/src/services/style-service.ts
+++ b/src/services/style-service.ts
@@ -66,8 +66,19 @@ enum ThemeAttribute {
 
 const resolveFontSize = (fontSize: string | undefined) => (fontSize ? `${parseInt(fontSize, 10)}px` : undefined);
 
-const resolveColor = (theme: ExtendedTheme, color: PaletteColor | undefined) =>
-  color ? theme.getColorPickerColor(color) : undefined;
+export const resolveColor = (theme: ExtendedTheme, color: PaletteColor | undefined) => {
+  if (color) {
+    const resolvedColor = theme.getColorPickerColor(color);
+    // Handle when color is set to "none" via the color picker
+    if (resolvedColor === "none") {
+      return Colors.Transparent;
+    }
+
+    return resolvedColor;
+  }
+
+  return undefined;
+};
 
 const fontSizeToCellHeight = (fontSize: string, lineClamp: number) =>
   +(parseInt(fontSize, 10) * LINE_HEIGHT_COEFFICIENT * lineClamp + CELL_PADDING_HEIGHT).toFixed(2);


### PR DESCRIPTION
Fixes an issue where setting the color for "border" and "divider" via the Styling panel to "none", would cause the borders to render with `currentcolor` producing some unexpected results.

Background color and font color appears to be working with `none` as color but this PR fixes those scenarios as well. As `none` is not a valid css color value.

Before:


https://github.com/qlik-oss/sn-pivot-table/assets/16608020/246a71e9-c01f-4a65-a017-d0671c19fe6c



After:

https://github.com/qlik-oss/sn-pivot-table/assets/16608020/c8260424-43c8-4153-b4f7-9fb64d24746a

