### PR TITLE
fix: handle hidden measures

### DIFF
--- a/src/pivot-table/components/helpers/get-item-size-handler.ts
+++ b/src/pivot-table/components/helpers/get-item-size-handler.ts
@@ -33,7 +33,7 @@ export const getColumnWidthHandler =
   ({ list, listValues, isLastRow, getRightGridColumnWidth }: ColumnWidthHandlerProps): ItemSizeHandler =>
   (colIndex: number) => {
     const cell = isLastRow ? list[colIndex] : listValues[colIndex];
-    // const measureInfoCount = layoutService.layout.qHyperCube.qMeasureInfo.length;
+    // const measureInfoCount = layoutService.visibleMeasureInfo.length;
 
     // TODO: This a bit of a special case but if you are on a different page then the first.
     // Scroll down a bit and expand a node. The "first row" does not exist yet as data has only been

--- a/src/pivot-table/hooks/__tests__/use-data.test.ts
+++ b/src/pivot-table/hooks/__tests__/use-data.test.ts
@@ -112,8 +112,9 @@ describe("useData", () => {
       layout: {
         qHyperCube,
       },
+      visibleMeasureInfo: [],
       size: { x: 3, y: 4 },
-    } as LayoutService;
+    } as unknown as LayoutService;
 
     leftDimensionData = {
       grid: [{}],

--- a/src/pivot-table/hooks/use-attr-expr-info-indexes.ts
+++ b/src/pivot-table/hooks/use-attr-expr-info-indexes.ts
@@ -6,15 +6,15 @@ import extractAttrExprInfoIndex from "../data/helpers/extract-attr-expr-info-ind
 const useAttrExprInfoIndexes = (
   visibleLeftDimensionInfo: VisibleDimensionInfo[],
   visibleTopDimensionInfo: VisibleDimensionInfo[],
-  qMeasureInfo: ExtendedMeasureInfo[],
+  visibleMeasureInfo: ExtendedMeasureInfo[],
 ): AttrExprInfoIndexes =>
   useMemo(
     () => ({
       left: visibleLeftDimensionInfo.map(extractAttrExprInfoIndex),
       top: visibleTopDimensionInfo.map(extractAttrExprInfoIndex),
-      measures: qMeasureInfo.map(extractAttrExprInfoIndex),
+      measures: visibleMeasureInfo.map(extractAttrExprInfoIndex),
     }),
-    [qMeasureInfo, visibleLeftDimensionInfo, visibleTopDimensionInfo],
+    [visibleMeasureInfo, visibleLeftDimensionInfo, visibleTopDimensionInfo],
   );
 
 export default useAttrExprInfoIndexes;

--- a/src/pivot-table/hooks/use-column-width/__tests__/use-column-width.test.ts
+++ b/src/pivot-table/hooks/use-column-width/__tests__/use-column-width.test.ts
@@ -57,7 +57,6 @@ describe("useColumnWidth", () => {
       layout: {
         qHyperCube: {
           qDimensionInfo: [dimInfo, dimInfo, dimInfo],
-          qMeasureInfo: [meaInfo, meaInfo, meaInfo],
           qNoOfLeftDims: 3,
           qEffectiveInterColumnSortOrder: [0, 1, 2, -1],
         },
@@ -69,6 +68,7 @@ describe("useColumnWidth", () => {
       getMeasureInfoIndexFromCellIndex: (index: number) => index,
       getDimensionInfoIndex: mockedGetDimensionInfoIndex,
       isLeftDimension: mockedIsLeftDimension,
+      visibleMeasureInfo: [meaInfo, meaInfo, meaInfo],
     } as unknown as LayoutService;
 
     visibleLeftDimensionInfo = [dimInfo, dimInfo, dimInfo];
@@ -156,7 +156,7 @@ describe("useColumnWidth", () => {
       mockMeasureText(width);
       visibleLeftDimensionInfo = createDimInfos([0, PSEUDO_DIMENSION_INDEX]);
       visibleTopDimensionInfo = createDimInfos([1, 2]);
-      layoutService.layout.qHyperCube.qMeasureInfo = [
+      layoutService.visibleMeasureInfo = [
         { columnWidth: { type: ColumnWidthType.Pixels, pixels: 30 } } as ExtendedMeasureInfo,
       ];
       mockedGetDimensionInfoIndex.mockImplementation((info) =>
@@ -224,7 +224,7 @@ describe("useColumnWidth", () => {
 
       mockEstimateWidth(10);
       mockMeasureText(40);
-      layoutService.layout.qHyperCube.qMeasureInfo = [
+      layoutService.visibleMeasureInfo = [
         meaInfo,
         { columnWidth: { type: ColumnWidthType.Percentage, percentage: 10 } } as ExtendedMeasureInfo,
         { columnWidth: { type: ColumnWidthType.Pixels, pixels: 60 } } as ExtendedMeasureInfo,
@@ -326,7 +326,7 @@ describe("useColumnWidth", () => {
 
     test("should return right column width for auto setting", () => {
       meaInfo = { columnWidth: { type: ColumnWidthType.Auto } } as ExtendedMeasureInfo;
-      layoutService.layout.qHyperCube.qMeasureInfo = [meaInfo, meaInfo, meaInfo];
+      layoutService.visibleMeasureInfo = [meaInfo, meaInfo, meaInfo];
 
       const { getRightGridColumnWidth } = renderUseColumnWidth();
       expect(getRightGridColumnWidth(0)).toBe(100);
@@ -337,7 +337,7 @@ describe("useColumnWidth", () => {
     test("should return right column width for auto setting when all columns can't fit (scroll)", () => {
       tableWidth = 110;
       meaInfo = { columnWidth: { type: ColumnWidthType.Auto } } as ExtendedMeasureInfo;
-      layoutService.layout.qHyperCube.qMeasureInfo = [meaInfo, meaInfo, meaInfo];
+      layoutService.visibleMeasureInfo = [meaInfo, meaInfo, meaInfo];
 
       const { getRightGridColumnWidth } = renderUseColumnWidth();
       expect(getRightGridColumnWidth(0)).toBe(ColumnWidthValues.AutoMin);
@@ -351,7 +351,7 @@ describe("useColumnWidth", () => {
       mockEstimateWidth(estimatedWidth);
       mockMeasureText(width);
       meaInfo = { columnWidth: { type: ColumnWidthType.FitToContent } } as ExtendedMeasureInfo;
-      layoutService.layout.qHyperCube.qMeasureInfo = [meaInfo, meaInfo, meaInfo];
+      layoutService.visibleMeasureInfo = [meaInfo, meaInfo, meaInfo];
 
       const { getRightGridColumnWidth } = renderUseColumnWidth();
       expect(getRightGridColumnWidth(0)).toBe(estimatedWidth + TOTAL_CELL_PADDING);
@@ -364,7 +364,7 @@ describe("useColumnWidth", () => {
       meaInfo = { columnWidth: { type: ColumnWidthType.Pixels, pixels } } as ExtendedMeasureInfo;
       const meaInfoWithoutValue = { columnWidth: { type: ColumnWidthType.Pixels } } as ExtendedMeasureInfo;
       const meaInfoWithNaN = { columnWidth: { type: ColumnWidthType.Pixels, pixels: NaN } } as ExtendedMeasureInfo;
-      layoutService.layout.qHyperCube.qMeasureInfo = [meaInfo, meaInfoWithoutValue, meaInfoWithNaN];
+      layoutService.visibleMeasureInfo = [meaInfo, meaInfoWithoutValue, meaInfoWithNaN];
 
       const { getRightGridColumnWidth } = renderUseColumnWidth();
       expect(getRightGridColumnWidth(0)).toBe(pixels);
@@ -379,7 +379,7 @@ describe("useColumnWidth", () => {
       const meaInfoWithNaN = {
         columnWidth: { type: ColumnWidthType.Percentage, percentage: NaN },
       } as ExtendedMeasureInfo;
-      layoutService.layout.qHyperCube.qMeasureInfo = [meaInfo, meaInfoWithoutValue, meaInfoWithNaN];
+      layoutService.visibleMeasureInfo = [meaInfo, meaInfoWithoutValue, meaInfoWithNaN];
 
       const { getRightGridColumnWidth } = renderUseColumnWidth();
       expect(getRightGridColumnWidth(0)).toBe(percentage * percentageConversion);
@@ -390,7 +390,7 @@ describe("useColumnWidth", () => {
     test("should return right column width for column that reaches the min pixel value", () => {
       const pixels = 20;
       meaInfo = { columnWidth: { type: ColumnWidthType.Pixels, pixels } } as ExtendedMeasureInfo;
-      layoutService.layout.qHyperCube.qMeasureInfo = [meaInfo, meaInfo, meaInfo];
+      layoutService.visibleMeasureInfo = [meaInfo, meaInfo, meaInfo];
 
       const { getRightGridColumnWidth } = renderUseColumnWidth();
       expect(getRightGridColumnWidth(0)).toBe(ColumnWidthValues.PixelsMin);
@@ -408,7 +408,7 @@ describe("useColumnWidth", () => {
       const meaInfoFitToContent = {
         columnWidth: { type: ColumnWidthType.FitToContent },
       } as ExtendedMeasureInfo;
-      layoutService.layout.qHyperCube.qMeasureInfo = [meaInfo, meaInfoPixels, meaInfoFitToContent];
+      layoutService.visibleMeasureInfo = [meaInfo, meaInfoPixels, meaInfoFitToContent];
 
       const { getRightGridColumnWidth } = renderUseColumnWidth();
       expect(getRightGridColumnWidth(0)).toBe(131);
@@ -501,7 +501,7 @@ describe("useColumnWidth", () => {
     test("should return grid and total widths when sum of all widths is greater than tableWidth", () => {
       const measureWidth = 100;
       meaInfo = { columnWidth: { type: ColumnWidthType.Pixels, pixels: measureWidth } } as ExtendedMeasureInfo;
-      layoutService.layout.qHyperCube.qMeasureInfo = [meaInfo, meaInfo, meaInfo];
+      layoutService.visibleMeasureInfo = [meaInfo, meaInfo, meaInfo];
 
       const { leftGridWidth, rightGridWidth, totalWidth, showLastRightBorder } = renderUseColumnWidth();
       expect(leftGridWidth).toBe(expectedLeftGridWidth);
@@ -514,7 +514,7 @@ describe("useColumnWidth", () => {
     test("should return grid and total widths when sum of all widths is smaller than tableWidth", () => {
       const measureWidth = 40;
       meaInfo = { columnWidth: { type: ColumnWidthType.Pixels, pixels: measureWidth } } as ExtendedMeasureInfo;
-      layoutService.layout.qHyperCube.qMeasureInfo = [meaInfo, meaInfo, meaInfo];
+      layoutService.visibleMeasureInfo = [meaInfo, meaInfo, meaInfo];
 
       const { leftGridWidth, rightGridWidth, totalWidth, showLastRightBorder } = renderUseColumnWidth();
       expect(leftGridWidth).toBe(expectedLeftGridWidth);

--- a/src/pivot-table/hooks/use-column-width/use-column-width-left.ts
+++ b/src/pivot-table/hooks/use-column-width/use-column-width-left.ts
@@ -28,8 +28,9 @@ export default function useColumnWidthLeft({ layoutService, tableWidth, headersD
     (widthOverride?: number, overrideIndex?: number) => {
       const {
         layout: {
-          qHyperCube: { qMeasureInfo, qNoOfLeftDims, topHeadersColumnWidth },
+          qHyperCube: { qNoOfLeftDims, topHeadersColumnWidth },
         },
+        visibleMeasureInfo,
         isFullyExpanded,
       } = layoutService;
 
@@ -40,7 +41,7 @@ export default function useColumnWidthLeft({ layoutService, tableWidth, headersD
       };
 
       const maxMeasureColumnWidth = (dimensionsFitToContentWidth = 0) =>
-        qMeasureInfo.reduce((maxWidth, { qFallbackTitle, columnWidth }) => {
+        visibleMeasureInfo.reduce((maxWidth, { qFallbackTitle, columnWidth }) => {
           const measureLabelWidth = measureTextForMeasureLabel(qFallbackTitle) + TOTAL_CELL_PADDING;
           return Math.max(
             maxWidth,

--- a/src/pivot-table/hooks/use-column-width/use-column-width-right.ts
+++ b/src/pivot-table/hooks/use-column-width/use-column-width-right.ts
@@ -17,9 +17,10 @@ export default function useColumnWidthRight({
 }: ColumnWidthRightHook) {
   const {
     layout: {
-      qHyperCube: { qMeasureInfo, qNoOfLeftDims, qEffectiveInterColumnSortOrder },
+      qHyperCube: { qNoOfLeftDims, qEffectiveInterColumnSortOrder },
     },
     size,
+    visibleMeasureInfo,
   } = layoutService;
   const styleService = useStyleContext();
   const { estimateWidth: estimateWidthForMeasureValue, measureText: measureTextForMeasureValue } = useMeasureText(
@@ -46,7 +47,7 @@ export default function useColumnWidthRight({
    * For measures this means one value for each measure.
    */
   const leafWidths = useMemo(() => {
-    const columnArray = topGridLeavesIsPseudo ? qMeasureInfo : [leafTopDimension];
+    const columnArray = topGridLeavesIsPseudo ? visibleMeasureInfo : [leafTopDimension];
     const numberOfColumnRepetitions = size.x / columnArray.length;
     const widths: number[] = [];
     const autoColumnIndexes: number[] = [];
@@ -63,7 +64,7 @@ export default function useColumnWidthRight({
       (topGridLeavesIsPseudo
         ? Math.max(estimateWidthForMeasureValue(qApprMaxGlyphCount), measureTextForMeasureValue(qFallbackTitle))
         : Math.max(
-            Math.max(...qMeasureInfo.map((m) => estimateWidthForMeasureValue(m.qApprMaxGlyphCount))),
+            Math.max(...visibleMeasureInfo.map((m) => estimateWidthForMeasureValue(m.qApprMaxGlyphCount))),
             estimateWidthForDimensionValue(qApprMaxGlyphCount) + leavesIconWidth,
           ));
 
@@ -108,7 +109,7 @@ export default function useColumnWidthRight({
     return widths;
   }, [
     topGridLeavesIsPseudo,
-    qMeasureInfo,
+    visibleMeasureInfo,
     leafTopDimension,
     size.x,
     rightGridAvailableWidth,
@@ -120,12 +121,12 @@ export default function useColumnWidthRight({
 
   const averageLeafWidth = useMemo(() => {
     if (topGridLeavesIsPseudo) {
-      const allMeasuresWidth = qMeasureInfo.reduce((totalWidth, _, index) => totalWidth + leafWidths[index], 0);
-      return allMeasuresWidth / qMeasureInfo.length;
+      const allMeasuresWidth = visibleMeasureInfo.reduce((totalWidth, _, index) => totalWidth + leafWidths[index], 0);
+      return allMeasuresWidth / visibleMeasureInfo.length;
     }
 
     return leafWidths[0];
-  }, [topGridLeavesIsPseudo, leafWidths, qMeasureInfo]);
+  }, [topGridLeavesIsPseudo, leafWidths, visibleMeasureInfo]);
 
   // when verticalScrollbarWidth is 0 (scrollbar is invisible)
   // there will be a 0/n division in below line which will result in 0
@@ -137,7 +138,7 @@ export default function useColumnWidthRight({
   const getRightGridColumnWidth = useCallback(
     (index?: number) =>
       topGridLeavesIsPseudo && index !== undefined
-        ? leafWidths[layoutService.getMeasureInfoIndexFromCellIndex(index)] - scrollbarWidthSharePerColumn
+        ? leafWidths[layoutService.getMeasureInfoIndexFromCellIndex(index, true)] - scrollbarWidthSharePerColumn
         : averageLeafWidth - scrollbarWidthSharePerColumn,
     [topGridLeavesIsPseudo, leafWidths, layoutService, averageLeafWidth, scrollbarWidthSharePerColumn],
   );

--- a/src/pivot-table/hooks/use-data-model.ts
+++ b/src/pivot-table/hooks/use-data-model.ts
@@ -99,9 +99,10 @@ export default function useDataModel({
           break;
         case ColumnWidthLocation.Measures:
           if (isLeftColumn) {
+            // This updates hidden measures as well so that if a measure becomes visible again it will not affect the column width
             paths = qMeasureInfo.map((info, idx) => ({
               qPath: `${Q_PATH}/qMeasures/${idx}/qDef/columnWidth`,
-              oldValue: qMeasureInfo[idx].columnWidth,
+              oldValue: info.columnWidth,
             }));
           } else {
             const idx = layoutService.getMeasureInfoIndexFromCellIndex(x);

--- a/src/pivot-table/hooks/use-data.ts
+++ b/src/pivot-table/hooks/use-data.ts
@@ -28,7 +28,7 @@ const useData = (
   const attrExprInfoIndexes = useAttrExprInfoIndexes(
     visibleLeftDimensionInfo,
     visibleTopDimensionInfo,
-    layoutService.layout.qHyperCube.qMeasureInfo,
+    layoutService.visibleMeasureInfo,
   );
 
   const headersData = useMemo<HeadersData>(

--- a/src/services/__tests__/layout-service.test.ts
+++ b/src/services/__tests__/layout-service.test.ts
@@ -84,6 +84,25 @@ describe("createLayoutService", () => {
       expect(service.getMeasureInfoIndexFromCellIndex(4)).toEqual(1);
       expect(service.getMeasureInfoIndexFromCellIndex(5)).toEqual(2);
     });
+
+    test("should return measure info index when a measure is hidden before the requested index", () => {
+      const hiddenMeasure = getMeasureInfo();
+      hiddenMeasure.qError = { qErrorCode: 7005 };
+      layout.qHyperCube.qMeasureInfo = [getMeasureInfo(), hiddenMeasure, getMeasureInfo(), getMeasureInfo()];
+      const service = create();
+      expect(service.getMeasureInfoIndexFromCellIndex(0)).toEqual(0);
+      expect(service.getMeasureInfoIndexFromCellIndex(1)).toEqual(2);
+    });
+
+    test("should return measure info index when a measure is hidden before the requested visible index", () => {
+      const getVisibleIndex = true;
+      const hiddenMeasure = getMeasureInfo();
+      hiddenMeasure.qError = { qErrorCode: 7005 };
+      layout.qHyperCube.qMeasureInfo = [getMeasureInfo(), hiddenMeasure, getMeasureInfo(), getMeasureInfo()];
+      const service = create();
+      expect(service.getMeasureInfoIndexFromCellIndex(0, getVisibleIndex)).toEqual(0);
+      expect(service.getMeasureInfoIndexFromCellIndex(1, getVisibleIndex)).toEqual(1);
+    });
   });
 
   describe("getDimensionInfoIndex", () => {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,7 +2,7 @@ import type { stardust } from "@nebula.js/stardust";
 import type { ColumnWidth } from "@qlik/nebula-table-utils/lib/components/ColumnAdjuster";
 import type { HeaderData, SortDirection } from "@qlik/nebula-table-utils/lib/components/HeadCellMenu/types";
 import type { PSEUDO_DIMENSION_INDEX } from "../constants";
-import type { ExtendedDimensionInfo, NxSelectionCellType, PivotLayout } from "./QIX";
+import type { ExtendedDimensionInfo, ExtendedMeasureInfo, NxSelectionCellType, PivotLayout } from "./QIX";
 
 export type ExpandOrCollapser = (rowIndex: number, columnIndex: number) => void;
 
@@ -193,7 +193,7 @@ export interface ViewService {
 
 export interface LayoutService {
   layout: PivotLayout;
-  getMeasureInfoIndexFromCellIndex: (index: number) => number;
+  getMeasureInfoIndexFromCellIndex: (index: number, getVisibleIndex?: boolean) => number;
   getDimensionInfo: (index: number) => VisibleDimensionInfo | undefined;
   getDimensionInfoIndex: (qDimensionInfo: VisibleDimensionInfo) => number;
   getNullValueText: () => string;
@@ -208,6 +208,7 @@ export interface LayoutService {
   isLeftDimension: (dimensionInfoIndex: number) => boolean;
   isFullyExpanded: boolean;
   triggerdByExpandOrCollapse: boolean;
+  visibleMeasureInfo: ExtendedMeasureInfo[];
 }
 
 export interface DataService {


### PR DESCRIPTION
It's currently not possible to set a show conditions on measures via the property panel, but by either convering an old PVT to sn-pivot-table or using a mashup with calculated conditions properties it's still possible to get layout with hidden measures.

This PR fixes:
-  An issue that can occur when combining color by expression on a measure and at the same time have a hidden measure before (with lower index) the measure with color by expression.
- An issue that can occur when adjusting the column width of a measure when a hidden measure exist before the adjusted measured. The column width patch would be applied to the wrong qMeasureInfo.
- With pseudo dimension on the left side. The column width would in include hidden measures, potentially having great affect on the column width.
- There might be other issues as well but the above issues are the once that I've found.

The fix:
- Filter `qMeasureInfo` by looking for a calculated condition error code. Consume the filtered (`visibleMeasureInfo`) instead of `qMeasureInfo`.