### PR TITLE
perf(useColumnWidth): remove overuse of memoization and make no unnesceary updates of return values

### DIFF
--- a/src/pivot-table/components/PivotTable.tsx
+++ b/src/pivot-table/components/PivotTable.tsx
@@ -101,7 +101,7 @@ export const StickyPivotTable = ({
     overrideLeftGridWidth,
   } = useColumnWidth({
     layoutService,
-    tableRect,
+    tableWidth: tableRect.width,
     headersData,
     visibleTopDimensionInfo,
     verticalScrollbarWidth,

--- a/src/pivot-table/hooks/use-column-width/__tests__/use-column-width.test.ts
+++ b/src/pivot-table/hooks/use-column-width/__tests__/use-column-width.test.ts
@@ -13,7 +13,6 @@ import {
   ColumnWidthLocation,
   type HeadersData,
   type LayoutService,
-  type Rect,
   type VisibleDimensionInfo,
 } from "../../../../types/types";
 import { GRID_BORDER } from "../../../constants";
@@ -31,7 +30,7 @@ jest.mock("../../../contexts/StyleProvider");
 describe("useColumnWidth", () => {
   let dimInfo: ExtendedDimensionInfo;
   let meaInfo: ExtendedMeasureInfo;
-  let tableRect: Rect;
+  let tableWidth: number;
   let percentageConversion: number;
   let mockedUseMeasureText: jest.MockedFunction<(styling: UseMeasureTextProps) => MeasureTextHook>;
   let mockedMeasureText: MeasureTextHook;
@@ -48,8 +47,8 @@ describe("useColumnWidth", () => {
     dimInfo = { qApprMaxGlyphCount: 1, qGroupFieldDefs: [""], qGroupPos: 0 } as ExtendedDimensionInfo;
     meaInfo = { qFallbackTitle: "1", qApprMaxGlyphCount: 0 } as ExtendedMeasureInfo;
 
-    tableRect = { width: 400, height: 100 };
-    percentageConversion = tableRect.width / 100;
+    tableWidth = 400;
+    percentageConversion = tableWidth / 100;
     mockedUseMeasureText = useMeasureText as jest.MockedFunction<typeof useMeasureText>;
     mockedIsLeftDimension = jest.fn().mockReturnValue(true);
     mockedGetDimensionInfoIndex = jest.fn().mockReturnValue(0);
@@ -96,7 +95,7 @@ describe("useColumnWidth", () => {
     } = renderHook(() =>
       useColumnWidth({
         layoutService,
-        tableRect,
+        tableWidth,
         headersData,
         visibleTopDimensionInfo,
         verticalScrollbarWidth,
@@ -173,7 +172,7 @@ describe("useColumnWidth", () => {
 
     test("should return left column width for pixel setting", () => {
       // need to make the width bigger so the col widths are not scaled
-      tableRect = { width: 800, height: 100 };
+      tableWidth = 800;
       const pixels = 50;
       dimInfo = {
         columnWidth: { type: ColumnWidthType.Pixels, pixels },
@@ -264,7 +263,7 @@ describe("useColumnWidth", () => {
       const { result } = renderHook(() =>
         useColumnWidth({
           layoutService,
-          tableRect,
+          tableWidth,
           headersData,
           visibleTopDimensionInfo,
           verticalScrollbarWidth,
@@ -304,8 +303,8 @@ describe("useColumnWidth", () => {
   describe("getRightGridColumnWidth", () => {
     beforeEach(() => {
       const leftSideWidth = 50;
-      tableRect = { width: 350, height: 100 };
-      percentageConversion = (tableRect.width - leftSideWidth) / 100;
+      tableWidth = 350;
+      percentageConversion = (tableWidth - leftSideWidth) / 100;
       layoutService.layout.qHyperCube.qNoOfLeftDims = 1;
       visibleLeftDimensionInfo = [
         {
@@ -336,7 +335,7 @@ describe("useColumnWidth", () => {
     });
 
     test("should return right column width for auto setting when all columns can't fit (scroll)", () => {
-      tableRect = { width: 110, height: 100 };
+      tableWidth = 110;
       meaInfo = { columnWidth: { type: ColumnWidthType.Auto } } as ExtendedMeasureInfo;
       layoutService.layout.qHyperCube.qMeasureInfo = [meaInfo, meaInfo, meaInfo];
 
@@ -453,7 +452,7 @@ describe("useColumnWidth", () => {
     });
 
     test("should subtract scrollbar width from columns", () => {
-      tableRect = { width: 110, height: 100 };
+      tableWidth = 110;
       meaInfo.columnWidth = { type: ColumnWidthType.Auto };
       // normal scrollbar width on mac, it will be automatically calculated on each operating system
       verticalScrollbarWidth = 14;
@@ -467,7 +466,7 @@ describe("useColumnWidth", () => {
     });
 
     test("should not subtract scrollbar width from columns when all rows are visible", () => {
-      tableRect = { width: 110, height: 100 };
+      tableWidth = 110;
       meaInfo = { columnWidth: { type: ColumnWidthType.Auto } } as ExtendedMeasureInfo;
       verticalScrollbarWidth = 0;
       visibleTopDimensionInfo = [dimInfo, dimInfo, dimInfo];
@@ -490,29 +489,29 @@ describe("useColumnWidth", () => {
       mockMeasureText(expectedLeftGridWidth / 3 - TOTAL_CELL_PADDING - MENU_ICON_SIZE);
     });
 
-    test("should return grid and total widths when sum of all widths is tableRect.width", () => {
-      tableRect.width = 500;
+    test("should return grid and total widths when sum of all widths is tableWidth", () => {
+      tableWidth = 500;
       const { leftGridWidth, rightGridWidth, totalWidth, showLastRightBorder } = renderUseColumnWidth();
       expect(leftGridWidth).toBe(expectedLeftGridWidth);
-      expect(rightGridWidth).toBe(tableRect.width - expectedLeftGridWidth - GRID_BORDER);
-      expect(totalWidth).toEqual(tableRect.width);
+      expect(rightGridWidth).toBe(tableWidth - expectedLeftGridWidth - GRID_BORDER);
+      expect(totalWidth).toEqual(tableWidth);
       expect(showLastRightBorder).toBe(false);
     });
 
-    test("should return grid and total widths when sum of all widths is greater than tableRect.width", () => {
+    test("should return grid and total widths when sum of all widths is greater than tableWidth", () => {
       const measureWidth = 100;
       meaInfo = { columnWidth: { type: ColumnWidthType.Pixels, pixels: measureWidth } } as ExtendedMeasureInfo;
       layoutService.layout.qHyperCube.qMeasureInfo = [meaInfo, meaInfo, meaInfo];
 
       const { leftGridWidth, rightGridWidth, totalWidth, showLastRightBorder } = renderUseColumnWidth();
       expect(leftGridWidth).toBe(expectedLeftGridWidth);
-      expect(rightGridWidth).toBe(tableRect.width - expectedLeftGridWidth - GRID_BORDER);
+      expect(rightGridWidth).toBe(tableWidth - expectedLeftGridWidth - GRID_BORDER);
       expect(totalWidth).toBe(expectedLeftGridWidth + measureWidth * 3 + GRID_BORDER);
-      expect(totalWidth).toBeGreaterThan(tableRect.width);
+      expect(totalWidth).toBeGreaterThan(tableWidth);
       expect(showLastRightBorder).toBe(false);
     });
 
-    test("should return grid and total widths when sum of all widths is smaller than tableRect.width", () => {
+    test("should return grid and total widths when sum of all widths is smaller than tableWidth", () => {
       const measureWidth = 40;
       meaInfo = { columnWidth: { type: ColumnWidthType.Pixels, pixels: measureWidth } } as ExtendedMeasureInfo;
       layoutService.layout.qHyperCube.qMeasureInfo = [meaInfo, meaInfo, meaInfo];
@@ -521,7 +520,7 @@ describe("useColumnWidth", () => {
       expect(leftGridWidth).toBe(expectedLeftGridWidth);
       expect(rightGridWidth).toBe(measureWidth * 3);
       expect(totalWidth).toBe(leftGridWidth + measureWidth * 3 + GRID_BORDER);
-      expect(totalWidth).toBeLessThan(tableRect.width);
+      expect(totalWidth).toBeLessThan(tableWidth);
       expect(showLastRightBorder).toBe(true);
     });
   });
@@ -575,7 +574,7 @@ describe("useColumnWidth", () => {
         expect(res.shouldShowLockIcon).toBe(true);
       });
 
-      test("should prioritise lock icon over menu, if there is enough space for only one icon", () => {
+      test("should prioritize lock icon over menu, if there is enough space for only one icon", () => {
         dimInfo.columnWidth = {
           type: ColumnWidthType.Pixels,
           pixels: columnWidthInPixels,

--- a/src/pivot-table/hooks/use-column-width/index.ts
+++ b/src/pivot-table/hooks/use-column-width/index.ts
@@ -1,5 +1,5 @@
 import { useMeasureText } from "@qlik/nebula-table-utils/lib/hooks";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import { GRID_BORDER } from "../../constants";
 import { useStyleContext } from "../../contexts/StyleProvider";
 import { LOCK_ICON_SIZE, MENU_ICON_SIZE, TOTAL_CELL_PADDING } from "./constants";
@@ -12,7 +12,7 @@ export type { GetHeaderCellsIconsVisibilityStatus, OverrideLeftGridWidth } from 
 
 export default function useColumnWidth({
   layoutService,
-  tableRect,
+  tableWidth,
   headersData,
   visibleTopDimensionInfo,
   verticalScrollbarWidth,
@@ -21,23 +21,20 @@ export default function useColumnWidth({
   const styleService = useStyleContext();
   const { measureText: measureTextForHeader } = useMeasureText(getMeasureTextArgs(styleService.header));
 
-  const leftWidths = useColumnWidthLeft({ layoutService, tableRect, headersData });
+  const leftWidths = useColumnWidthLeft({ layoutService, tableWidth, headersData });
 
   const rightWidths = useColumnWidthRight({
     layoutService,
-    tableRect,
+    tableWidth,
     visibleTopDimensionInfo,
     verticalScrollbarWidth,
     leftGridWidth: leftWidths.leftGridWidth,
   });
 
   // The full scrollable width of the chart
-  const totalWidth = useMemo(
-    () => leftWidths.leftGridWidth + rightWidths.rightGridFullWidth + GRID_BORDER,
-    [leftWidths.leftGridWidth, rightWidths.rightGridFullWidth],
-  );
+  const totalWidth = leftWidths.leftGridWidth + rightWidths.rightGridFullWidth + GRID_BORDER;
 
-  const showLastRightBorder = useMemo(() => totalWidth < tableRect.width, [totalWidth, tableRect.width]);
+  const showLastRightBorder = totalWidth < tableWidth;
 
   const getHeaderCellsIconsVisibilityStatus = useCallback<GetHeaderCellsIconsVisibilityStatus>(
     (idx, isLocked, title = "") => {
@@ -61,7 +58,7 @@ export default function useColumnWidth({
         shouldShowLockIcon,
       };
     },
-    [leftWidths, measureTextForHeader],
+    [leftWidths.leftGridColumnWidths, measureTextForHeader],
   );
 
   // Horizontal scrollbar height control based on columns (full) visibility

--- a/src/pivot-table/hooks/use-column-width/types.ts
+++ b/src/pivot-table/hooks/use-column-width/types.ts
@@ -1,4 +1,4 @@
-import type { HeadersData, LayoutService, Rect, VisibleDimensionInfo } from "../../../types/types";
+import type { HeadersData, LayoutService, VisibleDimensionInfo } from "../../../types/types";
 
 export type OverrideLeftGridWidth = (width: number, index: number) => void;
 
@@ -21,13 +21,13 @@ export interface GetHeaderCellsIconsVisibilityStatus {
 
 export interface ColumnWidthLeftHook {
   layoutService: LayoutService;
-  tableRect: Rect;
+  tableWidth: number;
   headersData: HeadersData;
 }
 
 export interface ColumnWidthRightHook {
   layoutService: LayoutService;
-  tableRect: Rect;
+  tableWidth: number;
   visibleTopDimensionInfo: VisibleDimensionInfo[];
   verticalScrollbarWidth: number;
   leftGridWidth: number;

--- a/src/pivot-table/hooks/use-column-width/use-column-width-left.ts
+++ b/src/pivot-table/hooks/use-column-width/use-column-width-left.ts
@@ -14,13 +14,7 @@ import {
 import type { ColumnWidthLeftHook, LeftGridWidthInfo } from "./types";
 import { getColumnWidthValue, getMeasureTextArgs } from "./utils";
 
-export default function useColumnWidthLeft({ layoutService, tableRect, headersData }: ColumnWidthLeftHook) {
-  const {
-    layout: {
-      qHyperCube: { qMeasureInfo, qNoOfLeftDims, topHeadersColumnWidth },
-    },
-    isFullyExpanded,
-  } = layoutService;
+export default function useColumnWidthLeft({ layoutService, tableWidth, headersData }: ColumnWidthLeftHook) {
   const styleService = useStyleContext();
   const { measureText: measureTextForHeader } = useMeasureText(getMeasureTextArgs(styleService.header));
   const { estimateWidth: estimateWidthForDimensionValue } = useMeasureText(
@@ -32,6 +26,13 @@ export default function useColumnWidthLeft({ layoutService, tableRect, headersDa
 
   const calculateLeftGridWidthInfo = useCallback(
     (widthOverride?: number, overrideIndex?: number) => {
+      const {
+        layout: {
+          qHyperCube: { qMeasureInfo, qNoOfLeftDims, topHeadersColumnWidth },
+        },
+        isFullyExpanded,
+      } = layoutService;
+
       const dimensionHeaderCellWidth = (lastRowHeader: HeaderCell) => {
         const { label, isLocked } = lastRowHeader;
         const lockedIconSize = isLocked ? LOCK_ICON_SIZE : 0;
@@ -43,7 +44,7 @@ export default function useColumnWidthLeft({ layoutService, tableRect, headersDa
           const measureLabelWidth = measureTextForMeasureLabel(qFallbackTitle) + TOTAL_CELL_PADDING;
           return Math.max(
             maxWidth,
-            getColumnWidthValue(tableRect.width, columnWidth, Math.max(measureLabelWidth, dimensionsFitToContentWidth)),
+            getColumnWidthValue(tableWidth, columnWidth, Math.max(measureLabelWidth, dimensionsFitToContentWidth)),
           );
         }, 0);
 
@@ -98,7 +99,7 @@ export default function useColumnWidthLeft({ layoutService, tableRect, headersDa
             }
           }
 
-          width = getColumnWidthValue(tableRect.width, columnWidth, fitToContentWidth);
+          width = getColumnWidthValue(tableWidth, columnWidth, fitToContentWidth);
         }
 
         sumOfWidths += width;
@@ -106,7 +107,7 @@ export default function useColumnWidthLeft({ layoutService, tableRect, headersDa
       });
 
       return {
-        leftGridWidth: Math.min(tableRect.width * LEFT_GRID_MAX_WIDTH_RATIO, sumOfWidths),
+        leftGridWidth: Math.min(tableWidth * LEFT_GRID_MAX_WIDTH_RATIO, sumOfWidths),
         leftGridColumnWidths: columnWidths,
         leftGridFullWidth: sumOfWidths,
       };
@@ -114,13 +115,10 @@ export default function useColumnWidthLeft({ layoutService, tableRect, headersDa
     [
       estimateWidthForDimensionValue,
       headersData.data,
-      isFullyExpanded,
+      layoutService,
       measureTextForHeader,
       measureTextForMeasureLabel,
-      qMeasureInfo,
-      qNoOfLeftDims,
-      tableRect.width,
-      topHeadersColumnWidth,
+      tableWidth,
     ],
   );
 

--- a/src/pivot-table/hooks/use-column-width/use-column-width-right.ts
+++ b/src/pivot-table/hooks/use-column-width/use-column-width-right.ts
@@ -10,7 +10,7 @@ import { getMeasureTextArgs, getPercentageValue, getPixelValue } from "./utils";
 
 export default function useColumnWidthRight({
   layoutService,
-  tableRect,
+  tableWidth,
   visibleTopDimensionInfo,
   verticalScrollbarWidth,
   leftGridWidth,
@@ -31,12 +31,9 @@ export default function useColumnWidthRight({
 
   /**
    * Calculates widths of the left columns as well as the sum of the widths.
-   * If the sum of widths exceed LEFT_SIDE_MAX_WIDTH_RATIO * tableRect.width, the left side will become scrollable
+   * If the sum of widths exceed LEFT_SIDE_MAX_WIDTH_RATIO * tableWidth, the left side will become scrollable
    */
-  const rightGridAvailableWidth = useMemo(
-    () => tableRect.width - leftGridWidth - GRID_BORDER,
-    [leftGridWidth, tableRect.width],
-  );
+  const rightGridAvailableWidth = tableWidth - leftGridWidth - GRID_BORDER;
 
   const leafTopDimension = visibleTopDimensionInfo.at(-1);
   const topGridLeavesIsPseudo = leafTopDimension === PSEUDO_DIMENSION_INDEX;
@@ -147,13 +144,10 @@ export default function useColumnWidthRight({
   );
 
   // The width of the sum of all columns, can be smaller or greater than what fits in the chart
-  const rightGridFullWidth = useMemo(() => size.x * averageLeafWidth, [averageLeafWidth, size.x]);
+  const rightGridFullWidth = size.x * averageLeafWidth;
 
   // The width that will be assigned to the top and data grid
-  const rightGridWidth = useMemo(
-    () => Math.min(rightGridFullWidth, rightGridAvailableWidth),
-    [rightGridFullWidth, rightGridAvailableWidth],
-  );
+  const rightGridWidth = Math.min(rightGridFullWidth, rightGridAvailableWidth);
 
   return {
     rightGridFullWidth,


### PR DESCRIPTION
The goal with this PR is that **nothing returned from the `useColumnWidth` hook should change (new value or instance), when we need the pivot table to be performant**. By performant I mean doing interactions with the chart, not editing it (then a full rerender is totally OK). For that I include
- selections
- scrolling
- sorting
- column resize

The resize will trigger a update in any case, for obvious reasons. Sorting fetches new data, so that one is hard to prevent. But for scrolling and selections, there should be no new values or instances returned. So now the properties returned from this hook, wont trigger any rerenders for the child components of `PivotTable`

What I've changed:
- only passing the `tableWidth`, the height is not relevant
- removing useMemo for values that are cheap to calculate, and since they are non-objects, they don't trigger other hooks
- moved destructuring of `layoutService` inside `calculateLeftGridWidthInfo`, to simplify the dependency array
- being more specific in the dep array for `getHeaderCellsIconsVisibilityStatus`, that one was actually updating every time it ran