### PR TITLE
fix: random bottom color

### DIFF
--- a/src/pivot-table/components/shared-styles.ts
+++ b/src/pivot-table/components/shared-styles.ts
@@ -111,11 +111,11 @@ export const getTotalCellDividerStyle = ({
   const style: React.CSSProperties = {};
 
   if (bottomDivider) {
-    style.borderBottomColor = borderColor;
+    style.borderBottom = getBorderAttributes(1, borderColor);
   }
 
   if (rightDivider) {
-    style.borderRightColor = borderColor;
+    style.borderRight = getBorderAttributes(1, borderColor);
   }
 
   return style;


### PR DESCRIPTION
Fixes an issue where "random" bottom border would appear. For this to happend, the totals at bottom had to be enabled and the bottom total rows had to be visible before expanding a cell. It also only occured in Firefox.

What would happen is that the border for the cells at row Y would go from having border styling set via `borderBottomColor` (from total divider border) to having border styling via `borderBottom`. This would cause bottom border to loose it's color for the bottom border.

There will be another PR that will fix the root cause of this issue which is that cells in the DataGrid gets a key that is generated from row and column index. This should instead be unique per data value.

React warning when it happend:
![Skärmavbild 2023-12-13 kl  07 55 42](https://github.com/qlik-oss/sn-pivot-table/assets/16608020/dd287a7a-9d58-4f58-ac0c-103629302871)


Before:

https://github.com/qlik-oss/sn-pivot-table/assets/16608020/1711172b-3951-4125-a5ee-73e0417b58fb



After:

https://github.com/qlik-oss/sn-pivot-table/assets/16608020/8737269f-fb93-4aed-8585-f8c498c724a5


