### PR TITLE
feat(IM-5878): consider scroll position when taking snapshot

### DIFF
--- a/src/ext/index.ts
+++ b/src/ext/index.ts
@@ -8,7 +8,7 @@ export default function ext(env: Galaxy): Record<string, unknown> {
       // TODO Most of the code is in place to enable snapshot, however WYSIWYG is not always true. Depending on the scroll position, some cell that where visible when the screenshot was taken, is not fully visiable in the screenshot.
       // This should be fixed, possibly be figuring out how much of a cell is in view and then in the snapshot scroll that cell into view by the same amount.
       cssScaling: false,
-      snapshot: false,
+      snapshot: env.flags.isEnabled("CLIENT_IM4976_PIVOT_DOWNLOAD"),
       export: false,
       sharing: false,
       exportData: true,

--- a/src/ext/index.ts
+++ b/src/ext/index.ts
@@ -8,7 +8,7 @@ export default function ext(env: Galaxy): Record<string, unknown> {
       // TODO Most of the code is in place to enable snapshot, however WYSIWYG is not always true. Depending on the scroll position, some cell that where visible when the screenshot was taken, is not fully visiable in the screenshot.
       // This should be fixed, possibly be figuring out how much of a cell is in view and then in the snapshot scroll that cell into view by the same amount.
       cssScaling: false,
-      snapshot: env.flags.isEnabled("CLIENT_IM4976_PIVOT_DOWNLOAD"),
+      snapshot: env.flags.isEnabled("CLIENT_IM5878_PIVOT_SNAPSHOT"),
       export: false,
       sharing: false,
       exportData: true,

--- a/src/hooks/use-render.ts
+++ b/src/hooks/use-render.ts
@@ -42,7 +42,7 @@ const useRender = (env: Galaxy) => {
   const themeName = theme.name();
   const { translator, language } = useTranslations();
   const { pageInfo, updatePageInfo } = usePagination(layoutService);
-  const viewService = useViewService(pageInfo);
+  const viewService = useViewService(layout, pageInfo);
   const rect = useSnapshot({ rect: useRect(), layoutService, viewService, model });
   const [qPivotDataPages, isLoading] = useLoadDataPages({ model, layoutService, viewService, pageInfo, rect });
   // It needs to be theme.name() because the reference to the theme object does not change when a theme is changed

--- a/src/hooks/use-snapshot.ts
+++ b/src/hooks/use-snapshot.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
-import { onTakeSnapshot, type stardust } from "@nebula.js/stardust";
+import { onTakeSnapshot, useImperativeHandle, type stardust } from "@nebula.js/stardust";
 import { Q_PATH } from "../constants";
+import { getViewState } from "../pivot-table/components/cells/utils/get-view-state";
 import type { Model, SnapshotLayout } from "../types/QIX";
 import type { LayoutService, ViewService } from "../types/types";
 
@@ -17,6 +18,7 @@ const useSnapshot = ({ layoutService, viewService, rect, model }: UseSnapshotPro
       return snapshotLayout;
     }
 
+    const { rowPartialHeight, visibleTopIndex, visibleRows, page, rowsPerPage } = getViewState(viewService);
     if ((model as EngineAPI.IGenericObject)?.getHyperCubePivotData) {
       snapshotLayout.snapshotData.content = {
         qPivotDataPages: await (model as EngineAPI.IGenericObject).getHyperCubePivotData(Q_PATH, [
@@ -27,6 +29,11 @@ const useSnapshot = ({ layoutService, viewService, rect, model }: UseSnapshotPro
             qHeight: viewService.gridHeight,
           },
         ]),
+        rowPartialHeight,
+        visibleTopIndex,
+        visibleRows,
+        page,
+        rowsPerPage,
       };
 
       snapshotLayout.snapshotData.object.size.w = rect.width;
@@ -34,6 +41,8 @@ const useSnapshot = ({ layoutService, viewService, rect, model }: UseSnapshotPro
     }
     return snapshotLayout;
   });
+
+  useImperativeHandle(() => ({ getViewState: () => getViewState(viewService) }), [viewService]);
 
   if (layoutService.layout.snapshotData?.content) {
     return {

--- a/src/hooks/use-view-service.ts
+++ b/src/hooks/use-view-service.ts
@@ -1,8 +1,15 @@
-import { useMemo } from "@nebula.js/stardust";
+import { useMemo, useOptions } from "@nebula.js/stardust";
 import createViewService from "../services/view-service";
-import type { PageInfo, ViewService } from "../types/types";
+import type { PivotLayout } from "../types/QIX";
+import type { PageInfo, UseOptions, ViewService } from "../types/types";
 
-// eslint-disable-next-line react-hooks/exhaustive-deps
-const useViewService = (pageInfo: PageInfo): ViewService => useMemo(() => createViewService(), [pageInfo.page]);
+const useViewService = (layout: PivotLayout, pageInfo: PageInfo): ViewService => {
+  const { viewState } = useOptions() as UseOptions;
+  return useMemo(
+    () => createViewService(viewState, layout.snapshotData),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [viewState, layout.snapshotData, pageInfo.page],
+  );
+};
 
 export default useViewService;

--- a/src/hooks/use-view-service.ts
+++ b/src/hooks/use-view-service.ts
@@ -1,15 +1,13 @@
-import { useMemo, useOptions } from "@nebula.js/stardust";
+import { useMemo } from "@nebula.js/stardust";
 import createViewService from "../services/view-service";
 import type { PivotLayout } from "../types/QIX";
-import type { PageInfo, UseOptions, ViewService } from "../types/types";
+import type { PageInfo, ViewService } from "../types/types";
 
-const useViewService = (layout: PivotLayout, pageInfo: PageInfo): ViewService => {
-  const { viewState } = useOptions() as UseOptions;
-  return useMemo(
-    () => createViewService(viewState, layout.snapshotData),
+const useViewService = (layout: PivotLayout, pageInfo: PageInfo): ViewService =>
+  useMemo(
+    () => createViewService(layout.snapshotData),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [viewState, layout.snapshotData, pageInfo.page],
+    [layout.snapshotData, pageInfo.page],
   );
-};
 
 export default useViewService;

--- a/src/pivot-table/components/PivotTable.tsx
+++ b/src/pivot-table/components/PivotTable.tsx
@@ -50,7 +50,7 @@ export const StickyPivotTable = ({
   const { visibleLeftDimensionInfo, visibleTopDimensionInfo } = useVisibleDimensions(layoutService, qPivotDataPages);
   const { changeSortOrder, changeActivelySortedHeader } = useSorting(model, layoutService.layout.qHyperCube);
 
-  const isPrintingMode = !!(layoutService.layout.snapshotData || viewService.viewState?.visibleRows);
+  const isPrintingMode = !!layoutService.layout.snapshotData;
   // const scrollLeft = isPrintingMode ? viewService.scrollLeft ?? 0 : 0;
   const scrollTopPartially = isPrintingMode ? viewService.rowPartialHeight ?? 0 : 0;
 

--- a/src/pivot-table/components/PivotTable.tsx
+++ b/src/pivot-table/components/PivotTable.tsx
@@ -1,5 +1,5 @@
 import type { stardust } from "@nebula.js/stardust";
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
 import type { Model } from "../../types/QIX";
 import {
   ScrollableContainerOrigin,
@@ -49,6 +49,10 @@ export const StickyPivotTable = ({
   const tableRect = useTableRect(rect, layoutService, pageInfo.shouldShowPagination);
   const { visibleLeftDimensionInfo, visibleTopDimensionInfo } = useVisibleDimensions(layoutService, qPivotDataPages);
   const { changeSortOrder, changeActivelySortedHeader } = useSorting(model, layoutService.layout.qHyperCube);
+
+  const isPrintingMode = !!(layoutService.layout.snapshotData || viewService.viewState?.visibleRows);
+  // const scrollLeft = isPrintingMode ? viewService.scrollLeft ?? 0 : 0;
+  const scrollTopPartially = isPrintingMode ? viewService.rowPartialHeight ?? 0 : 0;
 
   const { headersData, measureData, topDimensionData, leftDimensionData, attrExprInfoIndexes, nextPageHandler } =
     useData(qPivotDataPages, layoutService, pageInfo, visibleLeftDimensionInfo, visibleTopDimensionInfo);
@@ -122,6 +126,14 @@ export const StickyPivotTable = ({
 
   const headerCellRowHightCallback = useCallback(() => headerCellHeight, [headerCellHeight]);
   const contentCellRowHightCallback = useCallback(() => contentCellHeight, [contentCellHeight]);
+
+  useEffect(() => {
+    const element = verticalScrollableContainerRef.current;
+    if (element) {
+      // element.scrollLeft = scrollLeft;
+      element.scrollTop = scrollTopPartially;
+    }
+  }, [scrollTopPartially, verticalScrollableContainerRef]);
 
   return (
     <ScrollableContainer

--- a/src/pivot-table/components/cells/utils/get-view-state.ts
+++ b/src/pivot-table/components/cells/utils/get-view-state.ts
@@ -1,12 +1,9 @@
 import type { ViewService } from "../../../../types/types";
 
-export const getViewState = (viewService: ViewService) => {
-  if (viewService.viewState) return viewService.viewState;
-  return {
-    rowPartialHeight: 125,
-    visibleTopIndex: 5,
-    visibleRows: 16,
-    page: 0,
-    rowsPerPage: 0,
-  };
-};
+export const getViewState = (viewService: ViewService) => ({
+  rowPartialHeight: 125,
+  visibleTopIndex: 5,
+  visibleRows: 16,
+  page: 0,
+  rowsPerPage: 0,
+});

--- a/src/pivot-table/components/cells/utils/get-view-state.ts
+++ b/src/pivot-table/components/cells/utils/get-view-state.ts
@@ -1,0 +1,12 @@
+import type { ViewService } from "../../../../types/types";
+
+export const getViewState = (viewService: ViewService) => {
+  if (viewService.viewState) return viewService.viewState;
+  return {
+    rowPartialHeight: 125,
+    visibleTopIndex: 5,
+    visibleRows: 16,
+    page: 0,
+    rowsPerPage: 0,
+  };
+};

--- a/src/services/view-service.ts
+++ b/src/services/view-service.ts
@@ -1,10 +1,17 @@
-import type { ViewService } from "../types/types";
+import type { SnapshotData } from "../types/QIX";
+import type { ViewService, ViewState } from "../types/types";
 
-const createViewService = (): ViewService => ({
+const createViewService = (viewState: ViewState, snapshotData: SnapshotData | undefined): ViewService => ({
   gridColumnStartIndex: 0,
   gridRowStartIndex: 0,
   gridWidth: 0,
   gridHeight: 0,
+  rowPartialHeight: snapshotData?.content?.rowPartialHeight ?? 0,
+  visibleTopIndex: snapshotData?.content?.visibleTopIndex ?? viewState?.visibleTopIndex,
+  visibleRows: snapshotData?.content?.visibleRows ?? viewState?.visibleRows,
+  rowsPerPage: snapshotData?.content?.rowsPerPage ?? viewState?.rowsPerPage,
+  page: snapshotData?.content?.page ?? viewState?.page,
+  viewState,
 });
 
 export default createViewService;

--- a/src/services/view-service.ts
+++ b/src/services/view-service.ts
@@ -1,17 +1,15 @@
 import type { SnapshotData } from "../types/QIX";
-import type { ViewService, ViewState } from "../types/types";
+import type { ViewService } from "../types/types";
 
-const createViewService = (viewState: ViewState, snapshotData: SnapshotData | undefined): ViewService => ({
+const createViewService = (snapshotData: SnapshotData | undefined): ViewService => ({
   gridColumnStartIndex: 0,
   gridRowStartIndex: 0,
   gridWidth: 0,
   gridHeight: 0,
   rowPartialHeight: snapshotData?.content?.rowPartialHeight ?? 0,
-  visibleTopIndex: snapshotData?.content?.visibleTopIndex ?? viewState?.visibleTopIndex,
-  visibleRows: snapshotData?.content?.visibleRows ?? viewState?.visibleRows,
-  rowsPerPage: snapshotData?.content?.rowsPerPage ?? viewState?.rowsPerPage,
-  page: snapshotData?.content?.page ?? viewState?.page,
-  viewState,
+  visibleTopIndex: snapshotData?.content?.visibleTopIndex,
+  visibleRows: snapshotData?.content?.visibleRows,
+  rowsPerPage: snapshotData?.content?.rowsPerPage,
+  page: snapshotData?.content?.page,
 });
-
 export default createViewService;

--- a/src/types/QIX.ts
+++ b/src/types/QIX.ts
@@ -28,6 +28,11 @@ type Size = {
 export interface SnapshotData {
   content?: {
     qPivotDataPages?: EngineAPI.INxPivotPage[];
+    rowPartialHeight?: number;
+    visibleTopIndex?: number;
+    visibleRows?: number;
+    page?: number;
+    rowsPerPage?: number;
   };
   object: {
     size: Size;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -189,11 +189,29 @@ export interface ExtendedSelections extends stardust.ObjectSelections {
   removeListener: (name: string, callback: () => void) => void;
 }
 
+export interface UseOptions {
+  viewState: ViewState;
+}
+
+export interface ViewState {
+  rowPartialHeight: number;
+  visibleTopIndex: number;
+  visibleRows: number;
+  page: number;
+  rowsPerPage: number;
+}
+
 export interface ViewService {
   gridColumnStartIndex: number;
   gridRowStartIndex: number;
   gridWidth: number;
   gridHeight: number;
+  rowPartialHeight?: number;
+  visibleTopIndex?: number;
+  visibleRows?: number;
+  viewState: ViewState;
+  page?: number;
+  rowsPerPage?: number;
 }
 
 export interface LayoutService {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -189,18 +189,6 @@ export interface ExtendedSelections extends stardust.ObjectSelections {
   removeListener: (name: string, callback: () => void) => void;
 }
 
-export interface UseOptions {
-  viewState: ViewState;
-}
-
-export interface ViewState {
-  rowPartialHeight: number;
-  visibleTopIndex: number;
-  visibleRows: number;
-  page: number;
-  rowsPerPage: number;
-}
-
 export interface ViewService {
   gridColumnStartIndex: number;
   gridRowStartIndex: number;
@@ -209,7 +197,6 @@ export interface ViewService {
   rowPartialHeight?: number;
   visibleTopIndex?: number;
   visibleRows?: number;
-  viewState: ViewState;
   page?: number;
   rowsPerPage?: number;
 }


### PR DESCRIPTION
**What is the improvement ?**:
Pivot table snapshot should consider the scroll position so WYSIWYG as the result.

**How it is improved:**
The idea is when the snapshot is taken, `snapshotData content` provides one more property `rowPartialScrollHeight ` before the table re-renders. The considered property is basically a calculation for finding the hidden part of the table row when the scroll is positioned and add the result to the scrollTop/Left values when the snapshot is used.

Before merging this PR, all get-view-state properties will be reset to 0 to ensure they do not affect the current snapshot state. This will remain the case until further calculations are added

The attachment shows how the pv table looks like when the row partial height is applied on the snapshot.
![Skärmbild 2024-01-22 004022](https://github.com/qlik-oss/sn-pivot-table/assets/20701546/a9344de3-4732-4328-9469-02f4fea51bb8)

