### PR TITLE
fix: data grid row count

### DIFF
--- a/src/pivot-table/components/cells/DataCell.tsx
+++ b/src/pivot-table/components/cells/DataCell.tsx
@@ -25,9 +25,10 @@ const MeasureCell = ({ columnIndex, rowIndex, style, data }: MeasureCellProps): 
     shouldShowTotalCellBottomDivider,
     shouldShowTotalCellRightDivider,
     isTotalValue,
+    pageInfo,
   } = data;
   const cell = grid[rowIndex]?.[columnIndex];
-  const isLastRow = rowIndex === layoutService.size.y - 1;
+  const isLastRow = rowIndex === pageInfo.rowsOnCurrentPage - 1;
   const isLastColumn = columnIndex === layoutService.size.x - 1;
 
   if (!cell) {

--- a/src/pivot-table/components/cells/__tests__/DataCell.test.tsx
+++ b/src/pivot-table/components/cells/__tests__/DataCell.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, type RenderResult } from "@testing-library/react";
 import React from "react";
 import NxDimCellType from "../../../../types/QIX";
-import type { GridItemData, LayoutService, MeasureCell } from "../../../../types/types";
+import type { GridItemData, LayoutService, MeasureCell, PageInfo } from "../../../../types/types";
 import TestWithProvider from "../../../__tests__/test-with-providers";
 import DataCell, { testId } from "../DataCell";
 
@@ -10,6 +10,7 @@ describe("DataCell", () => {
   let data: GridItemData;
   let layoutService: LayoutService;
   let renderDataCell: () => RenderResult;
+  let pageInfo: PageInfo;
 
   const style: React.CSSProperties = {
     position: "absolute",
@@ -45,6 +46,10 @@ describe("DataCell", () => {
       },
     } as unknown as LayoutService;
 
+    pageInfo = {
+      rowsOnCurrentPage: 2,
+    } as PageInfo;
+
     data = {
       grid: [[cell]],
       layoutService,
@@ -52,6 +57,7 @@ describe("DataCell", () => {
       shouldShowTotalCellBottomDivider: () => false,
       shouldShowTotalCellRightDivider: () => false,
       isTotalValue: () => false,
+      pageInfo,
     } as GridItemData;
 
     renderDataCell = () =>

--- a/src/pivot-table/components/grids/DataGrid.tsx
+++ b/src/pivot-table/components/grids/DataGrid.tsx
@@ -120,7 +120,7 @@ const DataGrid = ({
       columnCount={layoutService.size.x}
       columnWidth={getRightGridColumnWidth}
       height={height}
-      rowCount={layoutService.size.y}
+      rowCount={pageInfo.rowsOnCurrentPage}
       rowHeight={rowHightCallback}
       width={width}
       itemData={
@@ -132,6 +132,7 @@ const DataGrid = ({
           isTotalValue,
           shouldShowTotalCellBottomDivider,
           shouldShowTotalCellRightDivider,
+          pageInfo,
         } as GridItemData
       }
       onItemsRendered={onItemsRenderedHandler}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -74,6 +74,7 @@ export interface GridItemData extends ItemData {
   isTotalValue: (x: number, y: number) => boolean;
   shouldShowTotalCellBottomDivider: (y: number) => boolean;
   shouldShowTotalCellRightDivider: (x: number) => boolean;
+  pageInfo: PageInfo;
 }
 
 export interface ListItemData extends ItemData {


### PR DESCRIPTION
Noticed an issue will working on #503 that the data grid was not getting the correct size on the last page.

I don't think it will fix any noticable issue until it's merged with #503, there this issue extra data fetch calls on the last page.