### PR TITLE
feat: text alignment

### DIFF
--- a/api-specifications/properties.json
+++ b/api-specifications/properties.json
@@ -223,6 +223,10 @@
         "columnWidth": {
           "optional": true,
           "type": "#/definitions/ColumnWidth"
+        },
+        "textAlign": {
+          "optional": true,
+          "type": "#/definitions/TextAlign"
         }
       }
     },
@@ -238,6 +242,10 @@
         "columnWidth": {
           "optional": true,
           "type": "#/definitions/ColumnWidth"
+        },
+        "textAlign": {
+          "optional": true,
+          "type": "#/definitions/TextAlign"
         }
       }
     },
@@ -276,6 +284,39 @@
           "description": "Percentage value used if type is `percentage`. Note that for the left grid columns, this is a percentage of the whole chart width. For the right grid columns, it is a percentage of the right grid width",
           "optional": true,
           "type": "number"
+        }
+      }
+    },
+    "TextAlignValues": {
+      "description": "Font styling values",
+      "kind": "union",
+      "items": [
+        {
+          "kind": "literal",
+          "value": "\"left\""
+        },
+        {
+          "kind": "literal",
+          "value": "\"center\""
+        },
+        {
+          "kind": "literal",
+          "value": "\"right\""
+        }
+      ]
+    },
+    "TextAlign": {
+      "description": "Set the alignment of text in the chart.",
+      "kind": "object",
+      "entries": {
+        "auto": {
+          "description": "If true the chart decides text alignment, otherwise the \"align\" value is used.",
+          "type": "boolean"
+        },
+        "align": {
+          "description": "Align value",
+          "optional": true,
+          "type": "#/definitions/TextAlignValues"
         }
       }
     },

--- a/api-specifications/properties.json
+++ b/api-specifications/properties.json
@@ -288,7 +288,7 @@
       }
     },
     "TextAlignValues": {
-      "description": "Font styling values",
+      "description": "Text align values",
       "kind": "union",
       "items": [
         {

--- a/nebula.config.js
+++ b/nebula.config.js
@@ -18,7 +18,9 @@ module.exports = {
     },
   },
   serve: {
-    flags: {},
+    flags: {
+      CLIENT_IM_5863_PVT_TEXT_ALIGN: true,
+    },
     keyboardNavigation: false,
     themes: [
       {

--- a/nebula.rendering.config.js
+++ b/nebula.rendering.config.js
@@ -4,7 +4,9 @@ module.exports = {
     build: false,
     open: false,
     fixturePath: "test/rendering/__fixtures__",
-    flags: {},
+    flags: {
+      CLIENT_IM_5863_PVT_TEXT_ALIGN: true,
+    },
     keyboardNavigation: false,
     themes: [
       {

--- a/src/ext/property-panel/data.ts
+++ b/src/ext/property-panel/data.ts
@@ -116,6 +116,57 @@ const columnResize = {
   },
 };
 
+const textAlignItems = {
+  textAlignAuto: {
+    ref: "qDef.textAlign.auto",
+    type: "boolean",
+    component: "switch",
+    translation: "Common.Text.TextAlignment",
+    options: [
+      {
+        value: true,
+        translation: "Common.Auto",
+      },
+      {
+        value: false,
+        translation: "Common.Custom",
+      },
+    ],
+    defaultValue: true,
+  },
+  textAlign: {
+    ref: "qDef.textAlign.align",
+    type: "string",
+    component: "item-selection-list",
+    horizontal: true,
+    items: [
+      {
+        component: "icon-item",
+        icon: "align_left",
+        labelPlacement: "bottom",
+        value: "left",
+        translation: "properties.dock.left",
+      },
+      {
+        component: "icon-item",
+        icon: "align_center",
+        labelPlacement: "bottom",
+        value: "center",
+        translation: "Common.Center",
+      },
+      {
+        component: "icon-item",
+        icon: "align_right",
+        labelPlacement: "bottom",
+        value: "right",
+        translation: "properties.dock.right",
+      },
+    ],
+    defaultValue: "left",
+    show: (data: DimensionOrMeasureDef) => data.qDef.textAlign !== undefined && !data.qDef.textAlign.auto,
+  },
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const createData = (env: Galaxy): Record<string, any> => {
   const { translator, anything, flags } = env;
@@ -214,6 +265,7 @@ const createData = (env: Galaxy): Record<string, any> => {
             },
           },
           cellColoring,
+          ...textAlignItems,
           ...columnResize,
         },
       },
@@ -271,6 +323,7 @@ const createData = (env: Galaxy): Record<string, any> => {
             },
           },
           cellColoring,
+          ...textAlignItems,
           ...columnResize,
         },
       },

--- a/src/pivot-table/components/cells/DataCell.tsx
+++ b/src/pivot-table/components/cells/DataCell.tsx
@@ -6,7 +6,7 @@ import { useStyleContext } from "../../contexts/StyleProvider";
 import getExpressionColor from "../../data/helpers/get-expression-color";
 import { baseCellStyle, getBorderStyle, getTotalCellDividerStyle } from "../shared-styles";
 import EmptyCell from "./EmptyCell";
-import { getCellStyle, getTextAlign, getTextStyle } from "./utils/get-measure-cell-style";
+import { getCellStyle, getJustifyContent, getTextStyle } from "./utils/get-measure-cell-style";
 import getMeasureInfoIndex from "./utils/get-measure-info-index";
 
 export interface MeasureCellProps {
@@ -69,7 +69,7 @@ const MeasureCell = ({ columnIndex, rowIndex, style, data }: MeasureCellProps): 
     }),
     ...baseCellStyle,
     display: "flex",
-    justifyContent: getTextAlign(layoutService.visibleMeasureInfo[measureInfoIndex], isNumeric, flags),
+    justifyContent: getJustifyContent(layoutService.visibleMeasureInfo[measureInfoIndex], isNumeric, flags),
   };
 
   return (

--- a/src/pivot-table/components/cells/DataCell.tsx
+++ b/src/pivot-table/components/cells/DataCell.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { areEqual } from "react-window";
 import type { GridItemData } from "../../../types/types";
+import { useBaseContext } from "../../contexts/BaseProvider";
 import { useStyleContext } from "../../contexts/StyleProvider";
 import getExpressionColor from "../../data/helpers/get-expression-color";
 import { baseCellStyle, getBorderStyle, getTotalCellDividerStyle } from "../shared-styles";
 import EmptyCell from "./EmptyCell";
-import { containerStyle, getCellStyle, getTextStyle } from "./utils/get-measure-cell-style";
+import { getCellStyle, getTextAlign, getTextStyle } from "./utils/get-measure-cell-style";
 import getMeasureInfoIndex from "./utils/get-measure-info-index";
 
 export interface MeasureCellProps {
@@ -19,6 +20,7 @@ export const testId = "measure-cell";
 
 const MeasureCell = ({ columnIndex, rowIndex, style, data }: MeasureCellProps): JSX.Element | null => {
   const styleService = useStyleContext();
+  const { flags } = useBaseContext();
   const { background } = styleService.measureValues;
   const {
     grid,
@@ -67,17 +69,11 @@ const MeasureCell = ({ columnIndex, rowIndex, style, data }: MeasureCellProps): 
     }),
     ...baseCellStyle,
     display: "flex",
-    justifyContent: isNumeric ? "flex-end" : "center",
+    justifyContent: getTextAlign(layoutService.visibleMeasureInfo[measureInfoIndex], isNumeric, flags),
   };
 
   return (
-    <div
-      title={text}
-      style={{ ...style, ...containerStyle }}
-      data-testid={testId}
-      data-row-index={rowIndex}
-      data-col-index={columnIndex}
-    >
+    <div title={text} style={style} data-testid={testId} data-row-index={rowIndex} data-col-index={columnIndex}>
       <div style={cellStyle}>
         <span style={getTextStyle(styleService, expressionColor.color, isNumeric, isTotalValueCell, cell.isNull)}>
           {text}

--- a/src/pivot-table/components/cells/DimensionValue/Container.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/Container.tsx
@@ -5,6 +5,7 @@ import { useSelectionsContext } from "../../../contexts/SelectionsProvider";
 import { useStyleContext } from "../../../contexts/StyleProvider";
 import { CELL_PADDING, baseCellStyle, getBorderStyle, getTotalCellDividerStyle } from "../../shared-styles";
 import { getBackground, getCursor } from "./utils/get-style";
+import getTextAlign from "./utils/get-text-align";
 
 type Props = {
   text: string;
@@ -38,7 +39,7 @@ const Container = ({
   isAdjustingWidth,
 }: Props): JSX.Element => {
   const styleService = useStyleContext();
-  const { interactions } = useBaseContext();
+  const { interactions, flags } = useBaseContext();
   const { select, isLocked } = useSelectionsContext();
   const { layoutService, showLastBorder } = data;
 
@@ -70,7 +71,7 @@ const Container = ({
         cursor: getCursor(canBeSelected),
         background: getBackground({ styleService, isCellSelected, cell, isCellLocked }),
         zIndex: isLeftColumn ? undefined : layoutService.size.x - cell.x,
-        justifyContent: isLeftColumn ? undefined : "center",
+        justifyContent: getTextAlign(cell, layoutService, isLeftColumn, flags),
         display: "flex",
       }}
       aria-hidden="true"

--- a/src/pivot-table/components/cells/DimensionValue/Container.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/Container.tsx
@@ -4,8 +4,8 @@ import { useBaseContext } from "../../../contexts/BaseProvider";
 import { useSelectionsContext } from "../../../contexts/SelectionsProvider";
 import { useStyleContext } from "../../../contexts/StyleProvider";
 import { CELL_PADDING, baseCellStyle, getBorderStyle, getTotalCellDividerStyle } from "../../shared-styles";
+import getJustifyContent from "./utils/get-justify-content";
 import { getBackground, getCursor } from "./utils/get-style";
-import getTextAlign from "./utils/get-text-align";
 
 type Props = {
   text: string;
@@ -71,7 +71,7 @@ const Container = ({
         cursor: getCursor(canBeSelected),
         background: getBackground({ styleService, isCellSelected, cell, isCellLocked }),
         zIndex: isLeftColumn ? undefined : layoutService.size.x - cell.x,
-        justifyContent: getTextAlign(cell, layoutService, isLeftColumn, flags),
+        justifyContent: getJustifyContent(cell, layoutService, isLeftColumn, flags),
         display: "flex",
       }}
       aria-hidden="true"

--- a/src/pivot-table/components/cells/DimensionValue/__tests__/DimensionValue.test.tsx
+++ b/src/pivot-table/components/cells/DimensionValue/__tests__/DimensionValue.test.tsx
@@ -84,6 +84,7 @@ describe("DimensionValue", () => {
       isDimensionLocked: jest.fn().mockReturnValue(false),
       showTotalsAbove: true,
       size: { x: 100 },
+      getDimensionInfo: () => ({}),
     } as unknown as LayoutService;
 
     expandLeftSpy = jest.spyOn(dataModel, "expandLeft");

--- a/src/pivot-table/components/cells/DimensionValue/utils/__tests__/get-justify-content.test.ts
+++ b/src/pivot-table/components/cells/DimensionValue/utils/__tests__/get-justify-content.test.ts
@@ -1,0 +1,39 @@
+import type { TextAlign } from "../../../../../../types/QIX";
+import type { Cell, Flags, LayoutService } from "../../../../../../types/types";
+import resolveTextAlign from "../../../utils/resolve-text-align";
+import getJustifyContent from "../get-justify-content";
+
+jest.mock("../../../utils/resolve-text-align");
+
+describe("getJustifyContent", () => {
+  const mockedResolveTextAlign = resolveTextAlign as jest.MockedFunction<typeof resolveTextAlign>;
+  const flags = {} as Flags;
+  const cell = {} as Cell;
+  const textAlign: TextAlign = {
+    auto: true,
+    align: "left",
+  };
+  const layoutService = {
+    getDimensionInfo: () => ({ textAlign }),
+  } as unknown as LayoutService;
+
+  beforeEach(() => {
+    mockedResolveTextAlign.mockReturnValue("");
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("should call resolve text align with default value for left grid", () => {
+    getJustifyContent(cell, layoutService, true, flags);
+
+    expect(mockedResolveTextAlign).toHaveBeenCalledWith(textAlign, undefined, flags);
+  });
+
+  test("should call resolve text align with default value for top grid", () => {
+    getJustifyContent(cell, layoutService, false, flags);
+
+    expect(mockedResolveTextAlign).toHaveBeenCalledWith(textAlign, "center", flags);
+  });
+});

--- a/src/pivot-table/components/cells/DimensionValue/utils/get-justify-content.ts
+++ b/src/pivot-table/components/cells/DimensionValue/utils/get-justify-content.ts
@@ -2,11 +2,11 @@ import type { ExtendedDimensionInfo } from "../../../../../types/QIX";
 import type { Cell, Flags, LayoutService } from "../../../../../types/types";
 import resolveTextAlign from "../../utils/resolve-text-align";
 
-const getTextAlign = (cell: Cell, layoutService: LayoutService, isLeftColumn: boolean, flags: Flags) => {
+const getJustifyContent = (cell: Cell, layoutService: LayoutService, isLeftColumn: boolean, flags: Flags) => {
   const { textAlign } = (layoutService.getDimensionInfo(cell.dimensionInfoIndex) as ExtendedDimensionInfo) ?? {};
   const defaultAlign = isLeftColumn ? undefined : "center";
 
   return resolveTextAlign(textAlign, defaultAlign, flags);
 };
 
-export default getTextAlign;
+export default getJustifyContent;

--- a/src/pivot-table/components/cells/DimensionValue/utils/get-text-align.ts
+++ b/src/pivot-table/components/cells/DimensionValue/utils/get-text-align.ts
@@ -1,0 +1,12 @@
+import type { ExtendedDimensionInfo } from "../../../../../types/QIX";
+import type { Cell, Flags, LayoutService } from "../../../../../types/types";
+import resolveTextAlign from "../../utils/resolve-text-align";
+
+const getTextAlign = (cell: Cell, layoutService: LayoutService, isLeftColumn: boolean, flags: Flags) => {
+  const { textAlign } = (layoutService.getDimensionInfo(cell.dimensionInfoIndex) as ExtendedDimensionInfo) ?? {};
+  const defaultAlign = isLeftColumn ? undefined : "center";
+
+  return resolveTextAlign(textAlign, defaultAlign, flags);
+};
+
+export default getTextAlign;

--- a/src/pivot-table/components/cells/__tests__/DataCell.test.tsx
+++ b/src/pivot-table/components/cells/__tests__/DataCell.test.tsx
@@ -45,6 +45,7 @@ describe("DataCell", () => {
           qMeasureInfo: [],
         },
       },
+      visibleMeasureInfo: [{}],
     } as unknown as LayoutService;
 
     pageInfo = {

--- a/src/pivot-table/components/cells/utils/__tests__/get-measure-cell-style.test.ts
+++ b/src/pivot-table/components/cells/utils/__tests__/get-measure-cell-style.test.ts
@@ -1,0 +1,36 @@
+import type { ExtendedMeasureInfo, TextAlign } from "../../../../../types/QIX";
+import type { Flags } from "../../../../../types/types";
+import { getJustifyContent } from "../get-measure-cell-style";
+import resolveTextAlign from "../resolve-text-align";
+
+jest.mock("../resolve-text-align");
+
+describe("getJustifyContent", () => {
+  const mockedResolveTextAlign = resolveTextAlign as jest.MockedFunction<typeof resolveTextAlign>;
+  const flags = {} as Flags;
+  const textAlign: TextAlign = {
+    auto: true,
+    align: "left",
+  };
+  const measureInfo = { textAlign } as ExtendedMeasureInfo;
+
+  beforeEach(() => {
+    mockedResolveTextAlign.mockReturnValue("");
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("should call resolve text align with default value for numeric values", () => {
+    getJustifyContent(measureInfo, true, flags);
+
+    expect(mockedResolveTextAlign).toHaveBeenCalledWith(textAlign, "flex-end", flags);
+  });
+
+  test("should call resolve text align with default value for non-numeric values", () => {
+    getJustifyContent(measureInfo, false, flags);
+
+    expect(mockedResolveTextAlign).toHaveBeenCalledWith(textAlign, "center", flags);
+  });
+});

--- a/src/pivot-table/components/cells/utils/__tests__/resolve-text-align.test.ts
+++ b/src/pivot-table/components/cells/utils/__tests__/resolve-text-align.test.ts
@@ -1,0 +1,38 @@
+import type { Flags } from "../../../../../types/types";
+import resolveTextAlign from "../resolve-text-align";
+
+describe("resolveTextAlign", () => {
+  let flags: Flags;
+
+  beforeEach(() => {
+    flags = {
+      isEnabled: () => true,
+    };
+  });
+
+  test("should return default value when flag is disabled", () => {
+    flags.isEnabled = () => false;
+
+    expect(resolveTextAlign({ auto: false, align: "left" }, "default", flags)).toEqual("default");
+  });
+
+  test("should return default value when text align is auto", () => {
+    expect(resolveTextAlign({ auto: true, align: "left" }, "default", flags)).toEqual("default");
+  });
+
+  test("should return default value when text align is undefined", () => {
+    expect(resolveTextAlign(undefined, "default", flags)).toEqual("default");
+  });
+
+  test("should return value when text align is center", () => {
+    expect(resolveTextAlign({ auto: false, align: "center" }, "default", flags)).toEqual("center");
+  });
+
+  test("should return value when text align is left", () => {
+    expect(resolveTextAlign({ auto: false, align: "left" }, "default", flags)).toEqual("flex-start");
+  });
+
+  test("should return value when text align is right", () => {
+    expect(resolveTextAlign({ auto: false, align: "right" }, "default", flags)).toEqual("flex-end");
+  });
+});

--- a/src/pivot-table/components/cells/utils/get-measure-cell-style.ts
+++ b/src/pivot-table/components/cells/utils/get-measure-cell-style.ts
@@ -1,6 +1,8 @@
-import type { StyleService } from "../../../../types/types";
+import type { ExtendedMeasureInfo } from "../../../../types/QIX";
+import type { Flags, StyleService } from "../../../../types/types";
 import { BOLD_FONT_WEIGHT } from "../../../constants";
 import { getLineClampStyle, textStyle } from "../../shared-styles";
+import resolveTextAlign from "./resolve-text-align";
 
 const numericStyle: React.CSSProperties = {
   display: "flex",
@@ -15,10 +17,6 @@ const nilStyle: React.CSSProperties = {
   flexDirection: "row",
   height: "100%",
   backgroundClip: "padding-box",
-};
-
-export const containerStyle: React.CSSProperties = {
-  justifyContent: "center",
 };
 
 export const getCellStyle = (
@@ -91,4 +89,11 @@ export const getTextStyle = (
     fontStyle,
     textDecoration,
   };
+};
+
+export const getTextAlign = (measureInfo: ExtendedMeasureInfo, isNumeric: boolean, flags: Flags) => {
+  const { textAlign } = measureInfo;
+  const defaultAlign = isNumeric ? "flex-end" : "center";
+
+  return resolveTextAlign(textAlign, defaultAlign, flags);
 };

--- a/src/pivot-table/components/cells/utils/get-measure-cell-style.ts
+++ b/src/pivot-table/components/cells/utils/get-measure-cell-style.ts
@@ -91,7 +91,7 @@ export const getTextStyle = (
   };
 };
 
-export const getTextAlign = (measureInfo: ExtendedMeasureInfo, isNumeric: boolean, flags: Flags) => {
+export const getJustifyContent = (measureInfo: ExtendedMeasureInfo, isNumeric: boolean, flags: Flags) => {
   const { textAlign } = measureInfo;
   const defaultAlign = isNumeric ? "flex-end" : "center";
 

--- a/src/pivot-table/components/cells/utils/resolve-text-align.ts
+++ b/src/pivot-table/components/cells/utils/resolve-text-align.ts
@@ -1,0 +1,21 @@
+import type { TextAlign } from "../../../../types/QIX";
+import type { Flags } from "../../../../types/types";
+
+const resolveTextAlign = (textAlign: TextAlign | undefined, defaultValue: string | undefined, flags: Flags) => {
+  if (!flags.isEnabled("CLIENT_IM_5863_PVT_TEXT_ALIGN") || textAlign?.auto) {
+    return defaultValue;
+  }
+
+  switch (textAlign?.align) {
+    case "center":
+      return "center";
+    case "left":
+      return "flex-start";
+    case "right":
+      return "flex-end";
+    default:
+      return defaultValue;
+  }
+};
+
+export default resolveTextAlign;

--- a/src/qae/initial-properties.js
+++ b/src/qae/initial-properties.js
@@ -118,6 +118,7 @@ const properties = {
  * @type object
  * @extends NxInlineDimensionDef
  * @property {ColumnWidth=} columnWidth
+ * @property {TextAlign=} textAlign
  */
 
 /**
@@ -126,6 +127,7 @@ const properties = {
  * @type object
  * @extends NxInlineMeasureDef
  * @property {ColumnWidth=} columnWidth
+ * @property {TextAlign=} textAlign
  */
 
 /**
@@ -136,6 +138,20 @@ const properties = {
  * @property {('auto' | 'FitToContent' | 'pixels' | 'percentage')} type - Defines how the column width is set. For the right grid, `auto` calculates the width(s) so the total width of the columns equals the right grid width. If the width reaches a minimum value, the columns will overflow. For the left grid, `auto` is N/A and defaults to `fitToContent`. `fitToContent` calculates a width based on the column's content. `pixels` uses a specified pixel value. `percentage` sets the column width to specified percentage of the chart/grid width
  * @property {number=} pixels - Pixel value used if type is `pixels`
  * @property {number=} percentage - Percentage value used if type is `percentage`. Note that for the left grid columns, this is a percentage of the whole chart width. For the right grid columns, it is a percentage of the right grid width
+ */
+
+/**
+ * Font styling values
+ * @name TextAlignValues
+ * @type {"left" | "center" | "right"}
+ */
+
+/**
+ * Set the alignment of text in the chart.
+ * @name TextAlign
+ * @type object
+ * @property {boolean} auto - If true the chart decides text alignment, otherwise the "align" value is used.
+ * @property {TextAlignValues=} align - Align value
  */
 
 /**

--- a/src/qae/initial-properties.js
+++ b/src/qae/initial-properties.js
@@ -141,7 +141,7 @@ const properties = {
  */
 
 /**
- * Font styling values
+ * Text align values
  * @name TextAlignValues
  * @type {"left" | "center" | "right"}
  */

--- a/src/types/QIX.ts
+++ b/src/types/QIX.ts
@@ -38,6 +38,11 @@ interface NullValueRepresentation {
   text?: string;
 }
 
+export type TextAlign = {
+  auto: boolean;
+  align: "left" | "center" | "right";
+};
+
 export interface PaletteColor {
   index?: number;
   color?: string;
@@ -158,10 +163,12 @@ export interface ExtendedDimensionInfo extends EngineAPI.INxDimensionInfo {
     qHypercubeCardinal: number;
   };
   columnWidth?: ColumnWidth;
+  textAlign?: TextAlign;
 }
 
 export interface ExtendedMeasureInfo extends EngineAPI.INxMeasureInfo {
   columnWidth?: ColumnWidth;
+  textAlign?: TextAlign;
 }
 
 export interface ExtendedHyperCube extends EngineAPI.IHyperCube {
@@ -194,10 +201,12 @@ export default NxDimCellType;
 // types for properties
 interface ExtendedInlineDimensionDef extends EngineAPI.INxInlineDimensionDef {
   columnWidth: ColumnWidth;
+  textAlign?: TextAlign;
 }
 
 interface ExtendedInlineMeasureDef extends EngineAPI.INxInlineMeasureDef {
   columnWidth: ColumnWidth;
+  textAlign?: TextAlign;
 }
 
 export interface DimensionOrMeasureDef {


### PR DESCRIPTION
Adds an option to the property panel to set text alignment for dimensions and measures. The alignment only affects the data values and not the header values.

PP option:
![Skärmavbild 2024-01-19 kl  07 56 51](https://github.com/qlik-oss/sn-pivot-table/assets/16608020/0dac9d57-972c-4f0b-8c8d-3f02745a73c6)

Output:
![Skärmavbild 2024-01-19 kl  07 59 15](https://github.com/qlik-oss/sn-pivot-table/assets/16608020/b9b08eef-4abb-4543-a5b9-8eadbc1aa429)

