### PR TITLE
perf: reduce usage of Object.values

### DIFF
--- a/src/pivot-table/components/grids/LeftGrid.tsx
+++ b/src/pivot-table/components/grids/LeftGrid.tsx
@@ -97,7 +97,7 @@ const LeftGrid = ({
             height={height}
             width={columnWidths[colIndex]}
             itemCount={itemCount}
-            itemSize={getRowHeightHandler(list, contentCellHeight, isLastColumn, qSize.qcy)}
+            itemSize={getRowHeightHandler(list, listValues, contentCellHeight, isLastColumn, qSize.qcy)}
             layout="vertical"
             itemData={{
               layoutService,

--- a/src/pivot-table/components/grids/TopGrid.tsx
+++ b/src/pivot-table/components/grids/TopGrid.tsx
@@ -91,7 +91,7 @@ const TopGrid = ({
             height={rowHightCallback()}
             width={width}
             itemCount={itemCount}
-            itemSize={getColumnWidthHandler({ list, isLastRow, getRightGridColumnWidth })}
+            itemSize={getColumnWidthHandler({ list, listValues, isLastRow, getRightGridColumnWidth })}
             layout="horizontal"
             itemData={{
               layoutService,

--- a/src/pivot-table/components/helpers/__tests__/get-item-size-handler.test.ts
+++ b/src/pivot-table/components/helpers/__tests__/get-item-size-handler.test.ts
@@ -3,9 +3,11 @@ import { getColumnWidthHandler, getRowHeightHandler } from "../get-item-size-han
 
 describe("getItemSizeHandler", () => {
   let list: List;
+  let listValues: Cell[];
 
   beforeEach(() => {
     list = {};
+    listValues = [];
   });
 
   describe("getRowHeightHandler", () => {
@@ -13,7 +15,7 @@ describe("getItemSizeHandler", () => {
     const qcy = 100;
 
     test("should return a size when cell is undefined", () => {
-      const handler = getRowHeightHandler(list, cellHeight, false, qcy);
+      const handler = getRowHeightHandler(list, listValues, cellHeight, false, qcy);
 
       expect(handler(0)).toEqual(cellHeight);
     });
@@ -25,7 +27,8 @@ describe("getItemSizeHandler", () => {
         leafCount,
         distanceToNextCell: 0,
       } as Cell;
-      const handler = getRowHeightHandler(list, cellHeight, false, qcy);
+      listValues = Object.values(list);
+      const handler = getRowHeightHandler(list, listValues, cellHeight, false, qcy);
 
       expect(handler(0)).toEqual(cellHeight * leafCount);
     });
@@ -38,7 +41,8 @@ describe("getItemSizeHandler", () => {
         leafCount,
         distanceToNextCell,
       } as Cell;
-      const handler = getRowHeightHandler(list, cellHeight, false, qcy);
+      listValues = Object.values(list);
+      const handler = getRowHeightHandler(list, listValues, cellHeight, false, qcy);
 
       expect(handler(0)).toEqual(cellHeight * (leafCount + distanceToNextCell));
     });
@@ -53,7 +57,8 @@ describe("getItemSizeHandler", () => {
         pageY,
         distanceToNextCell,
       } as Cell;
-      const handler = getRowHeightHandler(list, cellHeight, false, qcy);
+      listValues = Object.values(list);
+      const handler = getRowHeightHandler(list, listValues, cellHeight, false, qcy);
 
       expect(handler(0)).toEqual(cellHeight * (leafCount + pageY + distanceToNextCell));
     });
@@ -77,6 +82,7 @@ describe("getItemSizeHandler", () => {
         distanceToNextCell,
         x,
       } as Cell;
+      listValues = Object.values(list);
 
       getRightGridColumnWidth = () => columnWidth;
     });
@@ -84,12 +90,14 @@ describe("getItemSizeHandler", () => {
     const getHandler = (isLastRow = false) =>
       getColumnWidthHandler({
         list,
+        listValues,
         isLastRow,
         getRightGridColumnWidth,
       });
 
     test("should return a size when cell is undefined", () => {
       list = {};
+      listValues = [];
 
       const handler = getHandler();
       expect(handler(index)).toEqual(columnWidth);
@@ -103,6 +111,7 @@ describe("getItemSizeHandler", () => {
         distanceToNextCell,
         x,
       } as Cell;
+      listValues = Object.values(list);
 
       const handler = getHandler();
       expect(handler(index)).toEqual(columnWidth * distanceToNextCell);
@@ -114,6 +123,7 @@ describe("getItemSizeHandler", () => {
         leafCount,
         x,
       } as Cell;
+      listValues = Object.values(list);
 
       const handler = getHandler(true);
       expect(handler(index)).toEqual(columnWidth);
@@ -133,6 +143,7 @@ describe("getItemSizeHandler", () => {
         distanceToNextCell,
         x,
       } as Cell;
+      listValues = Object.values(list);
 
       const handler = getHandler();
       expect(handler(index)).toEqual(leafCount * columnWidth);
@@ -150,6 +161,7 @@ describe("getItemSizeHandler", () => {
         distanceToNextCell,
         x,
       } as Cell;
+      listValues = Object.values(list);
 
       const handler = getHandler();
       expect(handler(index)).toEqual((leafCount + distanceToNextCell + x) * columnWidth);

--- a/src/pivot-table/components/helpers/get-item-size-handler.ts
+++ b/src/pivot-table/components/helpers/get-item-size-handler.ts
@@ -1,7 +1,8 @@
-import type { List } from "../../../types/types";
+import type { Cell, List } from "../../../types/types";
 
 interface ColumnWidthHandlerProps {
   list: List;
+  listValues: Cell[];
   isLastRow: boolean;
   getRightGridColumnWidth: (index?: number) => number;
 }
@@ -9,9 +10,9 @@ interface ColumnWidthHandlerProps {
 type ItemSizeHandler = (index: number) => number;
 
 export const getRowHeightHandler =
-  (list: List, cellHeight: number, isLastColumn: boolean, qcy: number): ItemSizeHandler =>
+  (list: List, listValues: Cell[], cellHeight: number, isLastColumn: boolean, qcy: number): ItemSizeHandler =>
   (rowIndex: number) => {
-    const cell = isLastColumn ? list[rowIndex] : Object.values(list)[rowIndex];
+    const cell = isLastColumn ? list[rowIndex] : listValues[rowIndex];
 
     if (rowIndex === 0 && cell?.pageY > 0) {
       return (cell.leafCount + cell.pageY + cell.distanceToNextCell) * cellHeight;
@@ -29,9 +30,9 @@ export const getRowHeightHandler =
   };
 
 export const getColumnWidthHandler =
-  ({ list, isLastRow, getRightGridColumnWidth }: ColumnWidthHandlerProps): ItemSizeHandler =>
+  ({ list, listValues, isLastRow, getRightGridColumnWidth }: ColumnWidthHandlerProps): ItemSizeHandler =>
   (colIndex: number) => {
-    const cell = isLastRow ? list[colIndex] : Object.values(list)[colIndex];
+    const cell = isLastRow ? list[colIndex] : listValues[colIndex];
     // const measureInfoCount = layoutService.layout.qHyperCube.qMeasureInfo.length;
 
     // TODO: This a bit of a special case but if you are on a different page then the first.

--- a/src/pivot-table/hooks/use-column-width/use-column-width-right.ts
+++ b/src/pivot-table/hooks/use-column-width/use-column-width-right.ts
@@ -132,10 +132,7 @@ export default function useColumnWidthRight({
 
   // when verticalScrollbarWidth is 0 (scrollbar is invisible)
   // there will be a 0/n division in below line which will result in 0
-  const scrollbarWidthSharePerColumn = useMemo(
-    () => parseFloat((verticalScrollbarWidth / layoutService.size.x).toFixed(12)),
-    [layoutService.size.x, verticalScrollbarWidth],
-  );
+  const scrollbarWidthSharePerColumn = parseFloat((verticalScrollbarWidth / layoutService.size.x).toFixed(12));
 
   /**
    * Gets the width of a right grid column. This is always based on the leaf width(s)

--- a/src/pivot-table/hooks/use-column-width/use-column-width-right.ts
+++ b/src/pivot-table/hooks/use-column-width/use-column-width-right.ts
@@ -130,20 +130,22 @@ export default function useColumnWidthRight({
     return leafWidths[0];
   }, [topGridLeavesIsPseudo, leafWidths, qMeasureInfo]);
 
+  // when verticalScrollbarWidth is 0 (scrollbar is invisible)
+  // there will be a 0/n division in below line which will result in 0
+  const scrollbarWidthSharePerColumn = useMemo(
+    () => parseFloat((verticalScrollbarWidth / layoutService.size.x).toFixed(12)),
+    [layoutService.size.x, verticalScrollbarWidth],
+  );
+
   /**
    * Gets the width of a right grid column. This is always based on the leaf width(s)
    */
   const getRightGridColumnWidth = useCallback(
-    (index?: number) => {
-      // when verticalScrollbarWidth is 0 (scrollbar is invisible)
-      // there will be a 0/n division in below line which will result in 0
-      const scrollbarWidthSharePerColumn = parseFloat((verticalScrollbarWidth / layoutService.size.x).toFixed(12));
-
-      return topGridLeavesIsPseudo && index !== undefined
+    (index?: number) =>
+      topGridLeavesIsPseudo && index !== undefined
         ? leafWidths[layoutService.getMeasureInfoIndexFromCellIndex(index)] - scrollbarWidthSharePerColumn
-        : averageLeafWidth - scrollbarWidthSharePerColumn;
-    },
-    [topGridLeavesIsPseudo, leafWidths, layoutService, averageLeafWidth, verticalScrollbarWidth],
+        : averageLeafWidth - scrollbarWidthSharePerColumn,
+    [topGridLeavesIsPseudo, leafWidths, layoutService, averageLeafWidth, scrollbarWidthSharePerColumn],
   );
 
   // The width of the sum of all columns, can be smaller or greater than what fits in the chart


### PR DESCRIPTION
Did some profiling with a large number of dimensions in either Top or Left grid. The 3 calls that stood out as costly was calls to `Object.values` and `toFixed`, both methods where called for each cell in every react window list on every render.

- For `Object.values` the solution was to use the already resolved `listValues`
- There was no need to call `toFixed` everytime `getRightGridColumnWidth` was called. So simple moved that logic out